### PR TITLE
Forgetful Causal Masking and Alibi bias

### DIFF
--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -723,7 +723,7 @@ def _broadcast_order(a: NamedArray, b: NamedArray, require_subset: bool = True) 
         # maybe just add a context manager to allow it?
         raise ValueError(
             f"Cannot broadcast {a} and {b}: no subset relationship. "
-            "If you want to broadcast anyway, use the  function to explicitly add axes"
+            "If you want to broadcast anyway, use the broadcast_axis function to explicitly add axes"
         )
     return broadcasted
 

--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -98,9 +98,6 @@ class NamedArray:
     size = property(lambda self: self.array.size)
     nbytes = property(lambda self: self.array.nbytes)
 
-    def item(self):
-        return self.array.item()
-
     def tree_flatten(self) -> Any:
         return ((self.array,), self.axes)
 

--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -98,6 +98,9 @@ class NamedArray:
     size = property(lambda self: self.array.size)
     nbytes = property(lambda self: self.array.nbytes)
 
+    def item(self):
+        return self.array.item()
+
     def tree_flatten(self) -> Any:
         return ((self.array,), self.axes)
 
@@ -723,7 +726,7 @@ def _broadcast_order(a: NamedArray, b: NamedArray, require_subset: bool = True) 
         # maybe just add a context manager to allow it?
         raise ValueError(
             f"Cannot broadcast {a} and {b}: no subset relationship. "
-            "If you want to broadcast anyway, use the broadcast_axis function to explicitly add axes"
+            "If you want to broadcast anyway, use the  function to explicitly add axes"
         )
     return broadcasted
 
@@ -763,22 +766,37 @@ def _broadcast_axes(
     return tuple(x for x in b_axes if x not in a_axes) + a_axes
 
 
-def broadcast_to(a: NamedArray, axes: Tuple[Axis, ...], ensure_order: bool = True) -> NamedArray:
+def broadcast_to(
+    a: NamedArray, axes: AxisSpec, ensure_order: bool = True, enforce_no_extra_axes: bool = True
+) -> NamedArray:
     """
-    Broadcasts a to the given axes. If ensure_order is True (default), then the returned array will have the same axes
-    in the same order as the given axes. Otherwise, the axes may not be moved
+    Broadcasts a so that it has the given axes.
+     If ensure_order is True (default), then the returned array will have the same axes in the same order as the given
+     axes. Otherwise, the axes may not be moved
+
+    If enforce_no_extra_axes is True and the array has axes that are not in axes, then a ValueError is raised.
     """
+
+    axes = ensure_tuple(axes)
+
     if a.axes == axes:
         return a
 
     to_add = tuple(ax for ax in axes if ax not in a.axes)
 
+    all_axes = to_add + a.axes
+
+    if enforce_no_extra_axes and len(all_axes) != len(axes):
+        raise ValueError(f"Cannot broadcast {a} to {axes}: extra axes present")
+
+    extra_axes = tuple(ax for ax in a.axes if ax not in axes)
+
     # broadcast whatever we need to the front and reorder
-    a_array = jnp.broadcast_to(a.array, [ax.size for ax in to_add] + [ax.size for ax in a.axes])
-    a = NamedArray(a_array, to_add + a.axes)
+    a_array = jnp.broadcast_to(a.array, [ax.size for ax in all_axes])
+    a = NamedArray(a_array, all_axes)
 
     if ensure_order:
-        a = rearrange(a, axes)
+        a = rearrange(a, axes + extra_axes)
 
     return a
 
@@ -847,14 +865,13 @@ def broadcast_arrays_and_return_axes(
 
 def broadcast_axis(a: NamedArray, axis: AxisSpec) -> NamedArray:
     """
-    Broadcasts a, ensuring that it has all the axes in axis
+    Broadcasts a, ensuring that it has all the axes in axis.
+     broadcast_axis is an alias for broadcast_to(a, axis, enforce_no_extra_axes=False, ensure_order=False)
     """
     if isinstance(axis, Axis) and axis in a.axes:
         return a
 
-    axis = ensure_tuple(axis)
-    new_axes = tuple(ax for ax in axis if ax not in a.axes)
-    return broadcast_to(a, new_axes + a.axes)
+    return broadcast_to(a, axis, enforce_no_extra_axes=False, ensure_order=False)
 
 
 __all__ = [

--- a/src/haliax/nn/__init__.py
+++ b/src/haliax/nn/__init__.py
@@ -49,7 +49,7 @@ def one_hot(x: Union[NamedArray, int], class_axis: Axis, *, dtype=jnp.float_) ->
         return NamedArray(array, x.axes + (class_axis,))
     else:
         assert isinstance(x, int)
-        assert class_axis.size > x and x >= -class_axis.size
+        assert class_axis.size > x >= -class_axis.size
 
         array = jnp.zeros(class_axis.size).at[x].set(1)
         return haliax.named(array, class_axis)

--- a/src/haliax/nn/__init__.py
+++ b/src/haliax/nn/__init__.py
@@ -5,9 +5,10 @@ import jax.nn as jnn
 import jax.numpy as jnp
 
 import haliax
+import haliax.nn.attention as attention
 
 from ..core import NamedArray
-from ..types import Axis, AxisSpec
+from ..types import Axis
 from ..wrap import wrap_axiswise_call, wrap_elemwise_unary, wrap_reduction_call
 from .dropout import Dropout
 from .linear import Linear
@@ -56,6 +57,7 @@ def one_hot(x: Union[NamedArray, int], class_axis: Axis, *, dtype=jnp.float_) ->
 
 
 __all__ = [
+    "attention",
     "relu",
     "relu6",
     "sigmoid",

--- a/src/haliax/nn/__init__.py
+++ b/src/haliax/nn/__init__.py
@@ -51,7 +51,7 @@ def one_hot(x: Union[NamedArray, int], class_axis: Axis, *, dtype=jnp.float_) ->
         assert isinstance(x, int)
         assert class_axis.size > x >= -class_axis.size
 
-        array = jnp.zeros(class_axis.size).at[x].set(1)
+        array = jnp.zeros(class_axis.size, dtype=dtype).at[x].set(1)
         return haliax.named(array, class_axis)
 
 

--- a/src/haliax/nn/attention.py
+++ b/src/haliax/nn/attention.py
@@ -1,0 +1,120 @@
+import math
+from typing import List, Optional
+
+import jax.numpy as jnp
+from jax.random import PRNGKey
+
+import haliax
+import haliax.random as hrandom
+from haliax import Axis, AxisSpec, NamedArray
+
+
+def dot_product_attention_weights(
+    HeadDim: Axis,
+    KeySeqLen: AxisSpec,
+    query: NamedArray,
+    key: NamedArray,
+    bias: Optional[NamedArray] = None,
+    attention_dtype: Optional[jnp.dtype] = None,
+) -> NamedArray:
+    """
+    NamedArray version of dot product attention. Computes the logits for the attention weights.
+
+    :param HeadDim: Axis of head dimension
+    :param KeySeqLen: Axis of key sequence length. Can be an AxisSpec to attend along more than one axis.
+    :param query: NamedArray of shape (SeqLen, HeadDim)
+    :param key: NamedArray of shape (KeySeqLen, HeadDim)
+    :param bias: Optional[NamedArray] broadcast compatible with (HeadDim, SeqLen, KeySeqLen)
+    :param attention_dtype: Optional dtype to use for attention
+    :return: NamedArray of shape (SeqLen, KeySeqLen)
+    """
+    import haliax.nn as hnn
+
+    orig_dtype = query.dtype
+    query = query / jnp.sqrt(HeadDim.size)
+
+    if attention_dtype is not None:
+        query = query.astype(attention_dtype)
+        key = key.astype(attention_dtype)
+
+    weights = haliax.dot(HeadDim, query, key)
+
+    if bias is not None:
+        weights = weights + bias
+
+    weights = hnn.softmax(weights, axis=KeySeqLen)
+
+    return weights.astype(orig_dtype)
+
+
+def dot_product_attention(
+    SeqLen: Axis,
+    KeySeqLen: Axis,
+    HeadDim: Axis,
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    bias: Optional[NamedArray] = None,
+    attention_dtype: Optional[jnp.dtype] = None,
+) -> NamedArray:
+    """
+    NamedArray version of dot product attention
+
+    :param SeqLen: Axis of sequence length
+    :param KeySeqLen: Axis of key sequence length
+    :param HeadDim: Axis of head dimension
+    :param query: NamedArray of shape (SeqLen, HeadDim)
+    :param key: NamedArray of shape (KeySeqLen, HeadDim)
+    :param value: NamedArray of shape (KeySeqLen, HeadDim)
+    :param bias: Optional[NamedArray] broadcast compatible with (HeadDim, SeqLen, KeySeqLen)
+    :param attention_dtype: Optional dtype to use for attention
+    :return: NamedArray of shape (SeqLen, HeadDim)
+    """
+
+    # rename key/value length axis if it's the same as the query length axis
+    if KeySeqLen == SeqLen:
+        KeySeqLen = SeqLen.alias(KeySeqLen.name + "_key")
+        key = key.rename({KeySeqLen: SeqLen})
+        value = value.rename({KeySeqLen: SeqLen})
+
+    weights = dot_product_attention_weights(HeadDim, KeySeqLen, query, key, bias, attention_dtype)
+
+    return haliax.dot(KeySeqLen, weights, value)
+
+
+def dropout_mask(SeqLen: Axis, KeySeqLen: Axis, dropout_rate: float, *, key: PRNGKey) -> NamedArray:
+    return hrandom.bernoulli(key, (SeqLen, KeySeqLen), 1 - dropout_rate)
+
+
+def mask_to_bias(mask: NamedArray, mask_value: float = -1e9) -> NamedArray:
+    return mask * mask_value
+
+
+def _get_alibi_slopes(heads: int) -> List[float]:
+    # cf https://github.com/ofirpress/attention_with_linear_biases/blob/a35aaca144e0eb6b789dfcb46784c4b8e31b7983/fairseq/models/transformer.py#L742
+    def get_slopes_power_of_2(n: int):
+        start = 2 ** (-(2 ** -(math.log2(n) - 3)))
+        ratio = start
+        return [start * ratio**i for i in range(n)]
+
+    if math.log2(heads).is_integer():
+        return get_slopes_power_of_2(heads)
+    closest_power_of_2 = 2 ** math.floor(math.log2(heads))
+    return (
+        get_slopes_power_of_2(closest_power_of_2)
+        + get_slopes_power_of_2(2 * closest_power_of_2)[0::2][: heads - closest_power_of_2]
+    )
+
+
+def alibi_attention_bias(SeqLen: Axis, Heads: Axis) -> NamedArray:
+    """
+    Creates an attention bias for alibi attention.
+
+    :param SeqLen: Axis of sequence length
+    :param Heads: Axis of heads
+    :return: NamedArray of shape (Heads, SeqLen)
+    """
+    slopes = haliax.named(jnp.array(_get_alibi_slopes(Heads.size)), Heads)
+    positions = haliax.arange(SeqLen).broadcast_axis(Heads)
+
+    return slopes * positions

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -305,7 +305,7 @@ class Gpt2Transformer(TorchSerializationMixin, eqx.Module):
 
         # forgetful causal masking
         if not inference and self.config.fcm_prob > 0:
-            fcm_mask = hax.nn.attention.fcm_mask(self.KeySeqLen, self.config.fcm_prob, key=fcm_key)
+            fcm_mask = hax.nn.attention.forgetful_causal_mask(self.KeySeqLen, self.config.fcm_prob, key=fcm_key)
             causal_mask = causal_mask & fcm_mask
         return causal_mask
 

--- a/src/levanter/models/palm_lite.py
+++ b/src/levanter/models/palm_lite.py
@@ -41,7 +41,6 @@ def get_alibi_slopes(heads):
 
     if log2(heads).is_integer():
         return get_slopes_power_of_2(heads)
-
     closest_power_of_2 = 2 ** floor(log2(heads))
     return (
         get_slopes_power_of_2(closest_power_of_2)

--- a/tests/haliax/test_attention.py
+++ b/tests/haliax/test_attention.py
@@ -26,7 +26,7 @@ def test_alibi_attention_bias():
 def test_fcm_attention_mask():
     KeySeqLen = hax.Axis("KeySeqLen", 20)
 
-    mask = fcm_mask(KeySeqLen, dropout_prob=0.6, key=PRNGKey(0))
+    mask = fcm_mask(KeySeqLen, mask_ratio=0.6, sample_ratio=False, key=PRNGKey(0))
 
     assert mask.axes == (KeySeqLen,)
     assert mask.array[0].item() == 1

--- a/tests/haliax/test_attention.py
+++ b/tests/haliax/test_attention.py
@@ -26,7 +26,7 @@ def test_alibi_attention_bias():
 def test_fcm_attention_mask():
     KeySeqLen = hax.Axis("KeySeqLen", 20)
 
-    mask = fcm_mask(KeySeqLen, mask_ratio=0.6, sample_ratio=False, key=PRNGKey(0))
+    mask = fcm_mask(KeySeqLen, mask_prob=0.6, sample_prob=False, key=PRNGKey(0))
 
     assert mask.axes == (KeySeqLen,)
     assert mask.array[0].item() == 1

--- a/tests/haliax/test_attention.py
+++ b/tests/haliax/test_attention.py
@@ -1,7 +1,7 @@
 from jax.random import PRNGKey
 
 import haliax as hax
-from haliax.nn.attention import alibi_attention_bias, dot_product_attention_weights, fcm_mask
+from haliax.nn.attention import alibi_attention_bias, dot_product_attention_weights, forgetful_causal_mask
 
 
 def test_alibi_attention_bias():
@@ -9,7 +9,7 @@ def test_alibi_attention_bias():
     NumHeads = hax.Axis("NumHeads", 1)
     Hid = hax.Axis("Hid", 8)
 
-    bias = alibi_attention_bias(KeySeqLen, NumHeads)
+    bias = alibi_attention_bias(NumHeads, KeySeqLen)
 
     query = hax.ones((NumHeads, Hid))
     key = hax.ones((KeySeqLen, NumHeads, Hid))
@@ -26,7 +26,7 @@ def test_alibi_attention_bias():
 def test_fcm_attention_mask():
     KeySeqLen = hax.Axis("KeySeqLen", 20)
 
-    mask = fcm_mask(KeySeqLen, mask_prob=0.6, sample_prob=False, key=PRNGKey(0))
+    mask = forgetful_causal_mask(KeySeqLen, mask_prob=0.6, sample_prob=False, key=PRNGKey(0))
 
     assert mask.axes == (KeySeqLen,)
     assert mask.array[0].item() == 1

--- a/tests/haliax/test_attention.py
+++ b/tests/haliax/test_attention.py
@@ -1,0 +1,21 @@
+import haliax as hax
+from haliax.nn.attention import alibi_attention_bias, dot_product_attention_weights
+
+
+def test_alibi_attention_bias():
+    KeySeqLen = hax.Axis("KeySeqLen", 20)
+    NumHeads = hax.Axis("NumHeads", 1)
+    Hid = hax.Axis("Hid", 8)
+
+    bias = alibi_attention_bias(KeySeqLen, NumHeads)
+
+    query = hax.ones((NumHeads, Hid))
+    key = hax.ones((KeySeqLen, NumHeads, Hid))
+
+    weights_bias = dot_product_attention_weights(Hid, KeySeqLen, query, key, bias=bias)
+    weights_no_bias = dot_product_attention_weights(Hid, KeySeqLen, query, key)
+
+    assert weights_bias.take(KeySeqLen, -1).item() > weights_bias.take(KeySeqLen, -2).item()
+    assert weights_bias.take(KeySeqLen, -1).item() > weights_no_bias.take(KeySeqLen, -1).item()
+
+    assert weights_no_bias.take(KeySeqLen, -1).item() == weights_no_bias.take(KeySeqLen, -2).item()

--- a/tests/haliax/test_ops.py
+++ b/tests/haliax/test_ops.py
@@ -3,7 +3,7 @@ import pytest
 from jax.random import PRNGKey
 
 import haliax as hax
-from haliax import Axis
+from haliax import Axis, NamedArray
 
 
 def test_trace():
@@ -76,7 +76,25 @@ def test_add_scalar():
     assert jnp.all(jnp.isclose(named3.array, named1.array + 1.0))
 
 
-# TODO: tests for other ops
+def test_add_no_overlap():
+    Height = Axis("Height", 10)
+    Width = Axis("Width", 3)
+    Depth = Axis("Depth", 4)
+
+    named1: NamedArray = hax.random.uniform(PRNGKey(0), (Height))
+    named2 = hax.random.uniform(PRNGKey(1), (Width, Depth))
+
+    with pytest.raises(ValueError):
+        _ = named1 + named2
+
+    named3 = named1.broadcast_to((Height, Width, Depth)) + named2
+
+    assert jnp.all(
+        jnp.isclose(named3.array, named1.array.reshape((-1, 1, 1)) + named2.array.reshape((1,) + named2.array.shape))
+    )
+
+
+# TODO: tests for other ops:
 
 
 def test_where():


### PR DESCRIPTION
Implements [Forgetful Causal Masking](https://arxiv.org/abs/2210.13432) and [Alibi](https://arxiv.org/abs/2108.12409) attention biases.

I only integrated the former into GPT-2 because it only impacts training and not inference. Alibi is inference-time so would break HF model export.

Closes #47 