### PR TITLE
Fixed auto_sharded outside of pjit

### DIFF
--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -260,7 +260,8 @@ def named_jit(
         my_pjit_args = dict(**pjit_args)
 
         if in_axis_resources is not None or axis_resources is not None:
-            in_axis_resources = in_axis_resources or axis_resources
+            if in_axis_resources is None:
+                in_axis_resources = axis_resources
             in_resources = infer_resource_partitions(
                 (dynamic_donated, dynamic_reserved),
                 in_axis_resources,

--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -388,6 +388,8 @@ def _get_mesh():
 
 
 def _is_jit_tracer(x) -> bool:
+    if isinstance(x, NamedArray):
+        x = x.array
     return isinstance(x, jax.core.Tracer)
 
 

--- a/tests/haliax/test_partitioning.py
+++ b/tests/haliax/test_partitioning.py
@@ -165,3 +165,32 @@ def test_named_jit_works_without_axis_resources():
         r2 = pjit_foo2(hax.ones((Dim1, Dim2)))
 
         assert r2.array.sharding.is_equivalent_to(NamedSharding(mesh, PartitionSpec(None, ResourceAxis.DATA)), ndim=2)
+
+
+@skip_if_not_enough_devices(4)
+def test_shard_with_axis_mapping_inside_pjit():
+    devices = jax.devices()
+    with Mesh(np.array(devices).reshape(-1, 2), (ResourceAxis.DATA, ResourceAxis.MODEL)) as mesh:
+        x = hax.ones((Dim1, Dim2))
+        y = hax.ones((Dim2, Dim3))
+
+        def assert_inside_pjit(arr, expected: NamedSharding):
+            def assert_eq(x, y):
+                assert x == y
+
+            jax.debug.inspect_array_sharding(arr.array, callback=lambda x: assert_eq(x, expected))
+
+        @named_pjit(in_axis_resources={}, out_axis_resources=resource_map)
+        def do_shard(x, y):
+            x = hax.shard_with_axis_mapping(x, resource_map)
+            assert_inside_pjit(x, NamedSharding(mesh, PartitionSpec(None, ResourceAxis.DATA)))
+
+            y = hax.shard_with_axis_mapping(y, resource_map)
+            assert_inside_pjit(y, NamedSharding(mesh, PartitionSpec(ResourceAxis.DATA, ResourceAxis.MODEL)))
+
+            return x, y
+
+        x, y = do_shard(x, y)
+
+        assert x.array.sharding == NamedSharding(mesh, PartitionSpec(None, ResourceAxis.DATA))
+        assert y.array.sharding == NamedSharding(mesh, PartitionSpec(ResourceAxis.DATA, ResourceAxis.MODEL))

--- a/tests/haliax/test_partitioning.py
+++ b/tests/haliax/test_partitioning.py
@@ -168,7 +168,7 @@ def test_named_jit_works_without_axis_resources():
 
 
 @skip_if_not_enough_devices(4)
-def test_shard_with_axis_mapping_inside_pjit():
+def test_shard_with_axis_mapping_inside_jit():
     devices = jax.devices()
     with Mesh(np.array(devices).reshape(-1, 2), (ResourceAxis.DATA, ResourceAxis.MODEL)) as mesh:
         x = hax.ones((Dim1, Dim2))
@@ -180,7 +180,7 @@ def test_shard_with_axis_mapping_inside_pjit():
 
             jax.debug.inspect_array_sharding(arr.array, callback=lambda x: assert_eq(x, expected))
 
-        @named_pjit(in_axis_resources={}, out_axis_resources=resource_map)
+        @named_jit(in_axis_resources={}, out_axis_resources=resource_map)
         def do_shard(x, y):
             x = hax.shard_with_axis_mapping(x, resource_map)
             assert_inside_pjit(x, NamedSharding(mesh, PartitionSpec(None, ResourceAxis.DATA)))


### PR DESCRIPTION
Had a few issues when trying to initialize the mpt model for eval. This doesn't quite fix the issue I was seeing (and I can can just obviate it), but it's still a good bug fix.