### PR TITLE
Dataloader Cleanup

### DIFF
--- a/examples/gpt2_eval.py
+++ b/examples/gpt2_eval.py
@@ -24,7 +24,7 @@ from levanter import callbacks
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import load_hf_gpt2_checkpoint
 from levanter.config import TrainerConfig
-from levanter.data.sharded import ShardedIndexedDataset
+from levanter.data.sharded import GlobalBatchDataset
 from levanter.data.text import CachedLMDatasetConfig, TokenSeqDataset
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.trainer_hooks import StepInfo
@@ -52,7 +52,7 @@ def main(config: EvalGpt2Config):
 
     with config.trainer.device_mesh, axis_mapping(config.trainer.axis_resources):
         eval_cache = config.data.build_or_load_document_cache("validation")
-        eval_dataset = ShardedIndexedDataset(
+        eval_dataset = GlobalBatchDataset(
             TokenSeqDataset(eval_cache, config.model.seq_len),
             config.trainer.device_mesh,
             config.trainer.eval_batch_size,

--- a/examples/gpt2_eval.py
+++ b/examples/gpt2_eval.py
@@ -24,9 +24,8 @@ from levanter import callbacks
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import load_hf_gpt2_checkpoint
 from levanter.config import TrainerConfig
-from levanter.data import CachedLMDatasetConfig
 from levanter.data.sharded import ShardedIndexedDataset
-from levanter.data.text import TokenSeqDataset
+from levanter.data.text import CachedLMDatasetConfig, TokenSeqDataset
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.trainer_hooks import StepInfo
 

--- a/examples/gpt2_example.py
+++ b/examples/gpt2_example.py
@@ -11,16 +11,17 @@ import jax.random as jrandom
 import jmp
 import pyrallis
 from equinox import filter_vmap
+from jax.interpreters.pxla import PartitionSpec
 from transformers import GPT2Tokenizer
 
 import haliax as hax
 import haliax.random
 import wandb
 from haliax import Axis
-from haliax.partitioning import axis_mapping, named_pjit, round_axis_for_partitioning
+from haliax.partitioning import ResourceAxis, axis_mapping, named_pjit, round_axis_for_partitioning
 from levanter.callbacks import log_performance_stats, log_to_wandb, pbar_logger, wandb_xla_logger
 from levanter.config import TrainerConfig
-from levanter.data.sharded import ShardedIndexedDataset
+from levanter.data.sharded import GlobalBatchDataset
 from levanter.data.text import CachedLMDatasetConfig, TokenSeqDataset
 from levanter.jax_utils import global_key_array, parameter_count, simplify_gdas
 from levanter.logging import capture_time, log_time_to_wandb
@@ -49,13 +50,13 @@ def main(config: TrainGpt2Config):
     config.trainer.initialize(config)
 
     tokenizer: GPT2Tokenizer = config.data.the_tokenizer
-    dataset = ShardedIndexedDataset(
+    dataset = GlobalBatchDataset(
         TokenSeqDataset(config.data.build_or_load_document_cache("train"), config.model.seq_len),
         config.trainer.device_mesh,
         config.trainer.train_batch_size,
     )
 
-    eval_dataset = ShardedIndexedDataset(
+    eval_dataset = GlobalBatchDataset(
         TokenSeqDataset(config.data.build_or_load_document_cache("validation"), config.model.seq_len),
         config.trainer.device_mesh,
         config.trainer.eval_batch_size,
@@ -255,9 +256,11 @@ def main(config: TrainGpt2Config):
                 with log_time_to_wandb("throughput/loading_time", step=step):
                     input_ids = next(iter_data)
                     my_key, training_key = jrandom.split(training_key, 2)
-                    micro_keys = global_key_array(my_key, input_ids.shape[:-1], mesh, dataset.partition_spec[:-1])
+                    example_keys = global_key_array(
+                        my_key, config.trainer.train_batch_size, mesh, PartitionSpec(ResourceAxis.DATA)
+                    )
 
-                step_loss, model, opt_state = simplify_gdas(train_step(model, opt_state, input_ids, micro_keys))
+                step_loss, model, opt_state = simplify_gdas(train_step(model, opt_state, input_ids, example_keys))
                 step_loss = jnp.mean(step_loss).item()
 
             with log_time_to_wandb("throughput/hook_time", step=step):

--- a/examples/gpt2_example.py
+++ b/examples/gpt2_example.py
@@ -20,9 +20,8 @@ from haliax import Axis
 from haliax.partitioning import axis_mapping, named_pjit, round_axis_for_partitioning
 from levanter.callbacks import log_performance_stats, log_to_wandb, pbar_logger, wandb_xla_logger
 from levanter.config import TrainerConfig
-from levanter.data import CachedLMDatasetConfig
 from levanter.data.sharded import ShardedIndexedDataset
-from levanter.data.text import TokenSeqDataset
+from levanter.data.text import CachedLMDatasetConfig, TokenSeqDataset
 from levanter.jax_utils import global_key_array, parameter_count, simplify_gdas
 from levanter.logging import capture_time, log_time_to_wandb
 from levanter.modeling_utils import accumulate_gradients_sharded, cross_entropy_loss_and_log_normalizers

--- a/scripts/cache_dataset.py
+++ b/scripts/cache_dataset.py
@@ -1,6 +1,6 @@
 import pyrallis
 
-from levanter.data import CachedLMDatasetConfig
+from levanter.data.text import CachedLMDatasetConfig
 
 
 @pyrallis.wrap()

--- a/src/levanter/data/__init__.py
+++ b/src/levanter/data/__init__.py
@@ -1,99 +1,10 @@
-import json
-import os
-from dataclasses import dataclass
-from functools import cached_property
-from typing import List, Optional
-
-import braceexpand
-import datasets
-import fsspec
-from transformers import AutoTokenizer
-
-from levanter.data.dataset import Dataset, ShuffleDataset
-from levanter.data.text import TokenizedDocumentCache, tokenize_batch
+from levanter.data.dataset import Dataset, ShardableDataset, ShuffleDataset
 from levanter.data.utils import batched
 
 
-@dataclass
-class LMDatasetConfig:
-    """This class supports loading data both from HF Datasets and from a raw dataset of jsonl urls"""
-
-    id: Optional[str] = None  # id (or path) for hf dataset
-    name: Optional[str] = None  # name for hf dataset
-    stream: bool = True  # whether to use streaming when doing hf
-
-    train_urls: List[str] = ()  # type: ignore
-    validation_urls: List[str] = ()  # type:ignore
-
-    tokenizer: str = "gpt2"
-    enforce_eos: bool = True
-    text_key: str = "text"  # key for the text field in the jsonl file or hf dataset
-
-    @cached_property
-    def the_tokenizer(self):
-        return AutoTokenizer.from_pretrained(self.tokenizer)
-
-    def doc_iterator(self, split: str):
-        if self.id is not None:
-            dataset = datasets.load_dataset(self.id, name=self.name, streaming=self.stream)
-            data = dataset[split]
-            for doc in data:
-                text = doc[self.text_key]
-                if self.enforce_eos:
-                    text += self.the_tokenizer.eos_token
-                yield text
-        else:
-            if split == "train":
-                urls = self.train_urls
-            elif split == "validation":
-                urls = self.validation_urls
-            else:
-                raise ValueError(f"Unknown split {split}")
-
-            urls = [url for pat in urls for url in braceexpand.braceexpand(pat)]
-            files = fsspec.open_files(urls, "r", compression="infer")
-            for file in files:
-                with file as f:
-                    for line in f.readlines():
-                        text = json.loads(line)[self.text_key]
-                        if self.enforce_eos:
-                            text += self.the_tokenizer.eos_token
-                        yield text
-
-    # def __post_init__(self):
-    #     if self.id is None and len(self.train_urls) == 0 and len(self.validation_urls) == 0:
-    #         raise ValueError("Either id or urls must be provided")
-
-
-@dataclass
-class CachedLMDatasetConfig(LMDatasetConfig):
-    cache_dir: str = "cache/"
-    num_train_shards: int = 128
-    num_val_shards: int = 32
-
-    train_group_size: int = 1000
-    val_group_size: int = 100
-
-    def build_or_load_document_cache(self, split: str):
-        cache_dir = os.path.join(self.cache_dir, f"{split}")
-        # TODO: think about doing this on apache beam or something fancy. Maybe nothing fancy we can do for HF datasets,
-        # but for pure-url based ones, shouldn't be hard.
-        doc_iter = self.doc_iterator(split)
-        group_size = self.train_group_size if split == "train" else self.val_group_size
-        token_iter = (
-            tokenize_batch(self.the_tokenizer, batch, self.enforce_eos) for batch in batched(doc_iter, group_size)
-        )
-
-        num_shards = self.num_train_shards if split == "train" else self.num_val_shards
-
-        return TokenizedDocumentCache.build_or_load(token_iter, cache_dir, num_shards, self.enforce_eos)
-
-
 __all__ = [
-    "LMDatasetConfig",
-    "CachedLMDatasetConfig",
     "batched",
     "Dataset",
+    "ShardableDataset",
     "ShuffleDataset",
-    "TokenizedDocumentCache",
 ]

--- a/src/levanter/data/sharded.py
+++ b/src/levanter/data/sharded.py
@@ -1,5 +1,4 @@
 import itertools
-from math import prod
 from typing import Iterator, Optional, Sequence, Tuple, TypeVar
 
 import jax
@@ -22,30 +21,32 @@ Ex = TypeVar("Ex")
 # TODO: write tests to verify this works when data spans multiple processes
 # ExampleShape = Union[Tuple[int, ...], Sequence[Tuple[int, ...]]]
 
-# This is hard for me to think about.
-
-# We use GlobalDeviceArrays to coordinate data loading. A GlobalDeviceArray is an array that has a global shape
-# but only has the data for some of the chunks of the array (namely, the ones on the local devices). Data can be
-# replicated across devices, so that more than one device has the same chunk of data. This is useful for
-# data or model parallelism.
-# GlobalDeviceArrays are constructed using from_batched_callback, which passes in a list of slices that correspond to
-# the entries in the GDA.
-#
-# For our purposes (data loading), we want to load batches of data from a dataset. We want to load the data in a
-# way that is compatible with the GDA, so that we can use the GDA to coordinate the data loading.
-# For standard language modeling tasks, the data is a sequence of tokens of some length, so the GDA has shape
-# (batch_size, num_tokens). We want to load batches of data that are compatible with this shape.
-# The device mesh is (data, model), and we want to replicate data across the model axis. We partition the above array as
-# (data, None), meaning that the batch axis is distributed across the data axis. Each process is responsible for
-# loading data for its devices. GDA's from_batched_callback will tell us how much data to load and for which device, so
-# we just have to load it. We do need to make sure that, in the event the data axis is larger than
-# num_devices_per_process, each process that is part of the same position in the device mesh loads the same data.
+_TensorSliceIndex = Tuple[slice, ...]
 
 
-class ShardedIndexedDataset(Dataset[GlobalDeviceArray]):
+class GlobalBatchDataset(Dataset[GlobalDeviceArray]):
+    """
+    GlobalBatchDataset wraps a "local dataset" (a dataset that is shardable and can be iterated over) to produce
+    GlobalDeviceArrays representing batches of data. A GlobalDeviceArray is an array that has a global shape
+    but only has the data for some of the chunks of the array (namely, the ones on the local devices).
+    Thus, each process loads the data for its devices.
+
+    The details are a bit complex: We have a device mesh of shape (data, model). We want each row of the device mesh to
+    get batch_size//num_rows examples. Usually, a process will be responsible for one or more entire rows, meaning
+    that it wil load data that is distinct from every other process. However, if num_cols > num_devices_per_process,
+    then some processes will need to load the same data. We use the process_mesh_position to determine which data to
+    load, by determining which row(s) of the device mesh the process is responsible for.
+
+    For now GlobalBatchDataset is restricted to datasets that return a single sequence of tokens.
+
+    :arg local_dataset: a dataset that is shardable and can be iterated over
+    :arg mesh: the device mesh
+    :arg batch_size: the batch size
+    """
+
     def __init__(
         self,
-        token_dataset: ShardableDataset[BatchEncoding],
+        local_dataset: ShardableDataset[BatchEncoding],
         mesh: Mesh,
         batch_size: int,
         *,
@@ -61,57 +62,70 @@ class ShardedIndexedDataset(Dataset[GlobalDeviceArray]):
         if not override_process_data_groups:
             assert num_data_process_groups <= jax.process_count()
 
-        self.token_dataset = token_dataset.shard(process_data_pos, num_data_process_groups)
+        self.local_dataset = local_dataset.shard(process_data_pos, num_data_process_groups)
 
     def __iter__(self) -> Iterator[GlobalDeviceArray]:
         # TODO: support not infinite iterators
         def loop_gen():
             while True:
-                for ex in self.token_dataset:
+                for ex in self.local_dataset:
                     yield ex
 
         it = loop_gen()
 
-        batch_shape = self.batch_shape
+        item_shape = self.item_shape
         pspec = self.partition_spec
 
-        assert len(batch_shape) == len(pspec)
+        assert len(item_shape) == len(pspec)
 
-        def callback(indices: Sequence[Tuple[slice, ...]]):
-            # TODO: it seems like we may want to just directly index into the tokenized dataset somehow. This seems a
-            #  bit more fragile
-            # there is one entry in indices per device. They may be identical.
-            # convert slices to tuples so we can use hashes
+        # This callback takes a sequence of slices indicating a grid of the data to load, and returns the data
+        # We're mostly going to ignore the slices, because we're streaming the data
+        # We get one slice per device: the slices will be identical if the data is replicated
+        # TODO: we may want to just directly index into the tokenized dataset somehow. This seems a bit more fragile
+
+        def callback(indices: Sequence[_TensorSliceIndex]):
             out = []
-            data_for_group = {}
-            for index_group in indices:
-                # begin, end, step
-                my_indices: Tuple[Tuple[int, int, int], ...] = tuple(
-                    s.indices(axis_size) for axis_size, s in zip(batch_shape, index_group)
-                )
-                assert all(s[2] == 1 for s in my_indices)  # ensure step is 1
-                slice_sizes = [s[1] - s[0] for s in my_indices]
-                num_examples = prod(slice_sizes[0:-1])
-                if my_indices not in data_for_group:
-                    data_for_group[my_indices] = np.stack(
+
+            # because more than one device can get the same data, we need to make sure we only load it once since we're
+            # streaming. This is the cache
+            data_for_slice = {}
+
+            for tslice_index in indices:
+                begin_ends_for_index = self._get_begin_end_for_slice(item_shape, tslice_index)
+                slice_sizes = [s[1] - s[0] for s in begin_ends_for_index]
+
+                num_examples = slice_sizes[0]
+
+                if begin_ends_for_index not in data_for_slice:
+                    data_for_slice[begin_ends_for_index] = np.stack(
                         list([ex["input_ids"] for ex in itertools.islice(it, num_examples)])
-                    ).reshape(*slice_sizes)
-                out.append(data_for_group[my_indices])
+                    )
+                out.append(data_for_slice[begin_ends_for_index])
 
             return out
 
         while True:
             yield GlobalDeviceArray.from_batched_callback(
-                batch_shape,
+                item_shape,
                 self.mesh,
                 pspec,
                 callback,
             )
+
+    @staticmethod
+    def _get_begin_end_for_slice(tensor_shape, tslice_index) -> Tuple[Tuple[int, int], ...]:
+        # begin, end, step
+        my_indices: Tuple[Tuple[int, int, int], ...] = tuple(
+            s.indices(axis_size) for axis_size, s in zip(tensor_shape, tslice_index)
+        )
+        assert all(s[2] == 1 for s in my_indices)  # ensure step is 1
+        return tuple(s[0:2] for s in my_indices)
 
     @property
     def partition_spec(self):
         return PartitionSpec(ResourceAxis.DATA, None)
 
     @property
-    def batch_shape(self):
-        return (self.batch_size, self.token_dataset.seq_len)
+    def item_shape(self):
+        # TODO: make datasets expose data shapes as pytrees
+        return (self.batch_size, self.local_dataset.seq_len)

--- a/src/levanter/data/sharded.py
+++ b/src/levanter/data/sharded.py
@@ -5,7 +5,6 @@ import jax
 import numpy as np
 from jax.experimental.global_device_array import GlobalDeviceArray
 from jax.interpreters.pxla import Mesh, PartitionSpec
-from transformers import BatchEncoding
 
 import levanter.mesh
 from haliax.partitioning import ResourceAxis
@@ -46,7 +45,7 @@ class GlobalBatchDataset(Dataset[GlobalDeviceArray]):
 
     def __init__(
         self,
-        local_dataset: ShardableDataset[BatchEncoding],
+        local_dataset: ShardableDataset[Sequence[int]],
         mesh: Mesh,
         batch_size: int,
         *,
@@ -98,7 +97,7 @@ class GlobalBatchDataset(Dataset[GlobalDeviceArray]):
 
                 if begin_ends_for_index not in data_for_slice:
                     data_for_slice[begin_ends_for_index] = np.stack(
-                        list([ex["input_ids"] for ex in itertools.islice(it, num_examples)])
+                        list([ex for ex in itertools.islice(it, num_examples)])
                     )
                 out.append(data_for_slice[begin_ends_for_index])
 

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -44,7 +44,7 @@ overwatch = logging.getLogger("levanter.data.text")
 LEDGER_FILE = "ledger.json"
 
 
-class TokenSeqDataset(ShardableDataset[BatchEncoding]):
+class TokenSeqDataset(ShardableDataset[Sequence[int]]):
     """
     A dataset that yields sequences of tokens of fixed length from a TokenizedDocumentCache.
     """
@@ -60,9 +60,10 @@ class TokenSeqDataset(ShardableDataset[BatchEncoding]):
         """
         return TokenSeqDataset(self.doc_cache.shard(shard_id, num_shards), self.seq_len, self.stride)
 
-    def __iter__(self) -> Iterator[BatchEncoding]:
+    def __iter__(self) -> Iterator[Sequence[int]]:
         for doc in self.doc_cache:
-            yield from concatenate_and_group_texts(doc, self.seq_len, self.stride)
+            for encoded_slice in concatenate_and_group_texts(doc, self.seq_len, self.stride):
+                yield encoded_slice["input_ids"]
 
     @staticmethod
     def build_or_load(

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -15,15 +15,19 @@ import copy
 import json
 import logging
 import os
+from dataclasses import dataclass
+from functools import cached_property
 from itertools import chain
-from typing import Iterator, Optional, Sequence
+from typing import Iterator, List, Optional, Sequence
 
+import braceexpand
+import datasets
 import fsspec
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 from tqdm import tqdm
-from transformers import BatchEncoding
+from transformers import AutoTokenizer, BatchEncoding
 
 from levanter.data.dataset import ShardableDataset
 from levanter.data.utils import batched
@@ -333,3 +337,78 @@ def _mask_overlap(labels, target_len, stride, sentinel=-100):
         labels[0 : target_len - stride] = sentinel
 
     return labels
+
+
+@dataclass
+class LMDatasetConfig:
+    """This class supports loading data both from HF Datasets and from a raw dataset of jsonl urls"""
+
+    id: Optional[str] = None  # id (or path) for hf dataset
+    name: Optional[str] = None  # name for hf dataset
+    stream: bool = True  # whether to use streaming when doing hf
+
+    train_urls: List[str] = ()  # type: ignore
+    validation_urls: List[str] = ()  # type:ignore
+
+    tokenizer: str = "gpt2"
+    enforce_eos: bool = True
+    text_key: str = "text"  # key for the text field in the jsonl file or hf dataset
+
+    @cached_property
+    def the_tokenizer(self):
+        return AutoTokenizer.from_pretrained(self.tokenizer)
+
+    def doc_iterator(self, split: str):
+        if self.id is not None:
+            dataset = datasets.load_dataset(self.id, name=self.name, streaming=self.stream)
+            data = dataset[split]
+            for doc in data:
+                text = doc[self.text_key]
+                if self.enforce_eos:
+                    text += self.the_tokenizer.eos_token
+                yield text
+        else:
+            if split == "train":
+                urls = self.train_urls
+            elif split == "validation":
+                urls = self.validation_urls
+            else:
+                raise ValueError(f"Unknown split {split}")
+
+            urls = [url for pat in urls for url in braceexpand.braceexpand(pat)]
+            files = fsspec.open_files(urls, "r", compression="infer")
+            for file in files:
+                with file as f:
+                    for line in f.readlines():
+                        text = json.loads(line)[self.text_key]
+                        if self.enforce_eos:
+                            text += self.the_tokenizer.eos_token
+                        yield text
+
+    # def __post_init__(self):
+    #     if self.id is None and len(self.train_urls) == 0 and len(self.validation_urls) == 0:
+    #         raise ValueError("Either id or urls must be provided")
+
+
+@dataclass
+class CachedLMDatasetConfig(LMDatasetConfig):
+    cache_dir: str = "cache/"
+    num_train_shards: int = 128
+    num_val_shards: int = 32
+
+    train_group_size: int = 1000
+    val_group_size: int = 100
+
+    def build_or_load_document_cache(self, split: str):
+        cache_dir = os.path.join(self.cache_dir, f"{split}")
+        # TODO: think about doing this on apache beam or something fancy. Maybe nothing fancy we can do for HF datasets,
+        # but for pure-url based ones, shouldn't be hard.
+        doc_iter = self.doc_iterator(split)
+        group_size = self.train_group_size if split == "train" else self.val_group_size
+        token_iter = (
+            tokenize_batch(self.the_tokenizer, batch, self.enforce_eos) for batch in batched(doc_iter, group_size)
+        )
+
+        num_shards = self.num_train_shards if split == "train" else self.num_val_shards
+
+        return TokenizedDocumentCache.build_or_load(token_iter, cache_dir, num_shards, self.enforce_eos)

--- a/src/levanter/jax_utils.py
+++ b/src/levanter/jax_utils.py
@@ -14,6 +14,7 @@ from jax.interpreters.pxla import PartitionSpec
 from jaxtyping import PyTree
 
 from haliax.jax_utils import is_jax_array_like, shaped_rng_split
+from haliax.util import ensure_tuple
 
 
 def jnp_to_python(a: jnp.ndarray):
@@ -86,6 +87,7 @@ def global_key_array(key: PRNGKey, global_shape, global_mesh, mesh_axes):
     """
 
     # add key shape to global_shape and pad out axes
+    global_shape = ensure_tuple(global_shape)
     orig_global_shape = global_shape
     global_shape = global_shape + key.shape
     mesh_axes = list(mesh_axes) + [None] * (len(global_shape) - len(mesh_axes))

--- a/tests/test_sharded_data_loading.py
+++ b/tests/test_sharded_data_loading.py
@@ -10,7 +10,7 @@ from transformers import BatchEncoding
 from utils import skip_if_not_enough_devices
 
 from haliax.partitioning import ResourceAxis
-from levanter.data.sharded import ShardedIndexedDataset
+from levanter.data.sharded import GlobalBatchDataset
 from levanter.data.text import TokenizedDocumentCache, TokenSeqDataset
 
 
@@ -46,11 +46,11 @@ def test_sharded_data_loading_model_axis_2():
 
         seq_len = 128
         cache = _small_dataset(seq_len)
-        dataset = ShardedIndexedDataset(cache, mesh, batch_size=len(devices))
+        dataset = GlobalBatchDataset(cache, mesh, batch_size=len(devices))
 
         batches: List[GlobalDeviceArray] = list(itertools.islice(dataset, 10))
         for batch in batches:
-            assert batch.shape == dataset.batch_shape
+            assert batch.shape == dataset.item_shape
             shard_i: Shard
             check_batch_shard_consistency(batch, mesh)
 
@@ -80,11 +80,11 @@ def test_sharded_data_loading_model_axis_1():
 
         seq_len = 128
         cache = _small_dataset(seq_len)
-        dataset = ShardedIndexedDataset(cache, mesh, batch_size=len(devices))
+        dataset = GlobalBatchDataset(cache, mesh, batch_size=len(devices))
 
         batches: List[GlobalDeviceArray] = list(itertools.islice(dataset, 10))
         for batch in batches:
-            assert batch.shape == dataset.batch_shape
+            assert batch.shape == dataset.item_shape
             shard_i: Shard
             check_batch_shard_consistency(batch, mesh)
 
@@ -102,7 +102,7 @@ def test_sharded_data_loading_model_axis_1_override_process_indices():
         for process_index in range(2):
             seq_len = 128
             cache = _small_dataset(seq_len)
-            dataset = ShardedIndexedDataset(
+            dataset = GlobalBatchDataset(
                 cache,
                 mesh,
                 batch_size=len(devices),


### PR DESCRIPTION
This PR can be reviewed as individual commits, or I can break it up.

Some housekeeping as I prep adding mixtures, different tasks, possible multimodal support, etc.

* move the lm config classes to be with the other text-specific classes
* clean up docs for ShardedIndexedDataset and rename to GlobalBatchDataset
* refactor so that GlobalBatchDataset doesn't know about BatchEncodings