### PR TITLE
introduce HFCheckpointConverter to unify hf serialization

### DIFF
--- a/examples/backpack_example.py
+++ b/examples/backpack_example.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from dataclasses import dataclass
 from typing import Optional
 
@@ -209,10 +208,16 @@ def main(config: TrainBackpackConfig):
         checkpointer = config.trainer.checkpointer.create(config.trainer.run_name)
         engine.add_hook(checkpointer.on_step, every=1)  # checkpointer manages its own frequency
         if config.hf_save_path is not None:
-            full_save_path = os.path.join(config.hf_save_path, config.trainer.run_name)
-            from levanter.compat.hf_checkpoints import save_hf_gpt2_checkpoint_callback
+            # full_save_path = os.path.join(config.hf_save_path, config.trainer.run_name)
+            # from levanter.compat.hf_checkpoints import save_hf_checkpoint_callback
+            raise NotImplementedError("HF checkpointing is not yet supported")
 
-            engine.add_hook(save_hf_gpt2_checkpoint_callback(full_save_path), every=config.hf_save_steps)
+            # engine.add_hook(
+            #     save_hf_checkpoint_callback(
+            #         full_save_path,
+            #     ),
+            #     every=config.hf_save_steps,
+            # )
 
         # visualize log probs
         @named_jit(axis_resources=parameter_axis_mapping)

--- a/examples/convert_backpack_to_hf.py
+++ b/examples/convert_backpack_to_hf.py
@@ -4,13 +4,13 @@ from functools import cached_property
 from typing import Optional
 
 import jax
-import jax.numpy as jnp
+from jax.random import PRNGKey
 from transformers import GPT2Tokenizer
 
 import haliax as hax
+import haliax.tree_util as htu
 import levanter
-from haliax import Axis, NamedArray
-from haliax.util import is_named_array
+from haliax import Axis
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
 from levanter.tensorstore_serialization import tree_deserialize_leaves_tensorstore
@@ -66,13 +66,7 @@ def main(config: ConvertConfig):
         with hax.enable_shape_checks(False):
             model = tree_deserialize_leaves_tensorstore(f"{config.checkpoint_path}/model", model)
 
-        def patch_vocab(array):
-            if is_named_array(array):
-                return patch_vocab_size(array.array, array)
-            else:
-                return array
-
-        model = jax.tree_util.tree_map(patch_vocab, model, is_leaf=is_named_array)
+        model = htu.resize_axis(model, Vocab.resize(vocab_size), key=PRNGKey(0))
 
         converter.save_model(
             model,
@@ -81,19 +75,6 @@ def main(config: ConvertConfig):
             upload_to_hf=config.hf_checkpoint or False,
             commit_message="convert to hf checkpoint",
         )
-
-
-def patch_vocab_size(inner: jnp.ndarray, like: NamedArray):
-    # for partitioning reasons we frequently round the vocab size, but we need to patch it back
-    # to the original size for the HF checkpoint to work
-    if any(ax.name == "vocab" for ax in like.axes):
-        index_of_vocab = next(i for i, ax in enumerate(like.axes) if ax.name == "vocab")
-        desired_vocab_size = like.axes[index_of_vocab].size
-        vocab_size = inner.shape[index_of_vocab]
-        if vocab_size != desired_vocab_size:
-            logger.info(f"Patching vocab size from {vocab_size} back to {desired_vocab_size} for HF checkpoint")
-            inner = jnp.take(inner, jnp.arange(desired_vocab_size), axis=index_of_vocab)
-    return inner
 
 
 if __name__ == "__main__":

--- a/examples/convert_backpack_to_hf.py
+++ b/examples/convert_backpack_to_hf.py
@@ -12,7 +12,7 @@ import haliax as hax
 import levanter
 from haliax import Axis, NamedArray
 from haliax.util import is_named_array
-from levanter.compat.hf_checkpoints import HFAutoMapConfig, _save_hf_checkpoint_local
+from levanter.compat.hf_checkpoints import HFAutoMapConfig, _save_backpack_hf_checkpoint_local
 from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
 from levanter.tensorstore_serialization import tree_deserialize_leaves_tensorstore
 from levanter.utils.hf_utils import load_tokenizer
@@ -82,7 +82,7 @@ def main(config: ConvertConfig):
             with commit_and_upload_manager:
                 # commit_and_upload_manager will automatically upload the checkpoint to the hub
                 # it also cd's into the repo, so we can just save the checkpoint to the current directory
-                _save_hf_checkpoint_local(
+                _save_backpack_hf_checkpoint_local(
                     model=model,
                     path=".",
                     model_type=config.model_type,
@@ -91,7 +91,7 @@ def main(config: ConvertConfig):
                 if config.save_tokenizer:
                     tokenizer.save_pretrained(".")
         else:
-            _save_hf_checkpoint_local(
+            _save_backpack_hf_checkpoint_local(
                 model=model,
                 path=config.output_dir,
                 model_type=config.model_type,

--- a/examples/convert_backpack_to_hf.py
+++ b/examples/convert_backpack_to_hf.py
@@ -5,14 +5,13 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
-from huggingface_hub import Repository
 from transformers import GPT2Tokenizer
 
 import haliax as hax
 import levanter
 from haliax import Axis, NamedArray
 from haliax.util import is_named_array
-from levanter.compat.hf_checkpoints import HFAutoMapConfig, _save_backpack_hf_checkpoint_local
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
 from levanter.tensorstore_serialization import tree_deserialize_leaves_tensorstore
 from levanter.utils.hf_utils import load_tokenizer
@@ -25,8 +24,7 @@ logger = logging.getLogger(__name__)
 class ConvertConfig:
     checkpoint_path: str
     output_dir: str
-    hf_checkpoint: Optional[str] = None  # if specified, attempt to upload this checkpoint to the hf hub
-    hf_revision: Optional[str] = None  # if specified, use this branch name when uploading a checkpoint
+    hf_checkpoint: Optional[RepoRef] = None  # if specified, attempt to upload this checkpoint to the hf hub
 
     model: BackpackConfig = BackpackConfig()
 
@@ -36,9 +34,7 @@ class ConvertConfig:
 
     override_vocab_size: Optional[int] = None  # if specified, override the vocab size in the config
 
-    auto_map: Optional[HFAutoMapConfig] = None  # if specified, save to the auto_map config to config.json file
-
-    model_type: Optional[str] = None  # if specified, save the model_type the output config.json file
+    config_overrides: Optional[dict] = None  # if specified, override the config with these values
 
     @cached_property
     def the_tokenizer(self):
@@ -55,6 +51,15 @@ def main(config: ConvertConfig):
     vocab_size = config.override_vocab_size or len(tokenizer)
     Vocab = Axis("vocab", vocab_size)
 
+    converter = HFCheckpointConverter(
+        BackpackConfig,
+        "stanford-crfm/levanter-backpacks-test",
+        trust_remote_code=True,
+    )
+
+    if config.config_overrides:
+        converter = converter.with_config_overrides(config.config_overrides)
+
     with jax.default_device(jax.devices("cpu")[0]):
         model = BackpackLMHeadModel(Vocab, config.model, key=key)
 
@@ -69,31 +74,13 @@ def main(config: ConvertConfig):
 
         model = jax.tree_util.tree_map(patch_vocab, model, is_leaf=is_named_array)
 
-        if config.hf_checkpoint is not None:
-            repo: Repository = Repository(
-                config.output_dir, clone_from=config.hf_checkpoint, use_auth_token=False, skip_lfs_files=True
-            )
-            commit_and_upload_manager = repo.commit("convert to hf checkpoint", branch=config.hf_revision)
-            with commit_and_upload_manager:
-                # commit_and_upload_manager will automatically upload the checkpoint to the hub
-                # it also cd's into the repo, so we can just save the checkpoint to the current directory
-                _save_backpack_hf_checkpoint_local(
-                    model=model,
-                    path=".",
-                    model_type=config.model_type,
-                    auto_map_config=config.auto_map,
-                )
-                if config.save_tokenizer:
-                    tokenizer.save_pretrained(".")
-        else:
-            _save_backpack_hf_checkpoint_local(
-                model=model,
-                path=config.output_dir,
-                model_type=config.model_type,
-                auto_map_config=config.auto_map,
-            )
-            if config.save_tokenizer:
-                tokenizer.save_pretrained(config.output_dir)
+        converter.save_model(
+            model,
+            config.output_dir,
+            save_tokenizer=True,
+            upload_to_hf=config.hf_checkpoint or False,
+            commit_message="convert to hf checkpoint",
+        )
 
 
 def patch_vocab_size(inner: jnp.ndarray, like: NamedArray):

--- a/examples/gpt2_eval.py
+++ b/examples/gpt2_eval.py
@@ -14,7 +14,7 @@ from haliax import Axis
 from haliax.partitioning import named_jit, round_axis_for_partitioning
 from levanter import callbacks
 from levanter.checkpoint import load_checkpoint
-from levanter.compat.hf_checkpoints import HFCheckpointConverter, RemoteRef
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.config import TrainerConfig
 from levanter.data.sharded import LocalBatchDataset
 from levanter.data.text import LMDatasetConfig, TokenSeqDataset
@@ -28,9 +28,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class EvalGpt2Config:
     checkpoint_path: Optional[str] = None
-    hf_checkpoint: Optional[RemoteRef] = None
-    # hf_checkpoint: Optional[str] = None
-    # hf_revision: Optional[str] = None
+    hf_checkpoint: Optional[RepoRef] = None
     trainer: TrainerConfig = TrainerConfig()
     data: LMDatasetConfig = LMDatasetConfig()
     model: Gpt2Config = Gpt2Config()

--- a/examples/gpt2_example.py
+++ b/examples/gpt2_example.py
@@ -15,6 +15,7 @@ import wandb
 from haliax import Axis
 from haliax.partitioning import ResourceAxis, named_jit, round_axis_for_partitioning
 from levanter import callbacks
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.config import OptimizerConfig, TrainerConfig
 from levanter.data.sharded import GlobalBatchDataset, LocalBatchDataset
 from levanter.data.text import LMDatasetConfig, TokenSeqDataset
@@ -189,9 +190,14 @@ def main(config: TrainGpt2Config):
         engine.add_hook(checkpointer.on_step, every=1)  # checkpointer manages its own frequency
         if config.hf_save_path is not None:
             full_save_path = os.path.join(config.hf_save_path, config.trainer.run_name)
-            from levanter.compat.hf_checkpoints import save_hf_gpt2_checkpoint_callback
+            from levanter.compat.hf_checkpoints import save_hf_checkpoint_callback
 
-            engine.add_hook(save_hf_gpt2_checkpoint_callback(full_save_path), every=config.hf_save_steps)
+            converter = HFCheckpointConverter(Gpt2Config, "gpt2")
+
+            engine.add_hook(
+                save_hf_checkpoint_callback(full_save_path, converter),
+                every=config.hf_save_steps,
+            )
 
         # visualize log probs
         @named_jit(axis_resources=parameter_axis_mapping)

--- a/examples/mpt_continued_training.py
+++ b/examples/mpt_continued_training.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from dataclasses import dataclass
 from typing import Optional
 
@@ -197,10 +196,16 @@ def main(config: TrainMptConfig):
         checkpointer = config.trainer.checkpointer.create(config.trainer.run_name)
         engine.add_hook(checkpointer.on_step, every=1)  # checkpointer manages its own frequency
         if config.hf_save_path is not None:
-            full_save_path = os.path.join(config.hf_save_path, config.trainer.run_name)
-            from levanter.compat.hf_checkpoints import save_hf_gpt2_checkpoint_callback
+            # full_save_path = os.path.join(config.hf_save_path, config.trainer.run_name)
+            # from levanter.compat.hf_checkpoints import save_hf_checkpoint_callback
+            raise NotImplementedError("HF checkpointing is not yet supported")
 
-            engine.add_hook(save_hf_gpt2_checkpoint_callback(full_save_path), every=config.hf_save_steps)
+            # engine.add_hook(
+            #     save_hf_checkpoint_callback(
+            #         full_save_path,
+            #     ),
+            #     every=config.hf_save_steps,
+            # )
 
         # visualize log probs
         @named_jit(axis_resources=parameter_axis_mapping)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 [tool.black]
 line-length = 119
 target-version = ["py310"]
-experimental_string_processing = true
+preview = true
 
 [tool.isort]
 profile = "black"

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -134,7 +134,7 @@ _GLOBAL_SAVE_COUNT = 0
 
 
 @dataclass
-class HFCheckpointConverter(abc.ABC, Generic[LevConfig]):
+class HFCheckpointConverter(Generic[LevConfig]):
     LevConfigClass: Type[LevConfig]
     reference_checkpoint: Optional[Union[str, RepoRef]] = None
     "A reference HF Hub checkpoint to extract non-parameter files (like model code an config from)"

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -184,7 +184,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
         self,
         LevConfigClass: Type[LevConfig],
         reference_checkpoint: Optional[Union[RepoRef, str]] = None,
-        HFConfigClass: Optional[Union[str, Type]] = None,
+        HfConfigClass: Optional[Union[str, Type]] = None,
         tokenizer: Optional[Union[str, PreTrainedTokenizer]] = None,
         config_overrides: Optional[dict] = None,
         trust_remote_code: bool = False,
@@ -193,13 +193,13 @@ class HFCheckpointConverter(Generic[LevConfig]):
         # stupid python won't let you have a custom constructor with a frozen dataclass
 
         ref = _coerce_to_rr(reference_checkpoint) if reference_checkpoint is not None else None
-        HFConfigClass = HFCheckpointConverter._infer_config_class(HFConfigClass, ref, trust_remote_code)
+        HfConfigClass = HFCheckpointConverter._infer_config_class(HfConfigClass, ref, trust_remote_code)
         tokenizer = HFCheckpointConverter._infer_tokenizer(tokenizer, ref, trust_remote_code)
 
         self.__default_init__(  # type: ignore
             LevConfigClass=LevConfigClass,
             reference_checkpoint=ref,
-            HfConfigClass=HFConfigClass,
+            HfConfigClass=HfConfigClass,
             tokenizer=tokenizer,
             config_overrides=config_overrides,
             trust_remote_code=trust_remote_code,
@@ -560,7 +560,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
         else:
             # check hub
             try:
-                attributes_path = hf_hub_download(repo_id=repo, path=".gitattributes", revision=revision)
+                attributes_path = hf_hub_download(repo_id=repo, filename=".gitattributes", revision=revision)
             except EntryNotFoundError:
                 attributes_path = None
 
@@ -595,7 +595,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
         if os.path.exists(repo):
             local_code_path = repo
         else:
-            local_code_path = snapshot_download(repo, path, revision=revision, ignore_patterns=ignore_files)
+            local_code_path = snapshot_download(repo, revision=revision, ignore_patterns=ignore_files)
 
         # now we'll save the code
         os.makedirs(path, exist_ok=True)

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -359,6 +359,11 @@ class HFCheckpointConverter(Generic[LevConfig]):
     ):
         logger.info(f"Saving HF-compatible checkpoint to {path}")
         os.makedirs(path, exist_ok=True)
+
+        # save code first because we'll likely be overwriting it
+        if save_reference_code:
+            self._save_code_local(path)
+
         config = model.config.to_hf_config(model.Vocab.size)
         dict_config = config.to_dict()
 
@@ -468,6 +473,72 @@ class HFCheckpointConverter(Generic[LevConfig]):
         finally:
             if tmpdir is not None:
                 shutil.rmtree(tmpdir)
+
+    def _save_code_local(self, path):
+        if self.reference_checkpoint is None:
+            warnings.warn("No reference checkpoint provided, so no code will be saved")
+            return
+
+        repo, revision = self._get_ref(self.reference_checkpoint)
+
+        # first we're going to decide what code to save
+        # as a heuristic, we'll use .gitattributes to decide what to save: anything not in LFS will be saved
+        # need to also save the .gitattributes file itself
+        # TODO: .gitignore too? it's not used a lot with the hub
+        if os.path.exists(repo):
+            # local path
+            if revision is not None:
+                warnings.warn("Ignoring revision because this is a local path. We don't handle this case well yet")
+            attributes_path = os.path.join(repo, ".gitattributes")
+            if not os.path.exists(attributes_path):
+                attributes_path = None
+        else:
+            # check hub
+            try:
+                attributes_path = hf_hub_download(repo_id=repo, path=".gitattributes", revision=revision)
+            except EntryNotFoundError:
+                attributes_path = None
+
+        if attributes_path is None:
+            warnings.warn("HF Export - No .gitattributes file found, using a heuristic to decide what to save")
+            ignore_files = [
+                ".git",
+                "*.bin.*",
+                "*.lfs.*",
+                "*.bin",
+                "*.h5",
+                "*.tflite",
+                "*.tar.gz",
+                "*.ot",
+                "*.onnx",
+                "*.msgpack",
+                "model.safetensors",
+            ]
+        else:
+            # read the attributes file and get the globs
+            with open(attributes_path) as f:
+                attributes = f.read()
+            ignore_files = [".git"]
+            for line in attributes.split("\n"):
+                line = line.strip()
+                if line.startswith("#") or line == "":
+                    continue
+                # NB: this is not a full implementation of .gitattributes, but it's good enough for our purposes
+                if "filter=lfs" in line:
+                    ignore_files.append(line.split()[0])
+
+        if os.path.exists(repo):
+            local_code_path = repo
+        else:
+            local_code_path = snapshot_download(repo, path, revision=revision, ignore_patterns=ignore_files)
+
+        # now we'll save the code
+        os.makedirs(path, exist_ok=True)
+
+        shutil_ignore = shutil.ignore_patterns(*ignore_files)
+        shutil.copytree(local_code_path, path, ignore=shutil_ignore, dirs_exist_ok=True)
+
+        logger.debug(f"Saved code to {path}")
 
 
 def _save_backpack_hf_checkpoint_local(

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -62,6 +62,17 @@ class RemoteRef:
         return f"RemoteRev({self.model_name_or_path!r}, {self.revision!r})"
 
 
+class ConfigWithHFSer(abc.ABC):
+    @abc.abstractmethod
+    def to_hf_config(self) -> HfConfig:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def from_hf_config(cls, hf_config: HfConfig):
+        pass
+
+
 def _coerce_to_rr(s: Union[str, RemoteRef]) -> RemoteRef:
     if isinstance(s, RemoteRef):
         return s
@@ -88,7 +99,7 @@ class HFAutoMapConfig:
         return {k: v for k, v in self.__dict__.items() if v is not None}
 
 
-LevConfig = TypeVar("LevConfig")
+LevConfig = TypeVar("LevConfig", bound=ConfigWithHFSer)
 
 
 @dataclass
@@ -154,7 +165,7 @@ class HFCheckpointConverter(abc.ABC, Generic[LevConfig]):
         return tokenizer
 
     def config_from_hf_config(self, hf_config) -> LevConfig:
-        return self.LevConfigClass.from_hf_config(hf_config)  # type: ignore
+        return self.LevConfigClass.from_hf_config(hf_config)
 
     def config_from_hf_checkpoint(self, ref: Optional[Union[str, RemoteRef]] = None) -> LevConfig:
         config = self.hf_config_from_hf_checkpoint(ref)

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -145,6 +145,18 @@ KEYS_TO_COPY_FROM_BASE_CONFIG = {
 
 @dataclass
 class HFCheckpointConverter(Generic[LevConfig]):
+    """
+    A class to convert between Levanter and HF models. This class establishes a bidirectional mapping
+    between Levanter and HF models, and provides methods to convert between them.
+
+    This mapping supports:
+    * translating between Levanter and HF configs
+    * loading a Levanter model from an HF checkpoint
+    * saving a HF checkpoint from a Levanter model
+
+    HF checkpoints can be saved with params and config, and optionally with the tokenizer and code.
+    """
+
     LevConfigClass: Type[LevConfig]
     reference_checkpoint: Optional[RepoRef]
     "A reference HF Hub checkpoint to extract non-parameter files (like model code an config from)"

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -148,7 +148,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
     "If True, will trust the remote code and not download it locally."
 
     ignore_prefix: Optional[str] = None
-    """A prefix to optionally ignore when loading checkpoints. Typically this is 'transformer' to deal with the
+    """A prefix to optionally ignore when loading checkpoints. For "gpt2" this is 'transformer' to deal with the
     fact that some models are saved as XXXPreTrainedModel and others are saved as XXXLMHeadModel"""
 
     def __post_init__(self):
@@ -380,8 +380,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
             if jax.process_index() == 0:
                 if tmpdir is not None:  # we're uploading to GCS or similar
                     logger.info(f"Copying HF-compatible checkpoint to {path}")
-                    fs: AbstractFileSystem
-                    fs = fsspec.core.get_fs_token_paths(path, mode="wb")[0]
+                    fs: AbstractFileSystem = fsspec.core.get_fs_token_paths(path, mode="wb")[0]
                     fs.put(os.path.join(local_path, "*"), path, recursive=True)
                     logger.info(f"Finished copying HF-compatible checkpoint to {path}")
 

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -370,6 +370,14 @@ class HFCheckpointConverter(Generic[LevConfig]):
     def save_model_local(
         self, model: LmWithHFSer, path: str, save_tokenizer: bool = True, save_reference_code: bool = True
     ):
+        """
+        Saves a HF-compatible checkpoint to a local path.
+        :param model:
+        :param path:
+        :param save_tokenizer: Save the tokenizer to the checkpoint
+        :param save_reference_code: Save any code from the reference checkpoint
+        :return:
+        """
         logger.info(f"Saving HF-compatible checkpoint to {path}")
         os.makedirs(path, exist_ok=True)
 
@@ -432,6 +440,8 @@ class HFCheckpointConverter(Generic[LevConfig]):
         **hf_upload_kwargs,
     ):
         """
+        Saves a Levanter model to a huggingface checkpoint.
+
         If hf_repo is provided, this will upload the checkpoint to the huggingface hub, passing
         any additional kwargs to the huggingface_hub.upload_folder function.
 

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import urllib.parse
+import warnings
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Generic, Optional, Tuple, Type, TypeVar, Union, cast
@@ -18,7 +19,7 @@ import pyrallis
 import safetensors
 import safetensors.numpy
 from fsspec import AbstractFileSystem
-from huggingface_hub import hf_hub_download
+from huggingface_hub import hf_hub_download, snapshot_download
 from huggingface_hub.utils import EntryNotFoundError
 from jax.experimental import multihost_utils
 from jax.experimental.multihost_utils import sync_global_devices

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -259,13 +259,20 @@ class HFCheckpointConverter(abc.ABC, Generic[LevConfig]):
         self,
         lm_model_cls: Type[LmWithHFSer],
         ref: Optional[Union[str, RemoteRef]] = None,
-        Vocab: Optional[Axis] = None,
         axis_mapping: Optional[ResourceMapping] = None,
     ) -> LmWithHFSer:
+        """
+        Loads a levanter model from a huggingface checkpoint.
+
+        Args:
+            lm_model_cls: The model class to load
+            ref: The reference to load from. If None, will use the reference_checkpoint
+            axis_mapping: The axis mapping to use for sharding. If None, will use the default axis mapping
+        """
         state_dict = self.load_state_dict(ref)
         config = self.config_from_hf_checkpoint(ref)
 
-        Vocab = Vocab or self.default_Vocab
+        Vocab = self.default_Vocab
 
         ignore_prefix: Optional[str] = None
         if self.ignore_prefix:

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -71,6 +71,26 @@ class ConfigWithHFSer(abc.ABC):
         pass
 
 
+MConfig = TypeVar("MConfig", bound=ConfigWithHFSer)
+
+
+class LmWithHFSer(abc.ABC, Generic[MConfig]):
+    config: MConfig
+
+    def get_hf_config(self):
+        return self.config.to_hf_config(self.Vocab.size)
+
+    @property
+    @abc.abstractmethod
+    def Vocab(self) -> Axis:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def init(cls, Vocab: Axis, config: MConfig, *, key: PRNGKey) -> "LmWithHFSer":
+        pass
+
+
 def _coerce_to_rr(s: Union[str, RemoteRef]) -> RemoteRef:
     if isinstance(s, RemoteRef):
         return s

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -76,7 +76,7 @@ pyrallis.decode.register(RepoRef, RepoRef.from_string)
 pyrallis.encode.register(RepoRef, str)
 
 
-class ConfigWithHFSer(abc.ABC):
+class HFCompatConfig(abc.ABC):
     @abc.abstractmethod
     def to_hf_config(self, vocab_size: int, config_overrides: Optional[dict] = None) -> HfConfig:
         pass
@@ -87,7 +87,7 @@ class ConfigWithHFSer(abc.ABC):
         pass
 
 
-MConfig = TypeVar("MConfig", bound=ConfigWithHFSer)
+MConfig = TypeVar("MConfig", bound=HFCompatConfig)
 
 
 class LmWithHFSer(abc.ABC, Generic[MConfig], StateDictSerializationMixin):
@@ -133,7 +133,7 @@ class HFAutoMapConfig:
         return {k: v for k, v in self.__dict__.items() if v is not None}
 
 
-LevConfig = TypeVar("LevConfig", bound=ConfigWithHFSer)
+LevConfig = TypeVar("LevConfig", bound=HFCompatConfig)
 
 # just for generating unique ids
 _GLOBAL_SAVE_COUNT = 0

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -24,7 +24,6 @@ from jax.experimental import multihost_utils
 from jax.experimental.multihost_utils import sync_global_devices
 from jax.random import PRNGKey
 from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer
-from transformers import GPT2Config as HfGpt2Config
 from transformers import PretrainedConfig as HfConfig
 from transformers import PreTrainedTokenizer
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
@@ -401,46 +400,6 @@ class HFCheckpointConverter(Generic[LevConfig]):
                 shutil.rmtree(tmpdir)
 
 
-def load_hf_model_checkpoint(location_or_id, device=None, revision=None):
-    """
-    Loads a safetensors or PyTorch model checkpoint.
-    If model_file is None, this function attempts to load via safetensors first, then PyTorch.
-    """
-    local = os.path.exists(f"{location_or_id}/config.json")
-    if local:
-        config = json.load(open(f"{location_or_id}/config.json"))
-    else:
-        config_path = hf_hub_download(location_or_id, "config.json", revision=revision)
-        config = json.load(open(config_path))
-
-    if local:
-        if os.path.exists(f"{location_or_id}/{SAFE_TENSORS_MODEL}"):
-            checkpoint = safetensors.numpy.load_file(f"{location_or_id}/{SAFE_TENSORS_MODEL}")
-        elif os.path.exists(f"{location_or_id}/{PYTORCH_MODEL}"):
-            import torch
-
-            if isinstance(device, str):
-                device = torch.device(device)
-            checkpoint = torch.load(f"{location_or_id}/{PYTORCH_MODEL}", map_location=device)
-            checkpoint = {k: v.cpu().numpy() for k, v in checkpoint.items()}
-        else:
-            raise ValueError(f"Could not find model file for {location_or_id}")
-    else:
-        try:
-            model_path = hf_hub_download(location_or_id, SAFE_TENSORS_MODEL, revision=revision)
-            checkpoint = safetensors.numpy.load_file(model_path)
-        except EntryNotFoundError:  # noqa: E722
-            model_path = hf_hub_download(location_or_id, PYTORCH_MODEL, revision=revision)
-            import torch
-
-            if isinstance(device, str):
-                device = torch.device(device)
-            checkpoint = torch.load(model_path, map_location=device)
-            checkpoint = {k: v.cpu().numpy() for k, v in checkpoint.items()}
-
-    return config, checkpoint
-
-
 def backpack_config_to_hf(vocab_size: int, config, auto_map_config: Optional[HFAutoMapConfig] = None) -> HfConfig:
     config = HfConfig(
         vocab_size=vocab_size,
@@ -483,64 +442,6 @@ def hf_backpack_config_to_levanter(config: HfConfig):
     )
 
 
-def load_hf_gpt2_checkpoint(location_or_id, device=None, revision=None):
-    config, checkpoint = load_hf_model_checkpoint(location_or_id, device=device, revision=revision)
-
-    config = HfGpt2Config.from_dict(config)
-
-    Vocab = Axis("vocab", config.vocab_size)
-    from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
-
-    lev_config = Gpt2Config.from_hf_config(config)
-    key = PRNGKey(0)
-
-    model = Gpt2LMHeadModel.init(Vocab, lev_config, key=key)
-
-    has_transformer_prefix = False
-    for k in checkpoint.keys():
-        if k.startswith("transformer."):
-            has_transformer_prefix = True
-            break
-        elif k.startswith(".h"):
-            break
-
-    if has_transformer_prefix:
-        model = model.from_state_dict(checkpoint, prefix="transformer")
-    else:
-        model = model.from_state_dict(checkpoint)
-
-    return model
-
-
-def _save_hf_gpt2_checkpoint_local(model, path):
-    os.makedirs(path, exist_ok=True)
-    config = model.config.to_hf_config(model.vocab_size)
-    with open(f"{path}/config.json", "w") as f:
-        json.dump(config.to_dict(), f)
-
-    def get_to_cpu(arr: Union[jnp.ndarray, np.ndarray]):
-        if isinstance(arr, np.ndarray):
-            return arr
-        elif "cpu" in arr.device().device_kind:
-            return np.array(arr)
-        elif arr.is_fully_addressable:
-            r = np.array(arr)
-            return r
-        else:
-            return np.array(jax.device_get(multihost_utils.process_allgather(arr, tiled=True)))
-
-    # need to make sure the model is on *this machine* and *this machine's CPU* before saving
-    model = jax.tree_map(lambda arr: get_to_cpu(arr), model)
-
-    # TODO: it's be nice if safetensors supported an iterator or something so we could do the allgather one at a time
-    state_dict = model.to_state_dict()
-
-    # now that we've moved the model to the CPU, we don't need to do this on all processes
-    if jax.process_index() == 0:
-        # the "pt" is a lie but it doesn't seem to actually matter and HF demands it
-        safetensors.numpy.save_file(state_dict, f"{path}/{SAFE_TENSORS_MODEL}", metadata={"format": "pt"})
-
-
 def _save_backpack_hf_checkpoint_local(
     model,
     path: str,
@@ -577,53 +478,6 @@ def _save_backpack_hf_checkpoint_local(
 
 def _is_url_like(path):
     return urllib.parse.urlparse(path).scheme != ""
-
-
-def save_hf_gpt2_checkpoint(model, path, hf_repo: Optional[str] = None, **hf_upload_kwargs):
-    """
-    If hf_repo is provided, this will upload the checkpoint to the huggingface hub, passing
-    any additional kwargs to the huggingface_hub.upload_folder function.
-
-    :param path: the path to save the checkpoint to. path may be a GCS bucket path, in which case the checkpoint will be
-    uploaded to GCS after being written to a tmp
-    :param model: the model to save
-    :param hf_repo:
-    :param hf_upload_kwargs: any additional kwargs to pass to huggingface_hub.upload_folder
-    :return:
-    """
-    tmpdir: Optional[str] = None
-    if _is_url_like(path):
-        tmpdir = tempfile.mkdtemp()
-        local_path = tmpdir
-    else:
-        local_path = path
-
-    try:
-        logger.info(f"Saving HF-compatible checkpoint to {local_path}")
-        from levanter.models.gpt2 import Gpt2LMHeadModel
-
-        _save_hf_gpt2_checkpoint_local(cast(Gpt2LMHeadModel, model), local_path)
-        logger.debug(f"Finished saving HF-compatible checkpoint to {local_path}")
-
-        sync_global_devices(path)
-
-        if jax.process_index() == 0:
-            if tmpdir is not None:  # we're uploading to GCS or similar
-                logger.info(f"Copying HF-compatible checkpoint to {path}")
-                fs: AbstractFileSystem
-                fs = fsspec.core.get_fs_token_paths(path, mode="wb")[0]
-                fs.put(os.path.join(local_path, "*"), path, recursive=True)
-                logger.debug(f"Finished copying HF-compatible checkpoint to {path}")
-
-            if hf_repo is not None:
-                logger.info(f"Uploading HF-compatible checkpoint to {hf_repo}")
-                huggingface_hub.upload_folder(local_path, hf_repo, **hf_upload_kwargs)
-                logger.debug(f"Finished uploading HF-compatible checkpoint to {hf_repo}")
-
-        sync_global_devices(path + " done")
-    finally:
-        if tmpdir is not None:
-            shutil.rmtree(tmpdir)
 
 
 def save_hf_checkpoint_callback(

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -46,12 +46,18 @@ SAFE_TENSORS_MODEL = "model.safetensors"
 
 @dataclass
 class RepoRef:
+    """Represents a reference to a model (or similar) in a remote repository or local file system, and
+    optionally a revision. This lets you load particular revisions or branches of a model.
+
+    The string syntax is <model_name_or_path>@<revision>.
+
+    """
+
     model_name_or_path: str
     revision: Optional[str] = None
 
     @staticmethod
     def from_string(s: str) -> "RepoRef":
-        """syntax is <model_name_or_path>@<revision>"""
         if "@" not in s:
             return RepoRef(s)
         model_name_or_path, revision = s.split("@")

--- a/src/levanter/models/backpack.py
+++ b/src/levanter/models/backpack.py
@@ -6,6 +6,8 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
+from transformers import PretrainedConfig
+from transformers import PretrainedConfig as HfConfig
 
 import haliax as hax
 import haliax.jax_utils
@@ -36,6 +38,45 @@ class BackpackConfig(Gpt2Config):
     SenseIntermediate = property(
         lambda self: Axis(name="concat_senses", size=self.sense_intermediate_scale * self.hidden_dim)
     )
+
+    def to_hf_config(self, vocab_size, config_overrides=None):
+        if config_overrides is None:
+            config_overrides = {}
+
+        return PretrainedConfig(
+            vocab_size=vocab_size,
+            n_positions=self.seq_len,
+            n_layer=self.num_layers,
+            n_head=self.num_heads,
+            n_embd=self.hidden_dim,
+            initializer_range=self.initializer_range,
+            attn_pdrop=self.attn_pdrop,
+            embd_pdrop=self.embed_pdrop,
+            layer_norm_epsilon=self.layer_norm_epsilon,
+            activation_function=self.activation_function,
+            scale_attn_by_inverse_layer_idx=self.scale_attn_by_inverse_layer_idx,
+            reorder_and_upcast_attn=self.upcast_attn,
+            num_senses=self.num_senses,
+            sense_intermediate_scale=self.sense_intermediate_scale,
+        )
+
+    @classmethod
+    def from_hf_config(cls, hf_config: HfConfig):
+        return cls(
+            seq_len=hf_config.n_positions,
+            num_layers=hf_config.n_layer,
+            num_heads=hf_config.n_head,
+            hidden_dim=hf_config.n_embd,
+            initializer_range=hf_config.initializer_range,
+            attn_pdrop=hf_config.attn_pdrop,
+            embed_pdrop=hf_config.embd_pdrop,
+            layer_norm_epsilon=hf_config.layer_norm_epsilon,
+            activation_function=hf_config.activation_function,
+            scale_attn_by_inverse_layer_idx=hf_config.scale_attn_by_inverse_layer_idx,
+            upcast_attn=hf_config.reorder_and_upcast_attn,
+            num_senses=hf_config.num_senses,
+            sense_intermediate_scale=hf_config.sense_intermediate_scale,
+        )
 
 
 class BackpackMlp(StateDictSerializationMixin, Gpt2Mlp):

--- a/src/levanter/models/backpack.py
+++ b/src/levanter/models/backpack.py
@@ -365,3 +365,15 @@ class BackpackLMHeadModel(StateDictSerializationMixin, eqx.Module):
             "sense_net": "backpack.sense_network",
             "kq_selfattention": "backpack.sense_weight_net",
         }
+
+    def update_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> StateDict:
+        state_dict = super().update_state_dict(state_dict, prefix=prefix)
+        # In levanter's implementation, we have a shared embedding matrix for both the word
+        # embeddings and the sense embeddings
+        state_dict[apply_prefix(prefix, "word_embeddings.weight")] = state_dict[
+            apply_prefix(prefix, "backpack.gpt2_model.wte.weight")
+        ]
+        state_dict[apply_prefix(prefix, "position_embeddings.weight")] = state_dict[
+            apply_prefix(prefix, "backpack.gpt2_model.wpe.weight")
+        ]
+        return state_dict

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -329,7 +329,7 @@ class Gpt2Embeddings(StateDictSerializationMixin, eqx.Module):
         return {"token_embeddings": "wte.weight", "position_embeddings": "wpe.weight"}
 
 
-class Gpt2LMHeadModel(eqx.Module, StateDictSerializationMixin, LmWithHFSer[Gpt2Config]):
+class Gpt2LMHeadModel(eqx.Module, LmWithHFSer[Gpt2Config]):
     transformer: Gpt2Transformer
     embeddings: Gpt2Embeddings
 

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -15,7 +15,7 @@ import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import named_call, shaped_rng_split
 from haliax.nn.scan import Stacked
-from levanter.compat.hf_checkpoints import ConfigWithHFSer, LmWithHFSer
+from levanter.compat.hf_checkpoints import HFCompatConfig, LmWithHFSer
 from levanter.compat.torch_serialization import (
     StateDict,
     StateDictSerializationMixin,
@@ -27,7 +27,7 @@ from levanter.compat.torch_serialization import (
 
 
 @dataclass(frozen=True)
-class Gpt2Config(ConfigWithHFSer):
+class Gpt2Config(HFCompatConfig):
     seq_len: int = 512
     hidden_dim: int = 768
     num_layers: int = 12

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -15,7 +15,7 @@ import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import named_call, shaped_rng_split
 from haliax.nn.scan import Stacked
-from levanter.compat.hf_checkpoints import HFCompatConfig, LmWithHFSer
+from levanter.compat.hf_checkpoints import HFCompatConfig, LmWithHfSerializationMixin
 from levanter.compat.torch_serialization import (
     StateDict,
     StateDictSerializationMixin,
@@ -329,7 +329,7 @@ class Gpt2Embeddings(StateDictSerializationMixin, eqx.Module):
         return {"token_embeddings": "wte.weight", "position_embeddings": "wpe.weight"}
 
 
-class Gpt2LMHeadModel(eqx.Module, LmWithHFSer[Gpt2Config]):
+class Gpt2LMHeadModel(eqx.Module, LmWithHfSerializationMixin[Gpt2Config]):
     transformer: Gpt2Transformer
     embeddings: Gpt2Embeddings
 

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -6,6 +6,8 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
+from transformers import GPT2Config as HfGpt2Config
+from transformers import PretrainedConfig as HfConfig
 
 import haliax as hax
 import haliax.jax_utils
@@ -13,6 +15,7 @@ import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import named_call, shaped_rng_split
 from haliax.nn.scan import Stacked
+from levanter.compat.hf_checkpoints import ConfigWithHFSer
 from levanter.compat.torch_serialization import (
     StateDict,
     StateDictSerializationMixin,
@@ -24,7 +27,7 @@ from levanter.compat.torch_serialization import (
 
 
 @dataclass(frozen=True)
-class Gpt2Config:
+class Gpt2Config(ConfigWithHFSer):
     seq_len: int = 512
     hidden_dim: int = 768
     num_layers: int = 12
@@ -58,6 +61,43 @@ class Gpt2Config:
     Layers = property(lambda self: Axis(name="layers", size=self.num_layers))
     Mlp = property(lambda self: Axis(name="mlp", size=self.hidden_dim * self.mlp_scale))
     HeadSize = property(lambda self: Axis(name="head_size", size=self.hidden_dim // self.num_heads))
+
+    def to_hf_config(self, vocab_size, config_overrides=None) -> HfGpt2Config:
+        if config_overrides is None:
+            config_overrides = {}
+
+        return HfGpt2Config(
+            vocab_size=vocab_size,
+            n_positions=self.seq_len,
+            n_layer=self.num_layers,
+            n_head=self.num_heads,
+            n_embd=self.hidden_dim,
+            initializer_range=self.initializer_range,
+            attn_pdrop=self.attn_pdrop,
+            embd_pdrop=self.embed_pdrop,
+            layer_norm_epsilon=self.layer_norm_epsilon,
+            activation_function=self.activation_function,
+            scale_attn_by_inverse_layer_idx=self.scale_attn_by_inverse_layer_idx,
+            reorder_and_upcast_attn=self.upcast_attn,
+            **config_overrides,
+        )
+
+    @classmethod
+    def from_hf_config(cls, hf_config: HfConfig):
+        return Gpt2Config(
+            seq_len=hf_config.n_positions,
+            # vocab_size=config.vocab_size,
+            num_layers=hf_config.n_layer,
+            num_heads=hf_config.n_head,
+            hidden_dim=hf_config.n_embd,
+            initializer_range=hf_config.initializer_range,
+            attn_pdrop=hf_config.attn_pdrop,
+            embed_pdrop=hf_config.embd_pdrop,
+            layer_norm_epsilon=hf_config.layer_norm_epsilon,
+            activation_function=hf_config.activation_function,
+            scale_attn_by_inverse_layer_idx=hf_config.scale_attn_by_inverse_layer_idx,
+            upcast_attn=hf_config.reorder_and_upcast_attn,
+        )
 
 
 class Gpt2Mlp(eqx.Module):

--- a/src/levanter/models/mpt.py
+++ b/src/levanter/models/mpt.py
@@ -17,6 +17,7 @@ import haliax.nn as hnn
 from haliax import Axis, NamedArray
 from haliax.jax_utils import filter_eval_shape, named_call, shaped_rng_split
 from haliax.nn.scan import Stacked
+from levanter.compat.hf_checkpoints import HFCompatConfig
 from levanter.compat.torch_serialization import (
     StateDict,
     StateDictSerializationMixin,
@@ -82,7 +83,7 @@ class MptAttentionConfig:
 
 # Haliax-style data class version
 @dataclass
-class MptConfig:
+class MptConfig(HFCompatConfig):
     d_model: int = 768
     n_heads: int = 12
     n_layers: int = 12
@@ -130,8 +131,8 @@ class MptConfig:
         if self.init_config and self.init_config != init_config_defaults:
             raise ValueError("init_config_defaults not supported yet.")
 
-    @staticmethod
-    def from_hf_config(config):
+    @classmethod
+    def from_hf_config(cls, config):
         return MptConfig(
             d_model=config.d_model,
             n_heads=config.n_heads,
@@ -148,9 +149,12 @@ class MptConfig:
             init_config=config.init_config,
         )
 
-    def to_hf_config(self, vocab_size):
+    def to_hf_config(self, vocab_size, config_overrides=None):
         if LazyHfMPTConfig is None:
             _load_hf_mpt_config()
+
+        if config_overrides is None:
+            config_overrides = {}
 
         return LazyHfMPTConfig(
             d_model=self.d_model,
@@ -167,6 +171,7 @@ class MptConfig:
             logit_scale=self.logit_scale,
             init_config=self.init_config,
             vocab_size=vocab_size,
+            **config_overrides,
         )
 
 

--- a/src/levanter/utils/py_utils.py
+++ b/src/levanter/utils/py_utils.py
@@ -1,4 +1,36 @@
+from dataclasses import dataclass
+
+
 def non_caching_cycle(iterable):
     """Like itertools.cycle, but doesn't cache the iterable."""
     while True:
         yield from iterable
+
+
+# https://stackoverflow.com/a/58336722/1736826 CC-BY-SA 4.0
+def dataclass_with_default_init(_cls=None, *args, **kwargs):
+    def wrap(cls):
+        # Save the current __init__ and remove it so dataclass will
+        # create the default __init__.
+        user_init = getattr(cls, "__init__")
+        delattr(cls, "__init__")
+
+        # let dataclass process our class.
+        result = dataclass(cls, *args, **kwargs)
+
+        # Restore the user's __init__ save the default init to __default_init__.
+        setattr(result, "__default_init__", result.__init__)
+        setattr(result, "__init__", user_init)
+
+        # Just in case that dataclass will return a new instance,
+        # (currently, does not happen), restore cls's __init__.
+        if result is not cls:
+            setattr(cls, "__init__", user_init)
+
+        return result
+
+    # Support both dataclass_with_default_init() and dataclass_with_default_init
+    if _cls is None:
+        return wrap
+    else:
+        return wrap(_cls)

--- a/tests/test_backpack.py
+++ b/tests/test_backpack.py
@@ -11,7 +11,7 @@ import haliax
 import haliax as hax
 from haliax import Axis
 from haliax.partitioning import round_axis_for_partitioning
-from levanter.compat.hf_checkpoints import HFCheckpointConverter, backpack_config_to_hf, hf_backpack_config_to_levanter
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, hf_backpack_config_to_levanter
 from levanter.config import TrainerConfig
 from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
 
@@ -87,7 +87,7 @@ def test_backpack_nano_compare():
         model.save_pretrained(tmpdir)
         loaded_checkpoint = converter.load_state_dict(tmpdir)
 
-    roundtrip_hf_config = backpack_config_to_hf(vocab_size, lev_config)
+    roundtrip_hf_config = converter.hf_config_from_config(lev_config)
 
     for k, v in roundtrip_hf_config.__dict__.items():
         assert getattr(roundtrip_hf_config, k) == v, f"{k} {getattr(roundtrip_hf_config, k)} != {v}"

--- a/tests/test_backpack.py
+++ b/tests/test_backpack.py
@@ -113,7 +113,8 @@ def test_backpack_nano_compare():
     model = cls(config)
     lev_model["backpack.word_embeddings.weight"] = lev_model["backpack.gpt2_model.wte.weight"]
     lev_model["backpack.position_embeddings.weight"] = lev_model["backpack.gpt2_model.wpe.weight"]
-    model.load_state_dict(lev_model)
+    # TODO: switch to HF serialization in this test
+    model.load_state_dict(lev_model, strict=False)
 
     model.eval()
     with torch.no_grad():

--- a/tests/test_backpack.py
+++ b/tests/test_backpack.py
@@ -57,7 +57,7 @@ def test_backpack_nano_compare():
 
     # a bit hacky, using some internal-y APIs of transformers
     cls = converter.HFAutoModelClass()
-    config = converter.HFConfigClass(
+    config = converter.HfConfigClass(
         n_embd=32,
         n_positions=512,
         n_head=8,

--- a/tests/test_backpack.py
+++ b/tests/test_backpack.py
@@ -11,7 +11,7 @@ import haliax
 import haliax as hax
 from haliax import Axis
 from haliax.partitioning import round_axis_for_partitioning
-from levanter.compat.hf_checkpoints import HFCheckpointConverter, hf_backpack_config_to_levanter
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.config import TrainerConfig
 from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
 
@@ -80,10 +80,8 @@ def test_backpack_nano_compare():
         torch_out = torch_out.logits[0].detach().cpu().numpy()
 
     # now compare levanter
-    lev_config = hf_backpack_config_to_levanter(config)
-    # model_dict = model.state_dict()
-
     with tempfile.TemporaryDirectory() as tmpdir:
+        lev_config = converter.config_from_hf_config(config)
         model.save_pretrained(tmpdir)
         loaded_checkpoint = converter.load_state_dict(tmpdir)
 

--- a/tests/test_hf_checkpoints.py
+++ b/tests/test_hf_checkpoints.py
@@ -2,6 +2,7 @@ import tempfile
 
 import numpy as np
 import numpy.testing
+import torch
 from jax.random import PRNGKey
 
 import haliax
@@ -52,3 +53,10 @@ def test_save_model_with_code():
 
         input = haliax.random.randint(PRNGKey(0), lev_model.config.Pos, 0, lev_model.Vocab.size)
         np.testing.assert_equal(np.array(lev_model(input).array), np.array(loaded_model(input).array))
+
+        # now double check that the pytorch model is the same
+        loaded_model = cls.from_pretrained(tmpdir)
+        torch_input = torch.from_numpy(np.array(input.array)).to(torch.int64).unsqueeze(0)
+        np.testing.assert_allclose(
+            model(torch_input).logits[0].detach().numpy(), loaded_model(torch_input).logits[0].detach().numpy()
+        )

--- a/tests/test_hf_checkpoints.py
+++ b/tests/test_hf_checkpoints.py
@@ -1,0 +1,54 @@
+import tempfile
+
+import numpy as np
+import numpy.testing
+from jax.random import PRNGKey
+
+import haliax
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.models.mpt import MptConfig, MptLmHeadModel
+
+
+def test_save_model_with_code():
+    converter = HFCheckpointConverter(MptConfig, "mosaicml/mpt-7b", trust_remote_code=True)
+    tokenizer = converter.tokenizer
+    cls = converter.HFAutoModelClass()
+    config = converter.HFConfigClass(
+        d_model=32,
+        max_seq_len=512,
+        n_heads=8,
+        n_layers=2,
+        attn_config={"attn_impl": "torch", "alibi": True},
+        vocab_size=len(tokenizer),
+        no_bias=True,
+    )
+
+    model = cls(config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lev_config = converter.config_from_hf_config(config)
+        model.save_pretrained(tmpdir)
+        loaded_checkpoint = converter.load_state_dict(tmpdir)
+
+    roundtrip_hf_config = converter.hf_config_from_config(lev_config)
+
+    for k, v in roundtrip_hf_config.__dict__.items():
+        assert getattr(roundtrip_hf_config, k) == v, f"{k} {getattr(roundtrip_hf_config, k)} != {v}"
+
+    Vocab = converter.Vocab
+    lev_model = MptLmHeadModel.init(Vocab, lev_config, key=PRNGKey(0))
+    lev_model = lev_model.from_state_dict(loaded_checkpoint)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        converter.save_model_local(lev_model, tmpdir)
+
+        new_converter = HFCheckpointConverter(MptConfig, tmpdir, trust_remote_code=True)
+
+        assert new_converter.config_from_hf_config(config) == lev_config
+        loaded_model = new_converter.load_lm_model(MptLmHeadModel)
+
+        assert loaded_model.config == lev_model.config
+        assert loaded_model.Vocab == lev_model.Vocab
+
+        input = haliax.random.randint(PRNGKey(0), lev_model.config.Pos, 0, lev_model.Vocab.size)
+        np.testing.assert_equal(np.array(lev_model(input).array), np.array(loaded_model(input).array))

--- a/tests/test_hf_checkpoints.py
+++ b/tests/test_hf_checkpoints.py
@@ -7,6 +7,7 @@ from jax.random import PRNGKey
 
 import haliax
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
 from levanter.models.mpt import MptConfig, MptLmHeadModel
 
 
@@ -57,6 +58,63 @@ def test_save_model_with_code():
         # now double check that the pytorch model is the same
         loaded_model = cls.from_pretrained(tmpdir)
         torch_input = torch.from_numpy(np.array(input.array)).to(torch.int64).unsqueeze(0)
+        np.testing.assert_allclose(
+            model(torch_input).logits[0].detach().numpy(), loaded_model(torch_input).logits[0].detach().numpy()
+        )
+
+
+def test_save_backpack_model_with_code():
+    converter = HFCheckpointConverter(BackpackConfig, "stanford-crfm/levanter-backpack-1b", trust_remote_code=True)
+    tokenizer = converter.tokenizer
+    cls = converter.HFAutoModelClass()
+    config = converter.HfConfigClass(
+        n_embd=32,
+        n_positions=512,
+        n_head=8,
+        n_layer=2,
+        vocab_size=len(tokenizer),
+        resid_pdrop=0.0,
+    )
+
+    model = cls(config)
+    model.eval()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lev_config = converter.config_from_hf_config(config)
+        model.save_pretrained(tmpdir)
+        loaded_checkpoint = converter.load_state_dict(tmpdir)
+
+    roundtrip_hf_config = converter.hf_config_from_config(lev_config)
+
+    for k, v in roundtrip_hf_config.__dict__.items():
+        assert getattr(roundtrip_hf_config, k) == v, f"{k} {getattr(roundtrip_hf_config, k)} != {v}"
+
+    Vocab = converter.Vocab
+    lev_model = BackpackLMHeadModel.init(Vocab, lev_config, key=PRNGKey(0))
+    lev_model = lev_model.from_state_dict(loaded_checkpoint)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        converter.save_model_local(lev_model, tmpdir)
+
+        new_converter = converter.replaced(reference_checkpoint=tmpdir, trust_remote_code=True)
+
+        assert new_converter.config_from_hf_config(config) == lev_config
+        loaded_model = new_converter.load_lm_model(BackpackLMHeadModel)
+
+        assert loaded_model.config == lev_model.config
+        assert loaded_model.Vocab == lev_model.Vocab
+
+        input = haliax.random.randint(PRNGKey(0), lev_model.config.Pos, 0, lev_model.Vocab.size)
+        causal_mask = haliax.nn.attention.causal_mask(lev_model.config.Pos, lev_model.config.KeyPos)
+        np.testing.assert_equal(
+            np.array(lev_model(input, causal_mask, inference=True, key=None).array),
+            np.array(loaded_model(input, causal_mask, inference=True, key=None).array),
+        )
+
+        # now double check that the pytorch model is the same
+        loaded_model = cls.from_pretrained(tmpdir)
+        torch_input = torch.from_numpy(np.array(input.array)).to(torch.int64).unsqueeze(0)
+        loaded_model.eval()
         np.testing.assert_allclose(
             model(torch_input).logits[0].detach().numpy(), loaded_model(torch_input).logits[0].detach().numpy()
         )

--- a/tests/test_hf_checkpoints.py
+++ b/tests/test_hf_checkpoints.py
@@ -14,7 +14,7 @@ def test_save_model_with_code():
     converter = HFCheckpointConverter(MptConfig, "mosaicml/mpt-7b", trust_remote_code=True)
     tokenizer = converter.tokenizer
     cls = converter.HFAutoModelClass()
-    config = converter.HFConfigClass(
+    config = converter.HfConfigClass(
         d_model=32,
         max_seq_len=512,
         n_heads=8,

--- a/tests/test_hf_gpt2_serialize.py
+++ b/tests/test_hf_gpt2_serialize.py
@@ -15,7 +15,7 @@ from transformers import GPT2LMHeadModel as HfGpt2LMHeadModel
 
 import haliax as hax
 from haliax import Axis
-from levanter.compat.hf_checkpoints import HFCheckpointConverter, RemoteRef
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.config import OptimizerConfig
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.models.loss import next_token_loss
@@ -43,7 +43,7 @@ def _roundtrip_compare_gpt2_checkpoint(model_id, revision):
     torch_model: HfGpt2LMHeadModel = AutoModelForCausalLM.from_pretrained(model_id, revision=revision)
     torch_model.eval()
 
-    model = converter.load_lm_model(Gpt2LMHeadModel, RemoteRef(model_id, revision=revision))
+    model = converter.load_lm_model(Gpt2LMHeadModel, RepoRef(model_id, revision=revision))
 
     input = hax.random.randint(PRNGKey(0), model.Pos, 0, model.Vocab.size)
 
@@ -89,7 +89,7 @@ def _compare_gpt2_checkpoint_gradients(model_id, revision):
     torch_model: HfGpt2LMHeadModel = AutoModelForCausalLM.from_pretrained(model_id, revision=revision)
     torch_model.eval()
 
-    model = converter.load_lm_model(Gpt2LMHeadModel, RemoteRef(model_id, revision))
+    model = converter.load_lm_model(Gpt2LMHeadModel, RepoRef(model_id, revision))
 
     input = hax.random.randint(PRNGKey(0), model.Pos, 0, model.Vocab.size)
 

--- a/tests/test_hf_gpt2_serialize.py
+++ b/tests/test_hf_gpt2_serialize.py
@@ -15,12 +15,7 @@ from transformers import GPT2LMHeadModel as HfGpt2LMHeadModel
 
 import haliax as hax
 from haliax import Axis
-from levanter.compat.hf_checkpoints import (
-    HFCheckpointConverter,
-    RemoteRef,
-    load_hf_gpt2_checkpoint,
-    save_hf_gpt2_checkpoint,
-)
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, RemoteRef
 from levanter.config import OptimizerConfig
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.models.loss import next_token_loss
@@ -68,7 +63,7 @@ def _roundtrip_compare_gpt2_checkpoint(model_id, revision):
     assert onp.isclose(torch_out, onp.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out} != {jax_out}"
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        save_hf_gpt2_checkpoint(model, tmpdir)
+        converter.save_model(model, tmpdir)
 
         torch_model2: HfGpt2LMHeadModel = AutoModelForCausalLM.from_pretrained(tmpdir)
         torch_model2.eval()
@@ -167,8 +162,9 @@ def test_hf_save_to_fs_spec():
     Vocab = Axis("Vocab", 128)
     config = Gpt2Config(hidden_dim=32, num_heads=2, num_layers=2)
     simple_model = Gpt2LMHeadModel.init(Vocab, config, key=PRNGKey(0))
+    converter = HFCheckpointConverter(Gpt2Config, "gpt2", HfGpt2Config, ignore_prefix="transformer")
 
-    save_hf_gpt2_checkpoint(simple_model, "memory://model")
+    converter.save_model(simple_model, "memory://model")
 
     with tempfile.TemporaryDirectory() as tmpdir:
 
@@ -176,7 +172,7 @@ def test_hf_save_to_fs_spec():
         fs: AbstractFileSystem = fsspec.filesystem("memory")
         fs.get("model/", f"{tmpdir}/test", recursive=True)
 
-        loaded_model = load_hf_gpt2_checkpoint(f"{tmpdir}/test")
+        loaded_model = converter.load_lm_model(Gpt2LMHeadModel, ref=f"{tmpdir}/test")
 
         simple_dict = simple_model.to_state_dict()
         loaded_dict = loaded_model.to_state_dict()
@@ -185,7 +181,7 @@ def test_hf_save_to_fs_spec():
 
         for key, simple_p in simple_dict.items():
             loaded_p = loaded_dict[key]
-            assert onp.isclose(simple_p, loaded_p).all(), f"{key}: {onp.linalg.norm(simple_p - loaded_p, ord=onp.inf)}"
+            assert onp.allclose(simple_p, loaded_p), f"{key}: {onp.linalg.norm(simple_p - loaded_p, ord=onp.inf)}"
 
 
 # TODO: would be nice to have a test that tests hf upload?

--- a/tests/test_levanter_hf_consistency.py
+++ b/tests/test_levanter_hf_consistency.py
@@ -8,7 +8,7 @@ import haliax as hax
 from haliax import Axis
 from haliax.partitioning import round_axis_for_partitioning
 from levanter.checkpoint import load_checkpoint
-from levanter.compat.hf_checkpoints import hf_backpack_config_to_levanter, hf_gpt2_config_to_levanter
+from levanter.compat.hf_checkpoints import hf_backpack_config_to_levanter
 from levanter.config import TrainerConfig
 from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
 from levanter.models.gpt2 import Gpt2LMHeadModel
@@ -54,7 +54,9 @@ def test_hf_gpt2_consistency():
     hf_model = GPT2LMHeadModel.from_pretrained(HF_GPT2)
     hf_model.cuda().eval()
 
-    model_config: GPT2Config = hf_gpt2_config_to_levanter(hf_model_config)
+    from levanter.models.gpt2 import Gpt2Config
+
+    model_config: GPT2Config = Gpt2Config.from_hf_config(hf_model_config)
     trainer_config = TrainerConfig()
 
     vocab_size = hf_model_config.vocab_size

--- a/tests/test_levanter_hf_consistency.py
+++ b/tests/test_levanter_hf_consistency.py
@@ -8,9 +8,8 @@ import haliax as hax
 from haliax import Axis
 from haliax.partitioning import round_axis_for_partitioning
 from levanter.checkpoint import load_checkpoint
-from levanter.compat.hf_checkpoints import hf_backpack_config_to_levanter
 from levanter.config import TrainerConfig
-from levanter.models.backpack import BackpackConfig, BackpackLMHeadModel
+from levanter.models.backpack import BackpackLMHeadModel
 from levanter.models.gpt2 import Gpt2LMHeadModel
 
 
@@ -28,7 +27,9 @@ def test_hf_backpack_consistency():
     hf_model = AutoModelForCausalLM.from_pretrained(HF_BACKPACK, config=hf_model_config, trust_remote_code=True)
     hf_model.cuda().eval()
 
-    model_config: BackpackConfig = hf_backpack_config_to_levanter(hf_model_config)
+    from levanter.models.backpack import BackpackConfig
+
+    model_config: BackpackConfig = BackpackConfig.from_hf_config(hf_model_config)
     trainer_config = TrainerConfig()
 
     vocab_size = hf_model_config.vocab_size

--- a/tests/test_mpt.py
+++ b/tests/test_mpt.py
@@ -23,7 +23,7 @@ def test_mpt_nano_compare(use_bias):
     # a bit hacky, using some internal-y APIs of transformers
     converter = HFCheckpointConverter(MptConfig, "mosaicml/mpt-7b", trust_remote_code=True)
     cls = converter.HFAutoModelClass()
-    config = converter.HFConfigClass(
+    config = converter.HfConfigClass(
         d_model=32,
         max_seq_len=512,
         n_heads=8,

--- a/tests/test_mpt.py
+++ b/tests/test_mpt.py
@@ -28,7 +28,6 @@ def test_mpt_nano_compare(use_bias):
         max_seq_len=512,
         n_heads=8,
         n_layers=2,
-        dropout=0.0,
         attn_config={"attn_impl": "torch", "alibi": True},
         vocab_size=vocab_size,
         no_bias=not use_bias,
@@ -52,7 +51,6 @@ def test_mpt_nano_compare(use_bias):
 
     roundtrip_hf_config = lev_config.to_hf_config(vocab_size)
     # for reasons I don't understand, this flag is present in the config but not in the model
-    setattr(roundtrip_hf_config, "dropout", 0.0)
     assert config == roundtrip_hf_config
 
     Vocab = haliax.Axis("vocab", vocab_size)


### PR DESCRIPTION
 (open to bikeshedding on the name)

Supersedes #189 

could still be cleaned up, but i think overall this is an improvement. introduces a single class that handles the serialization for GPT2, MPT, and Backpacks in a pluggable way.

Haven't actually tested HF upload yet.

Next up is a registry, and maybe unifying the various _example and _eval scripts

