### PR TITLE
Fix converter for backpack

### DIFF
--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -116,25 +116,6 @@ def _coerce_to_rr(s: Union[str, RepoRef]) -> RepoRef:
         return RepoRef.from_string(s)
 
 
-@dataclass
-class HFAutoMapConfig:
-    """
-    To create a custom AutoModel class, in your model's config.json,
-    you will need to add a field like this:
-    "auto_map": {
-        "AutoConfig": "backpack_config.BackpackGPT2Config",
-        "AutoModelForCausalLM": "backpack_model.BackpackGPT2LMHeadModel"
-    },
-    """
-
-    AutoConfig: Optional[str] = None  # path of the AutoConfig class
-    AutoModelForCausalLM: Optional[str] = None  # path of the AutoModel class
-
-    def to_dict(self) -> dict:
-        """A helper function to convert class to dict"""
-        return {k: v for k, v in self.__dict__.items() if v is not None}
-
-
 LevConfig = TypeVar("LevConfig", bound=HFCompatConfig)
 
 # just for generating unique ids
@@ -418,8 +399,8 @@ class HFCheckpointConverter(Generic[LevConfig]):
     ):
         """
         Saves a HF-compatible checkpoint to a local path.
-        :param model:
-        :param path:
+        :param model: The model to convert and save
+        :param path: The path to save the output to
         :param save_tokenizer: Save the tokenizer to the checkpoint
         :param save_reference_code: Save any code from the reference checkpoint
         :return:
@@ -430,8 +411,10 @@ class HFCheckpointConverter(Generic[LevConfig]):
         # save code first because we'll likely be overwriting it
         if save_reference_code:
             self._save_code_local(path)
-
-        config = model.config.to_hf_config(model.Vocab.size)
+        config = model.config.to_hf_config(
+            model.Vocab.size, 
+            config_overrides=self.config_overrides
+        )
         dict_config = config.to_dict()
 
         # copy over the default keys

--- a/src/levanter/models/backpack.py
+++ b/src/levanter/models/backpack.py
@@ -60,6 +60,7 @@ class BackpackConfig(Gpt2Config):
             reorder_and_upcast_attn=self.upcast_attn,
             num_senses=self.num_senses,
             sense_intermediate_scale=self.sense_intermediate_scale,
+            **config_overrides,
         )
 
     @classmethod
@@ -414,10 +415,10 @@ class BackpackLMHeadModel(eqx.Module, LmWithHfSerializationMixin):
         state_dict = super().update_state_dict(state_dict, prefix=prefix)
         # In levanter's implementation, we have a shared embedding matrix for both the word
         # embeddings and the sense embeddings
-        state_dict[apply_prefix(prefix, "word_embeddings.weight")] = state_dict[
+        state_dict[apply_prefix(prefix, "backpack.word_embeddings.weight")] = state_dict[
             apply_prefix(prefix, "backpack.gpt2_model.wte.weight")
         ]
-        state_dict[apply_prefix(prefix, "position_embeddings.weight")] = state_dict[
+        state_dict[apply_prefix(prefix, "backpack.position_embeddings.weight")] = state_dict[
             apply_prefix(prefix, "backpack.gpt2_model.wpe.weight")
         ]
         return state_dict


### PR DESCRIPTION
A few minor changes:
1. Remove `HFAutoMapConfig` class as it is no longer used. Instead, I can put them in `config_overides` (for example [here](https://github.com/stanford-crfm/levanter/blob/671422ed82ffb269d3fe4d297a632d54d572516b/config/local_backpack_hf.yaml#L13-L17))
2. Pass `self.config_overrides` to `to_hf_config`
3. Add `backpack.` in front of `word_embeddings.weight` and `position_embeddings.weight`, see error log below:

```
Some weights of the model checkpoint at /sailhome/ivanzhou/dev/levanter-backpack-gpt2-large-ln/ were not used when initializing BackpackGPT2LMHeadModel: ['position_embeddings.weight', 'word_embeddings.weight']
- This IS expected if you are initializing BackpackGPT2LMHeadModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing BackpackGPT2LMHeadModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Some weights of BackpackGPT2LMHeadModel were not initialized from the model checkpoint at /sailhome/ivanzhou/dev/levanter-backpack-gpt2-large-ln/ and are newly initialized: ['backpack.word_embeddings.weight', 'backpack.position_embeddings.weight']
```