### PR TITLE
Update configuration for cosine_decay_schedule

### DIFF
--- a/src/levanter/config.py
+++ b/src/levanter/config.py
@@ -423,7 +423,7 @@ class TrainerConfig:
             schedule = optax.constant_schedule(self.learning_rate)
         elif self.lr_schedule == "cosine":
             schedule = optax.cosine_decay_schedule(
-                self.learning_rate, lr_decay_steps - warmup_steps, min_lr / self.learning_rate
+                self.learning_rate, lr_decay_steps, self.min_lr_ratio
             )
         elif self.lr_schedule == "linear":
             schedule = optax.linear_schedule(self.learning_rate, min_lr, lr_decay_steps - warmup_steps)


### PR DESCRIPTION
Minor change to the configuration for `optax.cosine_decay_schedule`:
- decay_steps: the value currently is self.num_train_steps - warmup_steps - warmup_steps. The third term seems redundant. 
- alpha should be just `self.min_lr_ratio` (right now it is `self.learning_rate * self.min_lr_ratio / self.learning_rate`)