### PR TITLE
Expose length of datasets so we can start/stop

### DIFF
--- a/examples/gpt2_eval.py
+++ b/examples/gpt2_eval.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 from dataclasses import dataclass
 from functools import partial
@@ -77,8 +76,7 @@ def main(config: EvalGpt2Config):
             return jnp.mean(compute_loss_vmap(model, input_ids, key))
 
         def eval_dataloader():
-            # TODO: only do one pass
-            for batch in itertools.islice(eval_dataset, 100):
+            for batch in eval_dataset:
                 yield (batch,)
 
         # initialize the model

--- a/examples/gpt2_example.py
+++ b/examples/gpt2_example.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 from dataclasses import dataclass
 from functools import partial
@@ -28,6 +27,7 @@ from levanter.logging import capture_time, log_time_to_wandb
 from levanter.modeling_utils import accumulate_gradients_sharded, cross_entropy_loss_and_log_normalizers
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.trainer_hooks import StepInfo, TrainerHooks
+from py_utils import non_caching_cycle
 
 
 logger = logging.getLogger(__name__)
@@ -157,11 +157,7 @@ def main(config: TrainGpt2Config):
             axis_resources=config.trainer.axis_resources,
         )
 
-        # Set up evaluation: dataloader, loop
-        def eval_dataloader():
-            # TODO: only do one pass
-            yield from itertools.islice(eval_dataset, 50)
-
+        # Set up evaluation
         def evaluate_step(info: StepInfo):
             model_inf = prepare_model_for_compute(info.model)
 
@@ -169,7 +165,7 @@ def main(config: TrainGpt2Config):
             loss = 0.0
             n = 0
 
-            for batch in eval_dataloader():
+            for batch in eval_dataset:
                 loss += simplify_gdas(compute_loss_pjit(model_inf, batch)).item()
                 n += 1
 
@@ -193,7 +189,7 @@ def main(config: TrainGpt2Config):
         engine.add_hook(checkpointer.on_step, every=1)  # checkpointer manages its own frequency
 
         # data loader
-        iter_data = iter(dataset)
+        iter_data = non_caching_cycle(dataset)
 
         # load the last checkpoint and resume if we want
         resume_step = None

--- a/src/levanter/data/dataset.py
+++ b/src/levanter/data/dataset.py
@@ -13,6 +13,10 @@ class Dataset(Iterable[T], ABC):
     def __iter__(self) -> Iterator[T]:
         raise NotImplementedError
 
+    @abstractmethod
+    def __len__(self) -> int:
+        raise NotImplementedError
+
 
 class ShardableDataset(Dataset[T], ABC):
     @abstractmethod
@@ -53,3 +57,6 @@ class ShuffleDataset(ShardableDataset[T]):
             i = jrandom.randint(subkey, (), 0, len(buffer))
             yield buffer[i]
             del buffer[i]
+
+    def __len__(self) -> int:
+        return len(self.dataset)

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -61,9 +61,29 @@ class TokenSeqDataset(ShardableDataset[Sequence[int]]):
         return TokenSeqDataset(self.doc_cache.shard(shard_id, num_shards), self.seq_len, self.stride)
 
     def __iter__(self) -> Iterator[Sequence[int]]:
+        extra_tokens = None  # BatchEncoding of the last tokens from the previous doc
         for doc in self.doc_cache:
-            for encoded_slice in concatenate_and_group_texts(doc, self.seq_len, self.stride):
-                yield encoded_slice["input_ids"]
+
+            # TODO: we could be cleverer here, and avoid these expensive copies etc
+            # should run some benchmarks to see if it's worth it
+            if extra_tokens is not None:
+                doc = _stack_batch_encodings(extra_tokens, doc)
+                extra_tokens = None
+
+            for encoded_slice in concatenate_and_group_texts(doc, self.seq_len, self.stride, drop_remainder=False):
+                if len(encoded_slice["input_ids"]) < self.seq_len:
+                    assert extra_tokens is None
+                    extra_tokens = encoded_slice
+                else:
+                    extra_tokens = None
+                    yield encoded_slice["input_ids"]
+
+    def __len__(self):
+        total_tokens = self.doc_cache.total_tokens
+        if self.stride is None:
+            return total_tokens // self.seq_len
+        else:
+            return (total_tokens - self.seq_len) // self.stride + 1
 
     @staticmethod
     def build_or_load(
@@ -111,21 +131,23 @@ class TokenizedDocumentCache(ShardableDataset[BatchEncoding]):
     operation, which makes concatenation much faster (and means we don't need to cache slices).
     """
 
-    def __init__(self, cache_dir, cache_files, flatten_docs):
+    def __init__(self, cache_dir, cache_files, token_counts, flatten_docs):
         self.cache_dir = cache_dir
         self.cache_files = cache_files
         self.flatten_docs = flatten_docs
+        self.token_counts = token_counts
+        self.total_tokens = sum(token_counts)
 
     def __iter__(self):
         for cache_file in self.cache_files:
-            full_path = os.path.join(self.cache_dir, cache_file)
-            for entry in _read_cache_file(full_path, self.flatten_docs):
+            for entry in self._read_cache_file(cache_file):
                 yield entry
 
     @staticmethod
     def load(cache_dir, flatten_docs=True):
         ledger = _load_ledger(cache_dir)
-        return TokenizedDocumentCache(cache_dir, [e["file_name"] for e in ledger["files"]], flatten_docs)
+        token_counts = [entry["num_tokens"] for entry in ledger["files"]]
+        return TokenizedDocumentCache(cache_dir, [e["file_name"] for e in ledger["files"]], token_counts, flatten_docs)
 
     @staticmethod
     def build_or_load(
@@ -147,28 +169,34 @@ class TokenizedDocumentCache(ShardableDataset[BatchEncoding]):
         if num_shards == 1:
             return self
 
-        return TokenizedDocumentCache(self.cache_dir, self.cache_files[shard_index::num_shards], self.flatten_docs)
+        shard_files = self.cache_files[shard_index::num_shards]
+        shard_token_counts = self.token_counts[shard_index::num_shards]
 
+        return TokenizedDocumentCache(self.cache_dir, shard_files, shard_token_counts, self.flatten_docs)
 
-def _read_cache_file(file, flatten: bool = False) -> Iterator[BatchEncoding]:
-    """Reads the cache files produced by cache_and_group and yields tokenized sequences.
-    If flatten is false, this returns the docs as they were presented to the caching process. If flatten is True,
-    then the documents returned are actually concatenated documents, where the number is the number of documents
-    presented as a batch to the caching process."""
-    fs, _, paths = fsspec.get_fs_token_paths(file)
-    for b in pq.read_table(file, filesystem=fs).to_batches():
-        if flatten:
-            # insert a newaxis to the beginning so that it appears to be bs=1
-            yield BatchEncoding(
-                {
-                    b.field(i).name: b.column(i).values.to_numpy(zero_copy_only=True)[np.newaxis, :]
-                    for i in range(b.num_columns)
-                }
-            )
-        else:
-            yield BatchEncoding(
-                {b.field(i).name: b.column(i).to_numpy(zero_copy_only=False) for i in range(b.num_columns)}
-            )
+    def _read_cache_file(self, file) -> Iterator[BatchEncoding]:
+        """Reads the cache files produced by cache_and_group and yields tokenized sequences.
+        If flatten is false, this returns the docs as they were presented to the caching process. If flatten is True,
+        then the documents returned are actually concatenated documents, where the number is the number of documents
+        presented as a batch to the caching process."""
+        for b in self._load_arrow_table(file).to_batches():
+            if self.flatten_docs:
+                # insert a newaxis to the beginning so that it appears to be bs=1
+                yield BatchEncoding(
+                    {
+                        b.field(i).name: b.column(i).values.to_numpy(zero_copy_only=True)[np.newaxis, :]
+                        for i in range(b.num_columns)
+                    }
+                )
+            else:
+                yield BatchEncoding(
+                    {b.field(i).name: b.column(i).to_numpy(zero_copy_only=False) for i in range(b.num_columns)}
+                )
+
+    def _load_arrow_table(self, path):
+        path = os.path.join(self.cache_dir, path)
+        fs, _, paths = fsspec.get_fs_token_paths(path)
+        return pq.read_table(path, filesystem=fs)
 
 
 def _as_record_batch(doc: BatchEncoding) -> pa.RecordBatch:
@@ -338,6 +366,20 @@ def _mask_overlap(labels, target_len, stride, sentinel=-100):
         labels[0 : target_len - stride] = sentinel
 
     return labels
+
+
+def _stack_batch_encodings(a: BatchEncoding, b: BatchEncoding) -> BatchEncoding:
+    """Stacks two batch encodings together, assuming that the keys are the same."""
+
+    def _ensure_batched(x):
+        if len(x) == 0:
+            return list(x)
+        elif isinstance(x[0], Sequence) or isinstance(x[0], np.ndarray):
+            return list(x)
+        else:
+            return [x]
+
+    return BatchEncoding({k: _ensure_batched(a[k]) + _ensure_batched(b[k]) for k in a.keys()})
 
 
 @dataclass

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -138,6 +138,12 @@ class TokenizedDocumentCache(ShardableDataset[BatchEncoding]):
         self.token_counts = token_counts
         self.total_tokens = sum(token_counts)
 
+    def __len__(self):
+        if self.flatten_docs:
+            sum([len(self._load_arrow_table(path).to_batches()) for path in self.cache_files])
+        else:
+            return sum([self._load_arrow_table(path).num_rows for path in self.cache_files])
+
     def __iter__(self):
         for cache_file in self.cache_files:
             for entry in self._read_cache_file(cache_file):

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -37,8 +37,7 @@ overwatch = logging.getLogger("levanter.data.text")
 
 # TASKS:
 # TODO: figure out directory structure for caching multiple sources
-# TODO: if we're super careful we can compute the number of samples (for a given batch size and stride) in advance
-#       if we do that, we can implement a Map-style dataset, which is somewhat preferable when not streaming
+# TODO: consider adding indexing a la Map-style datasets
 # TODO: support seeking/serialization/restore in the dataset
 
 LEDGER_FILE = "ledger.json"

--- a/src/py_utils.py
+++ b/src/py_utils.py
@@ -1,0 +1,4 @@
+def non_caching_cycle(iterable):
+    """Like itertools.cycle, but doesn't cache the iterable."""
+    while True:
+        yield from iterable

--- a/tests/test_shuffle_dataset.py
+++ b/tests/test_shuffle_dataset.py
@@ -16,6 +16,9 @@ class RangeDataset(Dataset[int]):
     def __iter__(self) -> Iterator[int]:
         yield from range(self.start, self.end)
 
+    def __len__(self) -> int:
+        return self.end - self.start
+
 
 def test_shuffle_dataset():
     dataset = RangeDataset(0, 100)


### PR DESCRIPTION
Builds on #64

previously we treated datasets as having unknown length, which was kinda problematic sometimes.

This changes behavior: in training, we have to explicitly loop forever, and we now skip the last little bit of shards that aren't the shortest shard. Previously we would skip the last little bit of every "batch" of docs written to the token cache