### PR TITLE
Explicitly define random number generators, make rng sharding opt-in

### DIFF
--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -897,9 +897,3 @@ __all__ = [
     "shape_checks",
     "are_shape_checks_enabled",
 ]
-
-
-def raw_array_or_scalar(x: NamedOrNumeric):
-    if isinstance(x, NamedArray):
-        return x.array
-    return x

--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -544,7 +544,7 @@ def split(a: NamedArray, axis: Axis, new_axes: Sequence[Axis]) -> Sequence[Named
 # e.g. we'd like something like rearrange(array, (..., new_axis), merge_axes={new_axis: (old_axis1, old_axis2)})
 # or rearrange(array, (new_axis1, ..., new_axis2), split_axes={old_axis: (new_axis1, new_axis2)})
 # or even rearrange(array, (x, ..., b, a), map_axes={old_axis: (a, b), x: (old1, old2)})
-def rearrange(array: NamedArray, axes: Sequence[Union[Axis, EllipsisType]]):
+def rearrange(array: NamedArray, axes: Sequence[Union[Axis, EllipsisType]]) -> NamedArray:
     """
     Rearrange an array so that its underlying storage conforms to axes.
     axes may include up to 1 ellipsis, indicating that the remaining axes should be
@@ -764,7 +764,7 @@ def _broadcast_axes(
 
 
 def broadcast_to(
-    a: NamedArray, axes: AxisSpec, ensure_order: bool = True, enforce_no_extra_axes: bool = True
+    a: NamedOrNumeric, axes: AxisSpec, ensure_order: bool = True, enforce_no_extra_axes: bool = True
 ) -> NamedArray:
     """
     Broadcasts a so that it has the given axes.
@@ -773,8 +773,12 @@ def broadcast_to(
 
     If enforce_no_extra_axes is True and the array has axes that are not in axes, then a ValueError is raised.
     """
-
     axes = ensure_tuple(axes)
+
+    if not isinstance(a, NamedArray):
+        a = named(jnp.asarray(a), ())
+
+    assert isinstance(a, NamedArray)  # mypy gets confused
 
     if a.axes == axes:
         return a
@@ -795,7 +799,7 @@ def broadcast_to(
     if ensure_order:
         a = rearrange(a, axes + extra_axes)
 
-    return a
+    return typing.cast(NamedArray, a)
 
 
 @overload

--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -106,6 +106,9 @@ class NamedArray:
         assert len(tree) == 1
         return cls(tree[0], axes=aux)
 
+    def has_axis(self, axis: AxisSpec) -> bool:
+        return self._lookup_indices(axis) is not None
+
     @typing.overload
     def _lookup_indices(self, axis: Axis) -> Optional[int]:
         ...

--- a/src/haliax/nn/dropout.py
+++ b/src/haliax/nn/dropout.py
@@ -67,7 +67,7 @@ class Dropout(eqx.Module):
                     shape_to_generate = tuple(ax for ax in x.axes if ax not in axes)
 
                 q = 1 - self.pdrop
-                mask = haliax.random.bernoulli(key, q, shape_to_generate)
+                mask = haliax.random.bernoulli(key, shape_to_generate, q)
                 q = x.dtype.type(q)
 
                 out = haliax.where(mask, x / q, 0)

--- a/src/haliax/nn/linear.py
+++ b/src/haliax/nn/linear.py
@@ -21,7 +21,7 @@ class Linear(eqx.Module):
 
     def __init__(self, In: AxisSpec, Out: AxisSpec, *, key, include_bias=True):
         joint_spec = hax.concat_axis_specs(In, Out)
-        self.weight = hax.random.normal(key, joint_spec) * 0.02
+        self.weight = hax.random.generate_sharded(hax.random.normal)(key, joint_spec) * 0.02
         self.bias = hax.zeros(Out) if include_bias else None
 
         self.In = In

--- a/src/haliax/ops.py
+++ b/src/haliax/ops.py
@@ -3,7 +3,7 @@ from typing import Union
 import jax
 import jax.numpy as jnp
 
-from .core import NamedArray, NamedOrNumeric, broadcast_arrays, broadcast_arrays_and_return_axes, raw_array_or_scalar
+from .core import NamedArray, NamedOrNumeric, broadcast_arrays, broadcast_arrays_and_return_axes
 from .types import Axis
 
 
@@ -85,6 +85,12 @@ def isclose(a: NamedArray, b: NamedArray, rtol=1e-05, atol=1e-08, equal_nan=Fals
     a, b = broadcast_arrays(a, b)
     # TODO: numpy supports an array atol and rtol, but we don't yet
     return NamedArray(jnp.isclose(a.array, b.array, rtol=rtol, atol=atol, equal_nan=equal_nan), a.axes)
+
+
+def raw_array_or_scalar(x: NamedOrNumeric):
+    if isinstance(x, NamedArray):
+        return x.array
+    return x
 
 
 __all__ = ["trace", "where", "tril", "triu", "isclose"]

--- a/src/haliax/random.py
+++ b/src/haliax/random.py
@@ -190,7 +190,7 @@ def generate_sharded(fn, axis: Optional[Axis] = None):
 
                 return haliax.vmap(fn, axis=_axis)(*bound.args, **bound.kwargs)
         else:
-            with jax.named_scope("unsharded_generate"):
+            with jax.named_scope(f"generate_sharded({_axis}, no_shard)"):
                 return fn(*args, **kwargs)
 
     return wrapped_fn

--- a/src/haliax/random.py
+++ b/src/haliax/random.py
@@ -1,107 +1,325 @@
 """Wrappers around jax.random functions."""
-
 import functools
 import inspect
-from typing import Sequence
+from typing import Optional
 
-import jax
+import jax.numpy as jnp
 import jax.random as jrandom
 
-# TODO: handle broadcasting of array args to random functions (e.g. minval and maxval for uniform)
-from haliax.core import NamedArray
+import haliax
+from haliax.core import NamedArray, NamedOrNumeric, broadcast_to
 from haliax.util import ensure_tuple
 
 from .jax_utils import named_call
-from .partitioning import auto_sharded, physical_axis_size, pspec_for_axis
-from .types import Axis
+from .partitioning import auto_sharded, physical_axis_name, physical_axis_size, pspec_for_axis
+from .types import Axis, AxisSpec
 
 
-def _wrap_random_function(func):
-    """Wrap a jax random function to return a NamedArray and takes axes as inputs"""
+@named_call
+def uniform(
+    key, shape: AxisSpec, dtype=jnp.float_, minval: NamedOrNumeric = 0.0, maxval: NamedOrNumeric = 1.0
+) -> NamedArray:
+    shape = ensure_tuple(shape)
+    minval = broadcast_to(minval, shape).array
+    maxval = broadcast_to(maxval, shape).array
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.uniform(key=key, shape=jax_shape, dtype=dtype, minval=minval, maxval=maxval)
+    return auto_sharded(NamedArray(jax_array, shape))
 
-    @named_call(name=func.__name__)
-    @functools.wraps(func)
-    def wrapper(key: jrandom.KeyArray, *args, **kwargs):
-        sig: inspect.BoundArguments = inspect.signature(func).bind(key, *args, **kwargs)
-        sig.apply_defaults()
 
-        # get shape
-        orig_shape = sig.arguments["shape"]
-        orig_shape = ensure_tuple(orig_shape)
-        if isinstance(orig_shape, Sequence):
-            is_haliax = len(orig_shape) == 0 or any(isinstance(s, Axis) for s in orig_shape)
-            shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in orig_shape)
-        else:
-            is_haliax = False
+@named_call
+def normal(key, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.normal(key=key, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
 
-        if is_haliax:
 
-            # this is a bit tricky but, for sharded models, we sometimes want to split the random key so that we only
-            # need to generate the random numbers for the local shard. We do this because the RNG can't actually
-            # auto-shard, meaning that if you want to generate a [1024] vector across 4 devices, each one actually
-            # generates all 1024 numbers, and then only uses 256 of them. This is a waste of time, especially when it's
-            # not a [1024] vector but a [1600, 6400] matrix (for say, gpt-2). So we split the key here, and then let
-            # vmap hopefully only generate the random numbers for the local shard.
-            #
-            # However, we don't want to oversplit or it kind of ruins the whole point since we have to split the key on
-            # every node... So instead we just split along the *largest* physical axis
-            # TODO: we won't need to do this when they add better splitting for random numbers
-            #  (froystig is maybe going to do this?)
+@named_call
+def bernoulli(key, p: NamedOrNumeric, shape: AxisSpec):
+    shape = ensure_tuple(shape)
+    p = broadcast_to(p, shape).array
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.bernoulli(key=key, p=p, shape=jax_shape)
+    return auto_sharded(NamedArray(jax_array, shape))
 
-            # what we do is we take the biggest axis that is sharded and split on it, ties going to the first axis
-            pspec = pspec_for_axis(orig_shape)
+
+@named_call
+def randint(key, shape: AxisSpec, minval: NamedOrNumeric, maxval: NamedOrNumeric, dtype=jnp.int_):
+    shape = ensure_tuple(shape)
+    minval = broadcast_to(minval, shape).array
+    maxval = broadcast_to(maxval, shape).array
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.randint(key=key, shape=jax_shape, minval=minval, maxval=maxval, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def poisson(key, lam: NamedOrNumeric, shape: AxisSpec, dtype=jnp.int_):
+    shape = ensure_tuple(shape)
+    lam = broadcast_to(lam, shape).array
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.poisson(key=key, lam=lam, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def exponential(key, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.exponential(key=key, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def gamma(key, a: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    a = broadcast_to(a, shape).array
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.gamma(key=key, a=a, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def beta(key, a: NamedOrNumeric, b: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    a = broadcast_to(a, shape).array
+    b = broadcast_to(b, shape).array
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.beta(key=key, a=a, b=b, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def laplace(key, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.laplace(key=key, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def cauchy(key, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.cauchy(key=key, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def logistic(key, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.logistic(key=key, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def truncated_normal(key, lower: NamedOrNumeric, upper: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    lower = broadcast_to(lower, shape).array
+    upper = broadcast_to(upper, shape).array
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.truncated_normal(key=key, lower=lower, upper=upper, shape=jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+_enforce_sharded_generate = False
+""" mostly for testing: enforces shard generation for all random functions even if not running distributed"""
+
+
+def generate_sharded(fn, axis: Optional[Axis] = None):
+    """
+    Create a wrapped version of fn (which should be a random generator) that generates the random array in a sharded
+    manner, using vmap over the provided axis, or inferring the "best" one if not provided.
+
+    This is a bit tricky but, for sharded models, we sometimes want to split the random key so that we only
+    need to generate the random numbers for the local shard. We do this because the RNG can't actually
+    auto-shard, meaning that if you want to generate a [1024] vector across 4 devices, each one actually
+    generates all 1024 numbers, and then only uses 256 of them. This is a waste of time, especially when it's
+    not a [1024] vector but a [1600, 6400] matrix (for say, gpt-2). So we split the key here, and then let
+    vmap hopefully only generate the random numbers for the local shard.
+
+
+
+    However, we don't want to oversplit or it kind of ruins the whole point since we have to split the key on
+    every node... So instead we just split along the *largest* physical axis, or the provided axis if it's
+    provided.
+    """
+    # TODO: we won't need to do this when they add better splitting for random numbers
+    #  (froystig is maybe going to do this?)
+
+    @functools.wraps(fn)
+    def wrapped_fn(*args, **kwargs):
+        bound = inspect.signature(fn).bind(*args, **kwargs)
+        bound.apply_defaults()
+        key = bound.arguments["key"]
+        shape = bound.arguments["shape"]
+
+        shape = ensure_tuple(shape)
+
+        if len(shape) == 0:
+            # scalar
+            return fn(*args, **kwargs)
+
+        if axis is None:
+            pspec = pspec_for_axis(shape)
             if pspec:
-                biggest_axis, biggest_physical = max(
-                    zip(orig_shape, pspec), key=lambda x: (physical_axis_size(x[0]) or 0) if x[1] else 0
+                axis_to_shard, biggest_physical = max(
+                    zip(shape, pspec), key=lambda x: (physical_axis_size(x[0]) or 0) if x[1] else 0
                 )
             else:
-                biggest_axis = biggest_physical = None
+                axis_to_shard = biggest_physical = None
 
-            if biggest_physical and biggest_axis.size > 1:
-                index_of_biggest_axis = orig_shape.index(biggest_axis)
-                shape = shape[:index_of_biggest_axis] + shape[index_of_biggest_axis + 1 :]
-                sig.arguments["shape"] = shape
-                keys = jrandom.split(key, biggest_axis.size)
-
-                def fn(key):
-                    return func(key, *sig.args[1:], **sig.kwargs)
-
-                out = jax.vmap(fn, in_axes=(0,), out_axes=index_of_biggest_axis)(keys)
-                return auto_sharded(NamedArray(out, orig_shape))
-            else:
-                sig.arguments["shape"] = shape
-                out = func(**sig.arguments)
-                return auto_sharded(NamedArray(out, orig_shape))
+            axis_to_shard = axis_to_shard or shape[0]
         else:
-            return func(**sig.arguments)
+            axis_to_shard = axis
+            biggest_physical = physical_axis_name(axis)
 
-    return wrapper
+        if _enforce_sharded_generate or biggest_physical:
+            index_of_axis_to_shard = shape.index(axis_to_shard)
+            # remove axis from shape
+            shape = shape[:index_of_axis_to_shard] + shape[index_of_axis_to_shard + 1 :]
+
+            keys = jrandom.split(key, axis_to_shard.size)
+
+            bound.arguments["shape"] = shape
+            bound.arguments["key"] = keys
+
+            return haliax.vmap(lambda *args, **kwargs: fn(*args, **kwargs), axis=axis)(*bound.args, **bound.kwargs)
+        else:
+            return fn(*args, **kwargs)
+
+    return wrapped_fn
 
 
-uniform = _wrap_random_function(jrandom.uniform)
-normal = _wrap_random_function(jrandom.normal)
-randint = _wrap_random_function(jrandom.randint)
-bernoulli = _wrap_random_function(jrandom.bernoulli)
-poisson = _wrap_random_function(jrandom.poisson)
-exponential = _wrap_random_function(jrandom.exponential)
-gamma = _wrap_random_function(jrandom.gamma)
-beta = _wrap_random_function(jrandom.beta)
-laplace = _wrap_random_function(jrandom.laplace)
-cauchy = _wrap_random_function(jrandom.cauchy)
-logistic = _wrap_random_function(jrandom.logistic)
-truncated_normal = _wrap_random_function(jrandom.truncated_normal)
+def ball(key, shape: AxisSpec, d: int, p: float = 2.0, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.ball(key=key, shape=jax_shape, d=d, p=p, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+# TODO: categorical
+# def categorical(key, logits: NamedArray, axis: Axis, shape: Optional[AxisSpec] = None):
+#     # TODO: this one is tricky. need to test carefully
+#     if shape is not None:
+#         logits = logits.broadcast_axis(shape)
+#     else:
+#         shape = logits.axes
+#         # TODO: add delete_axis
+#         index_of_axis = shape.index(axis)
+#         shape = shape[:index_of_axis] + shape[index_of_axis + 1 :]
+#
+#     axis_index = logits._lookup_indices(axis)
+#
+#     jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+#
+#     return auto_sharded(NamedArray(jrandom.categorical(key, logits.array, axis_index, jax_shape), shape))
+
+
+def choice(key, a: NamedArray, shape: AxisSpec, replace: bool = True, p: Optional[NamedArray] = None):
+    shape = ensure_tuple(shape)
+    if p is not None:
+        p = p.broadcast_axis(shape)
+    a = a.broadcast_axis(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.choice(key, a.array, jax_shape, replace=replace, p=p.array if p is not None else None)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+# TODO: dirichlet
+#     A random array with the specified dtype and shape given by
+#     ``shape + (alpha.shape[-1],)`` if ``shape`` is not None, or else
+#     ``alpha.shape``.
+# def dirichlet(key, alpha: NamedArray, shape: Optional[AxisSpec] = None):
+#     if shape is not None:
+#         alpha = alpha.broadcast_axis(shape)
+#     jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape) if shape is not None else None
+#     jax_array = jrandom.dirichlet(key, alpha.array, jax_shape)
+#     return auto_sharded(NamedArray(jax_array, alpha.axes))
+
+
+def gumbel(key, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.gumbel(key, jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+# def loggamma(key, a: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+#     shape = ensure_tuple(shape)
+#     a = broadcast_to(a, shape)
+#     jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+#     jax_array = jrandom.loggamma(key, a, jax_shape, dtype=dtype)
+#     return auto_sharded(NamedArray(jax_array, shape))
+
+
+def orthogonal(key, n: int, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.orthogonal(key, n, jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+# def pareto(key, b: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+#     shape = ensure_tuple(shape)
+#     b = broadcast_to(b, shape)
+#     jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+#     jax_array = jrandom.pareto(key, b, jax_shape, dtype=dtype)
+#     return auto_sharded(NamedArray(jax_array, shape))
+
+
+def permutation(key, x: NamedArray, axis: Axis, independent: bool = False):
+    axis_index = x._lookup_indices(axis)
+    jax_array = jrandom.permutation(key, x.array, axis_index, independent=independent)
+    return auto_sharded(NamedArray(jax_array, x.axes))
+
+
+def rademacher(key, shape: AxisSpec, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_array = jrandom.rademacher(key, jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+# def t(key, df: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+#     shape = ensure_tuple(shape)
+#     df = broadcast_to(df, shape)
+#     jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+#     jax_array = jrandom.t(key, df, jax_shape, dtype=dtype)
+#     return auto_sharded(NamedArray(jax_array, shape))
+
+
+# def weibull_min(key, scale: NamedOrNumeric, concentration: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+#     shape = ensure_tuple(shape)
+#     scale = broadcast_to(scale, shape)
+#     concentration = broadcast_to(concentration, shape)
+#     jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+#     jax_array = jrandom.weibull_min(key, scale, concentration, jax_shape, dtype=dtype)
+#     return auto_sharded(NamedArray(jax_array, shape))
+
 
 __all__ = [
+    "generate_sharded",
     "uniform",
     "normal",
-    "randint",
     "bernoulli",
     "poisson",
+    "permutation",
+    "choice",
+    "laplace",
     "exponential",
     "gamma",
+    # "pareto",
     "beta",
-    "laplace",
-    "cauchy",
-    "logistic",
-    "truncated_normal",
+    # "dirichlet",
+    "gumbel",
+    # "loggamma",
+    "rademacher",
+    # "t",
+    # "weibull_min",
+    "orthogonal",
+    # "categorical",
+    "ball",
 ]

--- a/src/haliax/random.py
+++ b/src/haliax/random.py
@@ -22,7 +22,7 @@ def uniform(
     shape = ensure_tuple(shape)
     minval = broadcast_to(minval, shape).array
     maxval = broadcast_to(maxval, shape).array
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.uniform(key=key, shape=jax_shape, dtype=dtype, minval=minval, maxval=maxval)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -30,16 +30,16 @@ def uniform(
 @named_call
 def normal(key, shape: AxisSpec, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.normal(key=key, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
 
 @named_call
-def bernoulli(key, p: NamedOrNumeric, shape: AxisSpec):
+def bernoulli(key, shape: AxisSpec, p: NamedOrNumeric):
     shape = ensure_tuple(shape)
     p = broadcast_to(p, shape).array
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.bernoulli(key=key, p=p, shape=jax_shape)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -49,16 +49,16 @@ def randint(key, shape: AxisSpec, minval: NamedOrNumeric, maxval: NamedOrNumeric
     shape = ensure_tuple(shape)
     minval = broadcast_to(minval, shape).array
     maxval = broadcast_to(maxval, shape).array
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.randint(key=key, shape=jax_shape, minval=minval, maxval=maxval, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
 
 @named_call
-def poisson(key, lam: NamedOrNumeric, shape: AxisSpec, dtype=jnp.int_):
+def poisson(key, shape: AxisSpec, lam: NamedOrNumeric, dtype=jnp.int_):
     shape = ensure_tuple(shape)
     lam = broadcast_to(lam, shape).array
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.poisson(key=key, lam=lam, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -66,26 +66,26 @@ def poisson(key, lam: NamedOrNumeric, shape: AxisSpec, dtype=jnp.int_):
 @named_call
 def exponential(key, shape: AxisSpec, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.exponential(key=key, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
 
 @named_call
-def gamma(key, a: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+def gamma(key, shape: AxisSpec, a: NamedOrNumeric, dtype=jnp.float_):
     shape = ensure_tuple(shape)
     a = broadcast_to(a, shape).array
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.gamma(key=key, a=a, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
 
 @named_call
-def beta(key, a: NamedOrNumeric, b: NamedOrNumeric, shape: AxisSpec, dtype=jnp.float_):
+def beta(key, shape: AxisSpec, a: NamedOrNumeric, b: NamedOrNumeric, dtype=jnp.float_):
     shape = ensure_tuple(shape)
     a = broadcast_to(a, shape).array
     b = broadcast_to(b, shape).array
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.beta(key=key, a=a, b=b, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -93,7 +93,7 @@ def beta(key, a: NamedOrNumeric, b: NamedOrNumeric, shape: AxisSpec, dtype=jnp.f
 @named_call
 def laplace(key, shape: AxisSpec, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.laplace(key=key, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -101,7 +101,7 @@ def laplace(key, shape: AxisSpec, dtype=jnp.float_):
 @named_call
 def cauchy(key, shape: AxisSpec, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.cauchy(key=key, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -109,7 +109,7 @@ def cauchy(key, shape: AxisSpec, dtype=jnp.float_):
 @named_call
 def logistic(key, shape: AxisSpec, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.logistic(key=key, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -119,7 +119,7 @@ def truncated_normal(key, shape: AxisSpec, lower: NamedOrNumeric, upper: NamedOr
     shape = ensure_tuple(shape)
     lower = broadcast_to(lower, shape).array
     upper = broadcast_to(upper, shape).array
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.truncated_normal(key=key, lower=lower, upper=upper, shape=jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -196,13 +196,13 @@ def generate_sharded(fn, axis: Optional[Axis] = None):
 @named_call
 def ball(key, shape: AxisSpec, D: Axis, p: float = 2.0, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.ball(key=key, shape=jax_shape, d=D.size, p=p, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape + (D,)))
 
 
 @named_call
-def choice(key, a: NamedArray, axis: Axis, shape: AxisSpec, replace: bool = True, p: Optional[NamedArray] = None):
+def choice(key, shape: AxisSpec, a: NamedArray, axis: Axis, replace: bool = True, p: Optional[NamedArray] = None):
     """
     Selects random elements from an array along the given axis. If p is provided, the elements are selected
     with probability proportional to their weights and it must be a 1-d array with its only axis being the axis.
@@ -218,21 +218,38 @@ def choice(key, a: NamedArray, axis: Axis, shape: AxisSpec, replace: bool = True
     if p is not None:
         assert p.axes == (axis,), f"p must have axis {axis} or be None"
 
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
+    jax_p = p.array if p is not None else None
 
-    jax_array = jrandom.choice(
-        key, a.array, jax_shape, replace=replace, p=p.array if p is not None else None, axis=index
-    )
+    jax_array = jrandom.choice(key, a.array, jax_shape, replace=replace, p=jax_p, axis=index)
 
     expected_shape = shape + tuple(a.axes[:index] + a.axes[index + 1 :])
 
     return auto_sharded(NamedArray(jax_array, expected_shape))
 
 
+# @named_call
+# def categorical(key, shape: AxisSpec, logits: NamedArray, axis: Axis):
+#     shape = ensure_tuple(shape)
+#     logits = broadcast_to(logits, shape)
+#
+#     index = logits._lookup_indices(axis)
+#     assert index is not None, f"axis {axis} not in p"
+#
+#     shape_without_axis = shape[:index] + shape[index + 1 :]
+#
+#
+#     jax_shape = _to_jax_shape(shape)
+#     jax_array = jrandom.categorical(key, logits.array, axis=index, shape=jax_shape)
+#     expected_shape = shape + tuple(logits.axes[:index] + logits.axes[index + 1:])
+#
+#     return auto_sharded(NamedArray(jax_array, expected_shape))
+
+
 @named_call
 def gumbel(key, shape: AxisSpec, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.gumbel(key, jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
 
@@ -247,9 +264,50 @@ def permutation(key, x: NamedArray, axis: Axis, independent: bool = False):
 @named_call
 def rademacher(key, shape: AxisSpec, dtype=jnp.float_):
     shape = ensure_tuple(shape)
-    jax_shape = tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
+    jax_shape = _to_jax_shape(shape)
     jax_array = jrandom.rademacher(key, jax_shape, dtype=dtype)
     return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def t(key, shape: AxisSpec, df: NamedOrNumeric, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    df = broadcast_to(df, shape)
+    jax_shape = _to_jax_shape(shape)
+    jax_array = jrandom.t(key, df.array, jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def weibull_min(key, shape: AxisSpec, scale: NamedOrNumeric, concentration: NamedOrNumeric, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    scale = broadcast_to(scale, shape)
+    concentration = broadcast_to(concentration, shape)
+    jax_shape = _to_jax_shape(shape)
+    jax_array = jrandom.weibull_min(key, scale.array, concentration.array, jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def pareto(key, shape: AxisSpec, b: NamedOrNumeric, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    b = broadcast_to(b, shape)
+    jax_shape = _to_jax_shape(shape)
+    jax_array = jrandom.pareto(key, b.array, jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+@named_call
+def loggamma(key, shape: AxisSpec, a: NamedOrNumeric, dtype=jnp.float_):
+    shape = ensure_tuple(shape)
+    a = broadcast_to(a, shape)
+    jax_shape = _to_jax_shape(shape)
+    jax_array = jrandom.loggamma(key, a.array, jax_shape, dtype=dtype)
+    return auto_sharded(NamedArray(jax_array, shape))
+
+
+def _to_jax_shape(shape):
+    return tuple(axis.size if isinstance(axis, Axis) else axis for axis in shape)
 
 
 __all__ = [
@@ -269,11 +327,11 @@ __all__ = [
     "permutation",
     "poisson",
     "rademacher",
-    "truncated_normal"
+    "truncated_normal",
     # "categorical",
     # "dirichlet",
-    # "loggamma",
-    # "pareto",
-    # "t",
-    # "weibull_min",
+    "loggamma",
+    "pareto",
+    "t",
+    "weibull_min",
 ]

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -16,6 +16,9 @@ from levanter.compat.torch_serialization import StateDict, TorchSerializationMix
 from levanter.modeling_utils import ACT2FN
 
 
+sharded_normal = hax.random.generate_sharded(hax.random.normal)
+
+
 @dataclass(frozen=True)
 class Gpt2Config:
     seq_len: int = 512
@@ -396,14 +399,14 @@ class Gpt2Embeddings(TorchSerializationMixin, eqx.Module):
         self.SeqLen = SeqLen
         self.Embed = Embed
 
-        self.token_embeddings = hax.random.normal(key=k_wte, shape=(Vocab, Embed)) * initializer_range
-        self.position_embeddings = hax.random.normal(key=k_wpe, shape=(SeqLen, Embed)) * (initializer_range / 2)
+        self.token_embeddings = sharded_normal(key=k_wte, shape=(Vocab, Embed)) * initializer_range
+        self.position_embeddings = sharded_normal(key=k_wpe, shape=(SeqLen, Embed)) * (initializer_range / 2)
         self.dropout = hnn.Dropout(pdrop=dropout_prob)
 
         if tie_word_embeddings:
             self.token_out_embeddings = None
         else:
-            self.token_out_embeddings = hax.random.normal(key=k_out, shape=(Vocab, Embed)) * initializer_range
+            self.token_out_embeddings = sharded_normal(key=k_out, shape=(Vocab, Embed)) * initializer_range
 
     @named_call
     def embed(self, input_ids, inference, *, key):

--- a/tests/haliax/test_random.py
+++ b/tests/haliax/test_random.py
@@ -112,32 +112,32 @@ def test_normal():
 
 
 def test_bernoulli():
-    check_gen_is_equal(lambda k, s: jax.random.bernoulli(k, 0.5, s), lambda k, s: hax.random.bernoulli(k, 0.5, s))
+    check_gen_is_equal(lambda k, s: jax.random.bernoulli(k, 0.5, s), lambda k, s: hax.random.bernoulli(k, s, 0.5))
     # check broadcasting
     prob = hax.arange(Width, step=0.1)
     check_gen_is_equal(
         lambda k, s: jax.random.bernoulli(k, prob.array.reshape(1, -1), s),
-        lambda k, s: hax.random.bernoulli(k, prob, s),
+        lambda k, s: hax.random.bernoulli(k, s, prob),
     )
     prob = hax.arange(Height, step=0.1)
     check_gen_is_equal(
         lambda k, s: jax.random.bernoulli(k, prob.array.reshape(-1, 1), s),
-        lambda k, s: hax.random.bernoulli(k, prob, s),
+        lambda k, s: hax.random.bernoulli(k, s, prob),
     )
 
 
 def test_poisson():
-    check_gen_is_equal(lambda k, s: jax.random.poisson(k, 0.5, s), lambda k, s: hax.random.poisson(k, 0.5, s))
+    check_gen_is_equal(lambda k, s: jax.random.poisson(k, 0.5, s), lambda k, s: hax.random.poisson(k, s, 0.5))
     # check broadcasting
     lam = hax.arange(Width, step=0.1)
     check_gen_is_equal(
         lambda k, s: jax.random.poisson(k, lam.array.reshape(1, -1), s),
-        lambda k, s: hax.random.poisson(k, lam, s),
+        lambda k, s: hax.random.poisson(k, s, lam),
     )
     lam = hax.arange(Height, step=0.1)
     check_gen_is_equal(
         lambda k, s: jax.random.poisson(k, lam.array.reshape(-1, 1), s),
-        lambda k, s: hax.random.poisson(k, lam, s),
+        lambda k, s: hax.random.poisson(k, s, lam),
     )
 
 
@@ -150,17 +150,17 @@ def test_exponential():
 
 
 def test_gamma():
-    check_gen_is_equal(lambda k, s: jax.random.gamma(k, 0.5, s), lambda k, s: hax.random.gamma(k, 0.5, s))
+    check_gen_is_equal(lambda k, s: jax.random.gamma(k, 0.5, s), lambda k, s: hax.random.gamma(k, s, 0.5))
     # check broadcasting
     alpha = hax.arange(Width, step=0.1)
     check_gen_is_equal(
         lambda k, s: jax.random.gamma(k, alpha.array.reshape(1, -1), s),
-        lambda k, s: hax.random.gamma(k, alpha, s),
+        lambda k, s: hax.random.gamma(k, s, alpha),
     )
     alpha = hax.arange(Height, step=0.1)
     check_gen_is_equal(
         lambda k, s: jax.random.gamma(k, alpha.array.reshape(-1, 1), s),
-        lambda k, s: hax.random.gamma(k, alpha, s),
+        lambda k, s: hax.random.gamma(k, s, alpha),
     )
 
 
@@ -169,19 +169,19 @@ def test_gumbel():
 
 
 def test_beta():
-    check_gen_is_equal(lambda k, s: jax.random.beta(k, 0.6, 0.5, s), lambda k, s: hax.random.beta(k, 0.6, 0.5, s))
+    check_gen_is_equal(lambda k, s: jax.random.beta(k, 0.6, 0.5, s), lambda k, s: hax.random.beta(k, s, 0.6, 0.5))
     # check broadcasting
     alpha = hax.arange(Width, step=0.1, start=0.01)
     beta = hax.arange(Width, step=0.1, start=0.01)
     check_gen_is_equal(
         lambda k, s: jax.random.beta(k, alpha.array.reshape(1, -1), beta.array.reshape(1, -1), s),
-        lambda k, s: hax.random.beta(k, alpha, beta, s),
+        lambda k, s: hax.random.beta(k, s, alpha, beta),
     )
     alpha = hax.arange(Height, step=0.1, start=0.01)
     beta = hax.arange(Height, step=0.1, start=0.01)
     check_gen_is_equal(
         lambda k, s: jax.random.beta(k, alpha.array.reshape(-1, 1), beta.array.reshape(-1, 1), s),
-        lambda k, s: hax.random.beta(k, alpha, beta, s),
+        lambda k, s: hax.random.beta(k, s, alpha, beta),
     )
 
 
@@ -228,13 +228,26 @@ def test_truncated_normal():
 def test_choice():
     digits = hax.arange(Digit)
     check_gen_is_equal(
-        lambda k, s: jax.random.choice(k, digits.array, shape=s), lambda k, s: hax.random.choice(k, digits, Digit, s)
+        lambda k, s: jax.random.choice(k, digits.array, shape=s), lambda k, s: hax.random.choice(k, s, digits, Digit)
     )
 
     weights = hax.arange(Digit, step=0.1, start=0.01)
     check_gen_is_equal(
         lambda k, s: jax.random.choice(k, digits.array, shape=s, p=weights.array),
-        lambda k, s: hax.random.choice(k, digits, Digit, s, p=weights),
+        lambda k, s: hax.random.choice(k, s, digits, Digit, p=weights),
+    )
+
+
+def test_categorical():
+    digits = hax.arange(Digit)
+    check_gen_is_equal(
+        lambda k, s: jax.random.choice(k, digits.array, shape=s), lambda k, s: hax.random.choice(k, s, digits, Digit)
+    )
+
+    weights = hax.arange(Digit, step=0.1, start=0.01)
+    check_gen_is_equal(
+        lambda k, s: jax.random.choice(k, digits.array, shape=s, p=weights.array),
+        lambda k, s: hax.random.choice(k, s, digits, Digit, p=weights),
     )
 
 
@@ -250,3 +263,38 @@ def test_permutation():
     jax_perm = jax.random.permutation(jax.random.PRNGKey(0), data.array, 0)
 
     assert jnp.all(hax_perm.array == jax_perm)
+
+
+def test_t():
+    param = hax.arange(Width, start=0.1)
+    check_gen_is_equal(lambda k, s: jax.random.t(k, param.array, shape=s), lambda k, s: hax.random.t(k, s, param))
+
+    check_gen_is_equal(lambda k, s: jax.random.t(k, 0.5, shape=s), lambda k, s: hax.random.t(k, s, 0.5))
+
+
+def test_weibull_min():
+    scale = hax.arange(Width, start=0.1)
+    concentration = hax.arange(Height, start=0.1)
+
+    check_gen_is_equal(
+        lambda k, s: jax.random.weibull_min(
+            k, scale.array.reshape(1, -1), concentration.array.reshape(-1, 1), shape=s
+        ),
+        lambda k, s: hax.random.weibull_min(k, s, scale, concentration),
+    )
+
+
+def test_pareto():
+    b = hax.arange(Width, start=0.1)
+
+    check_gen_is_equal(
+        lambda k, s: jax.random.pareto(k, b.array.reshape(1, -1), shape=s), lambda k, s: hax.random.pareto(k, s, b)
+    )
+
+
+def test_loggamma():
+    a = hax.arange(Width, start=0.1)
+
+    check_gen_is_equal(
+        lambda k, s: jax.random.loggamma(k, a.array.reshape(1, -1), shape=s), lambda k, s: hax.random.loggamma(k, s, a)
+    )

--- a/tests/haliax/test_random.py
+++ b/tests/haliax/test_random.py
@@ -1,8 +1,71 @@
 import jax
 
 import haliax as hax
+from haliax.random import generate_sharded
 
 
 def test_empty_shape():
     key = jax.random.PRNGKey(0)
     hax.random.uniform(key, shape=())
+
+
+def test_uniform_with_bounds_scalar():
+    key = jax.random.PRNGKey(0)
+    Height = hax.Axis("Height", 4)
+    Width = hax.Axis("Width", 8)
+    u = hax.random.uniform(key, shape=(Height, Width), minval=-3.0, maxval=0.5)
+
+    assert u.axes == (Height, Width)
+
+    assert hax.all(u >= -3.0)
+    assert hax.all(u <= 0.5)
+
+
+def test_uniform_with_bounds_broadcast():
+    key = jax.random.PRNGKey(0)
+    Height = hax.Axis("Height", 4)
+    Width = hax.Axis("Width", 8)
+    lb = hax.full(Height, -3.0)
+    ub = hax.full(Width, 0.5)
+    u = hax.random.uniform(key, shape=(Height, Width), minval=lb, maxval=ub)
+
+    assert u.axes == (Height, Width)
+
+    assert hax.all(u >= -3.0)
+    assert hax.all(u <= 0.5)
+
+
+def test_uniform_with_bounds_broadcast_and_scalar():
+    key = jax.random.PRNGKey(0)
+    Height = hax.Axis("Height", 4)
+    Width = hax.Axis("Width", 8)
+    lb = hax.full(Height, -3.0)
+    ub = 0.5
+    u = hax.random.uniform(key, shape=(Height, Width), minval=lb, maxval=ub)
+
+    assert u.axes == (Height, Width)
+
+    assert hax.all(u >= -3.0)
+    assert hax.all(u <= 0.5)
+
+
+def test_sharded_uniform_with_bounds_broadcast_and_scalar():
+    hax.random._enforce_sharded_generate = True
+    try:
+        key = jax.random.PRNGKey(0)
+        Height = hax.Axis("Height", 4)
+        Width = hax.Axis("Width", 8)
+        lb = hax.full(Height, -3.0)
+        ub = 0.5
+        u = generate_sharded(hax.random.uniform, axis=Height)(key, shape=(Height, Width), minval=lb, maxval=ub)
+
+        assert u.axes == (Height, Width)
+
+        assert hax.all(u >= -3.0)
+        assert hax.all(u <= 0.5)
+    finally:
+        hax.random._enforce_sharded_generate = False
+
+    # now just assert that this does in fact change the randomness
+    u2 = hax.random.uniform(key, shape=(Height, Width), minval=lb, maxval=ub)
+    assert not hax.all(u == u2)

--- a/tests/haliax/test_random.py
+++ b/tests/haliax/test_random.py
@@ -1,7 +1,16 @@
+from typing import Callable
+
 import jax
+import jax.numpy as jnp
+from chex import PRNGKey
 
 import haliax as hax
 from haliax.random import generate_sharded
+
+
+Height = hax.Axis("Height", 4)
+Width = hax.Axis("Width", 8)
+Digit = hax.Axis("Digit", 10)
 
 
 def test_empty_shape():
@@ -10,9 +19,9 @@ def test_empty_shape():
 
 
 def test_uniform_with_bounds_scalar():
+    check_gen_is_equal(jax.random.uniform, hax.random.uniform)
+
     key = jax.random.PRNGKey(0)
-    Height = hax.Axis("Height", 4)
-    Width = hax.Axis("Width", 8)
     u = hax.random.uniform(key, shape=(Height, Width), minval=-3.0, maxval=0.5)
 
     assert u.axes == (Height, Width)
@@ -23,22 +32,23 @@ def test_uniform_with_bounds_scalar():
 
 def test_uniform_with_bounds_broadcast():
     key = jax.random.PRNGKey(0)
-    Height = hax.Axis("Height", 4)
-    Width = hax.Axis("Width", 8)
-    lb = hax.full(Height, -3.0)
+    lb = hax.arange(Height, start=-5.0)
     ub = hax.full(Width, 0.5)
     u = hax.random.uniform(key, shape=(Height, Width), minval=lb, maxval=ub)
 
     assert u.axes == (Height, Width)
 
-    assert hax.all(u >= -3.0)
+    assert hax.all(u >= lb)
     assert hax.all(u <= 0.5)
+
+    check_gen_is_equal(
+        lambda k, s: jax.random.uniform(k, shape=s, minval=lb.array.reshape(-1, 1), maxval=ub.array.reshape(1, -1)),
+        lambda k, s: hax.random.uniform(k, s, minval=lb, maxval=ub),
+    )
 
 
 def test_uniform_with_bounds_broadcast_and_scalar():
     key = jax.random.PRNGKey(0)
-    Height = hax.Axis("Height", 4)
-    Width = hax.Axis("Width", 8)
     lb = hax.full(Height, -3.0)
     ub = 0.5
     u = hax.random.uniform(key, shape=(Height, Width), minval=lb, maxval=ub)
@@ -53,8 +63,6 @@ def test_sharded_uniform_with_bounds_broadcast_and_scalar():
     hax.random._enforce_sharded_generate = True
     try:
         key = jax.random.PRNGKey(0)
-        Height = hax.Axis("Height", 4)
-        Width = hax.Axis("Width", 8)
         lb = hax.full(Height, -3.0)
         ub = 0.5
         u = generate_sharded(hax.random.uniform, axis=Height)(key, shape=(Height, Width), minval=lb, maxval=ub)
@@ -69,3 +77,176 @@ def test_sharded_uniform_with_bounds_broadcast_and_scalar():
     # now just assert that this does in fact change the randomness
     u2 = hax.random.uniform(key, shape=(Height, Width), minval=lb, maxval=ub)
     assert not hax.all(u == u2)
+
+
+def test_randint():
+    check_gen_is_equal(lambda k, s: jax.random.randint(k, s, 0, 10), lambda k, s: hax.random.randint(k, s, 0, 10))
+    # check broadcasting
+    minval = hax.arange(Width, step=1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.randint(k, s, minval.array.reshape(1, -1), 10),
+        lambda k, s: hax.random.randint(k, s, minval, 10),
+    )
+
+    minval = hax.arange(Height, step=1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.randint(k, s, minval.array.reshape(-1, 1), 10),
+        lambda k, s: hax.random.randint(k, s, minval, 10),
+    )
+
+
+def check_gen_is_equal(
+    jax_fn: Callable[[PRNGKey, tuple], jnp.ndarray], hax_fn: Callable[[PRNGKey, hax.AxisSpec], hax.NamedArray]
+):
+    key = jax.random.PRNGKey(0)
+
+    hax_out = hax_fn(key, (Height, Width))
+    jax_out = jax_fn(key, (Height.size, Width.size))
+
+    assert hax_out.array.shape == jax_out.shape
+    assert hax.all(hax_out.array == jax_out)
+
+
+def test_normal():
+    check_gen_is_equal(jax.random.normal, hax.random.normal)
+
+
+def test_bernoulli():
+    check_gen_is_equal(lambda k, s: jax.random.bernoulli(k, 0.5, s), lambda k, s: hax.random.bernoulli(k, 0.5, s))
+    # check broadcasting
+    prob = hax.arange(Width, step=0.1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.bernoulli(k, prob.array.reshape(1, -1), s),
+        lambda k, s: hax.random.bernoulli(k, prob, s),
+    )
+    prob = hax.arange(Height, step=0.1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.bernoulli(k, prob.array.reshape(-1, 1), s),
+        lambda k, s: hax.random.bernoulli(k, prob, s),
+    )
+
+
+def test_poisson():
+    check_gen_is_equal(lambda k, s: jax.random.poisson(k, 0.5, s), lambda k, s: hax.random.poisson(k, 0.5, s))
+    # check broadcasting
+    lam = hax.arange(Width, step=0.1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.poisson(k, lam.array.reshape(1, -1), s),
+        lambda k, s: hax.random.poisson(k, lam, s),
+    )
+    lam = hax.arange(Height, step=0.1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.poisson(k, lam.array.reshape(-1, 1), s),
+        lambda k, s: hax.random.poisson(k, lam, s),
+    )
+
+
+def test_laplace():
+    check_gen_is_equal(lambda k, s: jax.random.laplace(k, s), lambda k, s: hax.random.laplace(k, s))
+
+
+def test_exponential():
+    check_gen_is_equal(lambda k, s: jax.random.exponential(k, s), lambda k, s: hax.random.exponential(k, s))
+
+
+def test_gamma():
+    check_gen_is_equal(lambda k, s: jax.random.gamma(k, 0.5, s), lambda k, s: hax.random.gamma(k, 0.5, s))
+    # check broadcasting
+    alpha = hax.arange(Width, step=0.1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.gamma(k, alpha.array.reshape(1, -1), s),
+        lambda k, s: hax.random.gamma(k, alpha, s),
+    )
+    alpha = hax.arange(Height, step=0.1)
+    check_gen_is_equal(
+        lambda k, s: jax.random.gamma(k, alpha.array.reshape(-1, 1), s),
+        lambda k, s: hax.random.gamma(k, alpha, s),
+    )
+
+
+def test_gumbel():
+    check_gen_is_equal(lambda k, s: jax.random.gumbel(k, s), lambda k, s: hax.random.gumbel(k, s))
+
+
+def test_beta():
+    check_gen_is_equal(lambda k, s: jax.random.beta(k, 0.6, 0.5, s), lambda k, s: hax.random.beta(k, 0.6, 0.5, s))
+    # check broadcasting
+    alpha = hax.arange(Width, step=0.1, start=0.01)
+    beta = hax.arange(Width, step=0.1, start=0.01)
+    check_gen_is_equal(
+        lambda k, s: jax.random.beta(k, alpha.array.reshape(1, -1), beta.array.reshape(1, -1), s),
+        lambda k, s: hax.random.beta(k, alpha, beta, s),
+    )
+    alpha = hax.arange(Height, step=0.1, start=0.01)
+    beta = hax.arange(Height, step=0.1, start=0.01)
+    check_gen_is_equal(
+        lambda k, s: jax.random.beta(k, alpha.array.reshape(-1, 1), beta.array.reshape(-1, 1), s),
+        lambda k, s: hax.random.beta(k, alpha, beta, s),
+    )
+
+
+def test_rademacher():
+    check_gen_is_equal(lambda k, s: jax.random.rademacher(k, s), lambda k, s: hax.random.rademacher(k, s))
+
+
+def test_ball():
+    check_gen_is_equal(lambda k, s: jax.random.ball(k, Digit.size, shape=s), lambda k, s: hax.random.ball(k, s, Digit))
+
+
+def test_cauchy():
+    check_gen_is_equal(lambda k, s: jax.random.cauchy(k, s), lambda k, s: hax.random.cauchy(k, s))
+
+
+def test_logistic():
+    check_gen_is_equal(lambda k, s: jax.random.logistic(k, s), lambda k, s: hax.random.logistic(k, s))
+
+
+def test_truncated_normal():
+    lower = hax.arange(Width, step=0.1, start=0.01)
+    upper = hax.arange(Width, step=0.1, start=0.01)
+    check_gen_is_equal(
+        lambda k, s: jax.random.truncated_normal(k, lower.array.reshape(1, -1), upper.array.reshape(1, -1), s),
+        lambda k, s: hax.random.truncated_normal(k, s, lower, upper),
+    )
+
+    lower = hax.arange(Height, step=0.1, start=0.01)
+    upper = hax.arange(Height, step=0.1, start=0.01)
+    check_gen_is_equal(
+        lambda k, s: jax.random.truncated_normal(k, lower.array.reshape(-1, 1), upper.array.reshape(-1, 1), s),
+        lambda k, s: hax.random.truncated_normal(k, s, lower, upper),
+    )
+
+    lower = hax.arange(Width, step=0.1, start=0.01)
+    upper = hax.arange(Height, step=0.1, start=0.01)
+
+    check_gen_is_equal(
+        lambda k, s: jax.random.truncated_normal(k, lower.array.reshape(1, -1), upper.array.reshape(-1, 1), s),
+        lambda k, s: hax.random.truncated_normal(k, s, lower, upper),
+    )
+
+
+def test_choice():
+    digits = hax.arange(Digit)
+    check_gen_is_equal(
+        lambda k, s: jax.random.choice(k, digits.array, shape=s), lambda k, s: hax.random.choice(k, digits, Digit, s)
+    )
+
+    weights = hax.arange(Digit, step=0.1, start=0.01)
+    check_gen_is_equal(
+        lambda k, s: jax.random.choice(k, digits.array, shape=s, p=weights.array),
+        lambda k, s: hax.random.choice(k, digits, Digit, s, p=weights),
+    )
+
+
+def test_permutation():
+    data = hax.random.uniform(jax.random.PRNGKey(0), (Width, Height))
+
+    hax_perm = hax.random.permutation(jax.random.PRNGKey(0), data, Height)
+    jax_perm = jax.random.permutation(jax.random.PRNGKey(0), data.array, 1)
+
+    assert jnp.all(hax_perm.array == jax_perm)
+
+    hax_perm = hax.random.permutation(jax.random.PRNGKey(0), data, Width)
+    jax_perm = jax.random.permutation(jax.random.PRNGKey(0), data.array, 0)
+
+    assert jnp.all(hax_perm.array == jax_perm)


### PR DESCRIPTION
This is maybe not worth reviewing since it's a bit outside critical path, but here it is.

Previously, I wrapped RNG functions with a single very python-y dynamic wrapper thing. This in adopt me is not super great because of things like broadcasting. I could improve the wrapper function but it was getting a little messy, so I went ahead and explicitly listed everything. This helps code coverage which is nice and helps the IDE etc.

While I was doing this, I also made this auto-RNG-sharding thing I had made explicit rather than implicit. It's a bit more ceremony, but it's worth it. (RNG sharding is necessary at ~6B or so.)

