### PR TITLE
Scan Module to hide "scan over layers" unpleasantness in gpt2

### DIFF
--- a/src/haliax/jax_utils.py
+++ b/src/haliax/jax_utils.py
@@ -53,6 +53,28 @@ def filter_eval_shape(fun: Callable, *args, **kwargs):
     return eqx.combine(dynamic_out, static_out.value)
 
 
+def filter_checkpoint(fun: Callable, *, prevent_cse: bool = True, policy: Optional[Callable[..., bool]] = None):
+    """As `jax.checkpoint`, but allows any Python object as inputs and outputs"""
+
+    @ft.wraps(fun)
+    def _fn(_static, _dynamic):
+        _args, _kwargs = eqx.combine(_static, _dynamic)
+        _out = fun(*_args, **_kwargs)
+        _dynamic_out, _static_out = eqx.partition(_out, is_jax_array_like)
+        return _dynamic_out, Static(_static_out)
+
+    checkpointed_fun = jax.checkpoint(_fn, prevent_cse=prevent_cse, policy=policy, static_argnums=(0,))
+
+    @ft.wraps(fun)
+    def wrapper(*args, **kwargs):
+        dynamic, static = eqx.partition((args, kwargs), is_jax_array_like)
+        dynamic_out, static_out = checkpointed_fun(static, dynamic)
+
+        return eqx.combine(dynamic_out, static_out.value)
+
+    return wrapper
+
+
 def is_jax_array_like(x):
     return hasattr(x, "shape") and hasattr(x, "dtype")
 

--- a/src/haliax/nn/linear.py
+++ b/src/haliax/nn/linear.py
@@ -30,8 +30,11 @@ class Linear(eqx.Module):
     @jax.named_scope(name="linear")
     def __call__(self, inputs):
         q = inputs.dot(self.In, self.weight)
+        q = hax.auto_sharded(q)
 
         if self.bias is not None:
             q = q + self.bias
+
+        q = hax.auto_sharded(q)
 
         return q

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -24,6 +24,7 @@ class Stacked(eqx.Module, Generic[M]):
 
     stacked: M
     Block: Axis = eqx.static_field()
+    # TODO: support fancier gradient checkpointing
     gradient_checkpointing: bool = eqx.static_field()
 
     def __init__(self, Block: Axis, module: Type[M], *args, gradient_checkpointing: bool = False, **kwargs):

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -26,6 +26,22 @@ class Stacked(eqx.Module, Generic[M]):
     output, while "scan" is the same as a for loop that accumulates a list of intermediates as well as the final output.
 
     Stacked also supports gradient checkpointing, which is useful for very large models that don't fit in memory.
+
+    Example:
+        >>> import equinox as eqx
+        >>> import haliax as hax
+        >>> import haliax.nn as hnn
+        >>> class MyModule(eqx.Module):
+        ...     def __init__(self, num_layers: int, hidden: hax.Axis, *, key):
+        ...         self.axis = Axis("layer", num_layers)
+        ...         self.layers = Stacked(self.axis, hnn.Linear, In=hidden, Out=hidden, key=key)
+        ...
+        ...     def __call__(self, x):
+        ...         return self.layers.fold(x)  # applies each layer in sequence
+        ...
+        >>> Hidden = Axis("hidden", 10)
+        >>> mod = MyModule(5, Hidden)
+        >>> mod(hax.ones(Hidden))
     """
 
     stacked: M

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -1,6 +1,7 @@
 from typing import Generic, Type, TypeVar
 
 import equinox as eqx
+import jax
 
 import haliax
 from haliax import Axis
@@ -23,17 +24,25 @@ class Stacked(eqx.Module, Generic[M]):
 
     stacked: M
     Block: Axis = eqx.static_field()
+    gradient_checkpointing: bool = eqx.static_field()
 
-    def __init__(self, Block: Axis, module: Type[M], *args, **kwargs):
+    def __init__(self, Block: Axis, module: Type[M], *args, gradient_checkpointing: bool = False, **kwargs):
         super().__init__()
         self.Block = Block
         self.stacked = haliax.vmap(module, Block)(*args, **kwargs)
+        self.gradient_checkpointing = gradient_checkpointing
 
-    def scan(self, *args, **kwargs):
-        return haliax.scan(self.stacked, self.Block)(*args, **kwargs)
+    def scan(self, init, *extra_args, **extra_kwargs):
+        return haliax.scan(self._do_block, self.Block)(init, self.stacked, *extra_args, **extra_kwargs)
 
-    def fold(self, *args, **kwargs):
-        return haliax.fold(self.stacked, self.Block)(*args, **kwargs)
+    def fold(self, init, *args, **kwargs):
+        return haliax.fold(self._do_block, self.Block)(init, self.stacked, *args, **kwargs)
+
+    def _do_block(self, carry, block, *extra_args, **extra_kwargs):
+        if self.gradient_checkpointing:
+            return jax.checkpoint(block)(carry, *extra_args, **extra_kwargs)
+        else:
+            return block(carry, *extra_args, **extra_kwargs)
 
     def __call__(self, *args, **kwargs):
         return self.fold(*args, **kwargs)

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -1,0 +1,39 @@
+from typing import Generic, Type, TypeVar
+
+import equinox as eqx
+
+import haliax
+from haliax import Axis
+
+
+M = TypeVar("M", bound=eqx.Module)
+
+
+class Stacked(eqx.Module, Generic[M]):
+    """
+    A "Stacked" wraps another module and produces a "stacked" version of it, where an input is applied
+    to each instance of the stacked module in sequence. This is useful for e.g. transformers
+    where you have multiple instances of the same transformer block and the input is applied in a fold/for loop
+    in sequence.
+
+    It's similar in spirit to an equinox.nn.Sequential, but it must be homogeneous. In Jax, this is much cheaper
+    to compile than a sequential (or moral equivalent), because jax compiles the module's method once, instead of
+    unrolling the sequential and compiling everything as a giant graph.
+    """
+
+    stacked: M
+    Block: Axis = eqx.static_field()
+
+    def __init__(self, Block: Axis, module: Type[M], *args, **kwargs):
+        super().__init__()
+        self.Block = Block
+        self.stacked = haliax.vmap(module, Block)(*args, **kwargs)
+
+    def scan(self, *args, **kwargs):
+        return haliax.scan(self.stacked, self.Block)(*args, **kwargs)
+
+    def fold(self, *args, **kwargs):
+        return haliax.fold(self.stacked, self.Block)(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        return self.fold(*args, **kwargs)

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -18,8 +18,15 @@ class Stacked(eqx.Module, Generic[M]):
     in sequence.
 
     It's similar in spirit to an equinox.nn.Sequential, but it must be homogeneous. In Jax, this is much cheaper
-    to compile than a sequential (or moral equivalent), because jax compiles the module's method once, instead of
-    unrolling the sequential and compiling everything as a giant graph.
+    to compile than a sequential (or moral equivalent), because Jax compiles the module's method once, instead of
+    unrolling the sequential and compiling everything as a giant graph. In Jax, this pattern is often called
+    "scan layers" or "scan over layers".
+
+    Stacked supports both "fold" and "scan" semantics. "fold" is the default, and it's the same as a for loop that
+    accumulates a single output, while "scan" is the same as a for loop that accumulates a list of intermediates
+    as well as the final output.
+
+    Stacked also supports gradient checkpointing, which is useful for very large models that don't fit in memory.
     """
 
     stacked: M

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -17,14 +17,13 @@ class Stacked(eqx.Module, Generic[M]):
     where you have multiple instances of the same transformer block and the input is applied in a fold/for loop
     in sequence.
 
-    It's similar in spirit to an equinox.nn.Sequential, but it must be homogeneous. In Jax, this is much cheaper
-    to compile than a sequential (or moral equivalent), because Jax compiles the module's method once, instead of
-    unrolling the sequential and compiling everything as a giant graph. In Jax, this pattern is often called
-    "scan layers" or "scan over layers".
+    It's similar in spirit to an equinox.nn.Sequential, but it must be homogeneous. In Jax, this is much cheaper to
+    compile than a sequential (or moral equivalent), because Jax compiles the module's method once, instead of unrolling
+    the sequential and compiling everything as a giant graph. In Jax, this pattern is often called "scan layers" or
+    "scan over layers".
 
-    Stacked supports both "fold" and "scan" semantics. "fold" is the default, and it's the same as a for loop that
-    accumulates a single output, while "scan" is the same as a for loop that accumulates a list of intermediates
-    as well as the final output.
+    Stacked supports both "fold" and "scan" semantics. "fold" is the same as a for loop that accumulates a single
+    output, while "scan" is the same as a for loop that accumulates a list of intermediates as well as the final output.
 
     Stacked also supports gradient checkpointing, which is useful for very large models that don't fit in memory.
     """
@@ -58,9 +57,6 @@ class Stacked(eqx.Module, Generic[M]):
     @staticmethod
     def _do_block(carry, block, *extra_args, **extra_kwargs):
         return block(carry, *extra_args, **extra_kwargs)
-
-    def __call__(self, *args, **kwargs):
-        return self.fold(*args, **kwargs)
 
     # TODO: this is for logic that's in levanter. We should move that logic to haliax I guess?
     def _state_dict_key_map(self) -> Optional[Dict[str, Optional[str]]]:

--- a/src/levanter/compat/torch_serialization.py
+++ b/src/levanter/compat/torch_serialization.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, List, Optional, Tuple, TypeVar, cast
 
 import equinox as eqx
 import jax.numpy as jnp
+import numpy
 from jaxtyping import PyTree
-from sympy.physics.continuum_mechanics.beam import numpy
 
 from haliax import NamedArray
 

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -308,7 +308,7 @@ class Gpt2Transformer(StateDictSerializationMixin, eqx.Module):
     @named_call
     def __call__(self, hidden_states: NamedArray, attn_mask: Optional[NamedArray], *, inference, key) -> NamedArray:
         keys = hax.jax_utils.maybe_rng_split(key, self.config.num_layers) if key is not None else None
-        hidden_states = self.blocks(hidden_states, attn_mask, hax.arange(self.Layers), inference=inference, key=keys)
+        hidden_states = self.blocks.fold(hidden_states, attn_mask, hax.arange(self.Layers), inference, key=keys)
         hidden_states = self.ln_f(hidden_states)
 
         return hidden_states

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -326,9 +326,10 @@ class Gpt2Transformer(StateDictSerializationMixin, eqx.Module):
 
         tensors_to_vectorize: Dict[str, List[Optional[Any]]] = {}
         prefix_to_vectorize = cast(str, apply_prefix(prefix, "h"))
-        other_keys_prefix = cast(str, apply_prefix(prefix, ""))
         escaped = re.escape(prefix_to_vectorize)
         pattern = re.compile(rf"{escaped}\.(\d+)\.(.*)")
+
+        other_keys_prefix = cast(str, apply_prefix(prefix, ""))
         for k, v in state_dict.items():
             match = pattern.match(k)
             if match:

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -99,7 +99,6 @@ class Gpt2Mlp(eqx.Module):
 
     @named_call
     def __call__(self, hidden_states: NamedArray):
-        hidden_states = hax.auto_sharded(hidden_states)
         hidden_states = self.c_fc(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.c_proj(hidden_states)
@@ -271,7 +270,6 @@ class Gpt2Block(StateDictSerializationMixin, eqx.Module):
     def __call__(self, hidden_states: NamedArray, mask: Optional[NamedArray], inference, layer_idx, *, key):
         k1, k2, k3 = haliax.jax_utils.maybe_rng_split(key, 3)
 
-        hidden_states = hax.auto_sharded(hidden_states)
         attn_output = self.attn(self.ln_1(hidden_states), mask=mask, inference=inference, layer_idx=layer_idx, key=k1)
         attn_output = self.resid_dropout(attn_output, key=k2, inference=inference)
         hidden_states = hidden_states + attn_output
@@ -312,7 +310,6 @@ class Gpt2Transformer(StateDictSerializationMixin, eqx.Module):
         hidden_states = hax.fold(do_block, self.Layers)(  # type: ignore
             hidden_states, self.blocks, hax.arange(self.Layers), key=keys  # type: ignore
         )
-        hidden_states = hax.auto_sharded(hidden_states)
         hidden_states = self.ln_f(hidden_states)
 
         return hidden_states


### PR DESCRIPTION
Fixes #105.

A "Stacked" wraps another module and produces a "stacked" version of it, where an input is applied to each instance of the stacked module in sequence. This is useful for e.g. transformers where you have multiple instances of the same transformer block and the input is applied in a fold/for loop in sequence.

It's similar in spirit to an equinox.nn.Sequential (or torch.nn.Sequential), but it must be homogeneous. In Jax, this is much cheaper to compile than a sequential (or moral equivalent), because Jax compiles the module's method once, instead of unrolling the sequential and compiling everything as a giant graph. In Jax, this pattern is often called "scan layers" or "scan over layers".
