### PR TITLE
add a version of wandb.log that we can call from within jit

### DIFF
--- a/src/levanter/logging.py
+++ b/src/levanter/logging.py
@@ -91,3 +91,13 @@ def log_time_to_wandb(name: str, *, step=None):
     with capture_time() as fn:
         yield fn
     wandb.log({name: fn()}, step=step)
+
+
+def jittable_wandb_log(data, *, step=None):
+    """uses jax effect callback to log to wandb from the host"""
+    if is_wandb_available():
+        jax.debug.callback(wandb.log, data, step=step)
+
+
+def is_wandb_available():
+    return wandb is not None and wandb.run is not None


### PR DESCRIPTION
Helpful for the hero stuff and possibly helpful for #11 