### PR TITLE
add '/files/*' to git safe directory

### DIFF
--- a/scripts/setup-tpu-vm.sh
+++ b/scripts/setup-tpu-vm.sh
@@ -16,10 +16,13 @@ retCode=$?
 #sudo apt update
 #sudo apt upgrade -y
 
-# install python 3.10 and nfs
-sudo apt install -y software-properties-common
+# install python 3.10, latest git, and nfs
+# we need git>=2.36 for the glob safe directory thing, below
+sudo apt-get install -y software-properties-common
 sudo add-apt-repository -y ppa:deadsnakes/ppa
-sudo apt install -y python3.10-full python3.10-dev nfs-common
+sudo add-apt-repository -y ppa:git-core/ppa
+sudo apt-get update
+sudo apt-get install -y python3.10-full python3.10-dev nfs-common git
 
 
 # set up nfs
@@ -45,3 +48,4 @@ sudo mount -a
 sudo bash -c "echo \"source ${MOUNT_POINT}/venv310/bin/activate\" > /etc/profile.d/activate_shared_venv.sh"
 
 git config --global --add safe.directory /files/levanter
+git config --global --add safe.directory '/files/*'  # This is maybe not the safest thing, but it makes things easier


### PR DESCRIPTION
This may be a little much, but... wandb wants to access the git repo to get the current sha for logging, but git doesn't want to do that on NFS/shared directories. git's `safe.directory` fixes that. I've been using it for the main levanter, but this adds it for everything in /files/

It seems like there ought to be a way to get a git sha safely without this, but i dunno.