### PR TITLE
Switch to Draccus, change how we write subtyped configs (fixes #214 fixes #207)

### DIFF
--- a/config/backpack.yaml
+++ b/config/backpack.yaml
@@ -5,15 +5,15 @@ data:
      - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  backpack:
-    hidden_dim: 768
-    num_heads: 12
-    num_layers: 12
-    seq_len: 512
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
-    num_senses: 16
-    sense_intermediate_scale: 4
+  type: backpack
+  hidden_dim: 768
+  num_heads: 12
+  num_layers: 12
+  seq_len: 512
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
+  num_senses: 16
+  sense_intermediate_scale: 4
 trainer:
   wandb:
     project: "levanter"

--- a/config/backpack_nano.yaml
+++ b/config/backpack_nano.yaml
@@ -1,15 +1,15 @@
 data:
   id: dlwh/wikitext_103_detokenized
 model:
-  backpack:
-    hidden_dim: 32
-    num_heads: 4
-    num_layers: 2
-    seq_len: 512
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
-    num_senses: 16
-    sense_intermediate_scale: 4
+  type: backpack
+  hidden_dim: 32
+  num_heads: 4
+  num_layers: 2
+  seq_len: 512
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
+  num_senses: 16
+  sense_intermediate_scale: 4
 trainer:
   mp: f32
 

--- a/config/gpt2_1536.yaml
+++ b/config/gpt2_1536.yaml
@@ -5,13 +5,13 @@ data:
       - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  gpt2:
-    hidden_dim: 1536
-    num_heads: 24
-    num_layers: 48
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: gpt2
+  hidden_dim: 1536
+  num_heads: 24
+  num_layers: 48
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_20b.yaml
+++ b/config/gpt2_20b.yaml
@@ -4,16 +4,16 @@ data:
   cache_dir: "gs://levanter-data/tokenized/pile-old/"
   tokenizer: "EleutherAI/gpt-neox-20b"
 model:
-  gpt2:
-    hidden_dim: 6144
-    num_heads: 64
-    num_layers: 44
-    seq_len: 2048
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
-    attn_pdrop: 0.0
-    resid_pdrop: 0.0
-    use_bias: false
+  type: gpt2
+  hidden_dim: 6144
+  num_heads: 64
+  num_layers: 44
+  seq_len: 2048
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
+  attn_pdrop: 0.0
+  resid_pdrop: 0.0
+  use_bias: false
 fcm_prob: 0.15
 trainer:
   wandb:

--- a/config/gpt2_7b.yaml
+++ b/config/gpt2_7b.yaml
@@ -4,15 +4,15 @@ data:
   cache_dir: "gs://levanter-data/tokenized/pile-old/"
   tokenizer: "EleutherAI/gpt-neox-20b"
 model:
-  gpt2:
-    hidden_dim: 4096
-    num_heads: 32
-    num_layers: 32
-    seq_len: 2048
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
-    attn_pdrop: 0.0
-    resid_pdrop: 0.0
+  type: gpt2
+  hidden_dim: 4096
+  num_heads: 32
+  num_layers: 32
+  seq_len: 2048
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
+  attn_pdrop: 0.0
+  resid_pdrop: 0.0
 fcm_prob: 0.15
 trainer:
   wandb:

--- a/config/gpt2_large.yaml
+++ b/config/gpt2_large.yaml
@@ -5,13 +5,13 @@ data:
       - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  gpt2:
-    hidden_dim: 1280
-    num_heads: 20
-    num_layers: 36
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: gpt2
+  hidden_dim: 1280
+  num_heads: 20
+  num_layers: 36
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_medium.yaml
+++ b/config/gpt2_medium.yaml
@@ -5,13 +5,13 @@ data:
       - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  gpt2:
-    hidden_dim: 1024
-    num_heads: 16
-    num_layers: 24
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: gpt2
+  hidden_dim: 1024
+  num_heads: 16
+  num_layers: 24
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_micro.yaml
+++ b/config/gpt2_micro.yaml
@@ -1,10 +1,10 @@
 data:
   id: dlwh/wikitext_103_detokenized
 model:
-  gpt2:
-    hidden_dim: 128
-    num_heads: 8
-    num_layers: 4
+  type: gpt2
+  hidden_dim: 128
+  num_heads: 8
+  num_layers: 4
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_nano.yaml
+++ b/config/gpt2_nano.yaml
@@ -1,10 +1,10 @@
 data:
   id: dlwh/wikitext_103_detokenized
 model:
-  gpt2:
-    hidden_dim: 32
-    num_heads: 4
-    num_layers: 2
+  type: gpt2
+  hidden_dim: 32
+  num_heads: 4
+  num_layers: 2
 trainer:
   mp: f32
   num_train_steps: 100

--- a/config/gpt2_pubmed.yaml
+++ b/config/gpt2_pubmed.yaml
@@ -5,13 +5,13 @@ data:
       - "gs://pubmed-mosaic/pubmed-sharded/pubmedRandomized_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/pubmed-sharded/"
 model:
-  gpt2:
-    hidden_dim: 1600
-    num_heads: 25
-    num_layers: 48
-    seq_len: 1024
+  type: gpt2
+  hidden_dim: 1600
+  num_heads: 25
+  num_layers: 48
+  seq_len: 1024
 
-    gradient_checkpointing: true
+  gradient_checkpointing: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_small.yaml
+++ b/config/gpt2_small.yaml
@@ -5,13 +5,13 @@ data:
       - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  gpt2:
-    hidden_dim: 768
-    num_heads: 12
-    num_layers: 12
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: gpt2
+  hidden_dim: 768
+  num_heads: 12
+  num_layers: 12
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_small_fast.yaml
+++ b/config/gpt2_small_fast.yaml
@@ -5,13 +5,13 @@ data:
       - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  gpt2:
-    hidden_dim: 768
-    num_heads: 12
-    num_layers: 12
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: gpt2
+  hidden_dim: 768
+  num_heads: 12
+  num_layers: 12
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_small_fast_pile.yaml
+++ b/config/gpt2_small_fast_pile.yaml
@@ -3,13 +3,13 @@ data:
   cache_dir: "gs://levanter-data/tokenized/pile-old/"
   tokenizer: "EleutherAI/gpt-neox-20b"
 model:
-  gpt2:
-    hidden_dim: 768
-    num_heads: 12
-    num_layers: 12
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: gpt2
+  hidden_dim: 768
+  num_heads: 12
+  num_layers: 12
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/gpt2_xl.yaml
+++ b/config/gpt2_xl.yaml
@@ -5,13 +5,13 @@ data:
       - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  gpt2:
-    hidden_dim: 1600
-    num_heads: 25
-    num_layers: 48
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: gpt2
+  hidden_dim: 1600
+  num_heads: 25
+  num_layers: 48
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
 trainer:
   wandb:
     project: "levanter"

--- a/config/mpt_7b_continued.yaml
+++ b/config/mpt_7b_continued.yaml
@@ -5,7 +5,8 @@ data:
     - gs://levanter-data/pile/val.jsonl.zst
   cache_dir: "gs://levanter-data/tokenized/pile-old/"
   tokenizer: "EleutherAI/gpt-neox-20b"
-model: mpt
+model:
+  type: mpt
 initialize_from_hf: true
 use_hf_model_config: true
 trainer:

--- a/docs/Getting-Started-Training.md
+++ b/docs/Getting-Started-Training.md
@@ -20,7 +20,7 @@ python src/levanter/main/train_lm.py --config_path config/gpt2_small.yaml
 This will execute the training pipeline pre-defined in the [train_lm.py](../src/levanter/main/train_lm.py) and set model and training configuration
 set in [gpt2_small.yaml](../config/gpt2_small.yaml). You can find more template configurations in the [config](../config/) directory.
 
-Configuration files are processed using [Pyrallis](https://github.com/eladrich/pyrallis). Pyrallis is yet-another yaml-to-dataclass library.
+Configuration files are processed using [Pyrallis](https://github.com/eladrich/draccus). Pyrallis is yet-another yaml-to-dataclass library.
 
 ## Set Custom Training Configuration
 In machine learning experiments, it is common to adjust model hyperparameters. In this section, we will provide examples of different use cases

--- a/docs/Getting-Started-Training.md
+++ b/docs/Getting-Started-Training.md
@@ -20,7 +20,7 @@ python src/levanter/main/train_lm.py --config_path config/gpt2_small.yaml
 This will execute the training pipeline pre-defined in the [train_lm.py](../src/levanter/main/train_lm.py) and set model and training configuration
 set in [gpt2_small.yaml](../config/gpt2_small.yaml). You can find more template configurations in the [config](../config/) directory.
 
-Configuration files are processed using [Pyrallis](https://github.com/eladrich/draccus). Pyrallis is yet-another yaml-to-dataclass library.
+Configuration files are processed using [Pyrallis](https://github.com/dlwh/draccus). Pyrallis is yet-another yaml-to-dataclass library.
 
 ## Set Custom Training Configuration
 In machine learning experiments, it is common to adjust model hyperparameters. In this section, we will provide examples of different use cases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "transformers>=4.22.0",
     "optax",
     "wandb",
-    "pyrallis>=0.3.1",
+    "draccus>=0.4",
     "pyarrow>=11.0.0",
     "zstandard>=0.20.0",
     "datasets==2.11.0",

--- a/src/levanter/checkpoint.py
+++ b/src/levanter/checkpoint.py
@@ -11,10 +11,10 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, TypeVar, Unio
 
 import fsspec
 import jax
+from draccus import field
 from equinox.serialisation import _is_index, default_deserialise_filter_spec, default_serialise_filter_spec
 from fsspec import AbstractFileSystem
 from jaxtyping import PyTree
-from pyrallis import field
 
 from levanter.tensorstore_serialization import tree_deserialize_leaves_tensorstore, tree_serialize_leaves_tensorstore
 from levanter.utils.jax_utils import multihost_broadcast_sync
@@ -396,7 +396,7 @@ def _assert_same(new, old):
 class CheckpointerConfig:
     base_path: str = "checkpoints/"
     save_interval: timedelta = timedelta(hours=6)
-    # TODO: I'd like to write this, but it's not supported by pyrallis
+    # TODO: I'd like to write this, but it's not supported by draccus
     # keep: List[CheckpointInterval] = field(default_factory=lambda: [CheckpointInterval(every=1000)])
     keep: List[dict] = field(
         default_factory=lambda: [dict(every=10000)]

--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -12,12 +12,12 @@ from functools import cached_property
 from typing import Generic, Optional, Tuple, Type, TypeVar, Union, cast
 from urllib.parse import urlparse
 
+import draccus
 import fsspec
 import huggingface_hub
 import jax
 import jax.numpy as jnp
 import numpy as np
-import pyrallis
 import safetensors
 import safetensors.numpy
 from fsspec import AbstractFileSystem
@@ -77,9 +77,9 @@ class RepoRef:
         return f"RemoteRev({self.model_name_or_path!r}, {self.revision!r})"
 
 
-# register pyrallis parsing
-pyrallis.decode.register(RepoRef, RepoRef.from_string)
-pyrallis.encode.register(RepoRef, str)
+# register draccus parsing
+draccus.decode.register(RepoRef, RepoRef.from_string)
+draccus.encode.register(RepoRef, str)
 
 
 class HFCompatConfig(LmConfig["LmWithHfSerializationMixin"]):

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -14,8 +14,8 @@ import jax.numpy as jnp
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+from draccus import field
 from jaxtyping import PyTree
-from pyrallis import field
 
 import haliax as hax
 from haliax import Axis, NamedArray

--- a/src/levanter/logging.py
+++ b/src/levanter/logging.py
@@ -7,11 +7,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Union
 
+import draccus
 import jax
-import pyrallis
+from draccus import field
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 from optax import MultiStepsState
-from pyrallis import field
 
 import wandb
 from levanter.utils import jax_utils
@@ -229,7 +229,7 @@ class WandbConfig:
             with tempfile.TemporaryDirectory() as tmpdir:
                 config_path = f"{tmpdir}/config.yaml"
                 with open(config_path, "w") as f:
-                    pyrallis.dump(hparams, f, encoding="utf-8")
+                    draccus.dump(hparams, f, encoding="utf-8")
                 wandb.run.log_artifact(str(config_path), name="config.yaml", type="config")
 
         # generate a pip freeze

--- a/src/levanter/models/lm_model.py
+++ b/src/levanter/models/lm_model.py
@@ -1,9 +1,9 @@
 import abc
 from typing import Generic, Optional, Type, TypeVar
 
+import draccus
 from jax.random import PRNGKey
 
-import levanter.config
 from haliax import Axis, NamedArray
 
 
@@ -11,8 +11,8 @@ LmConfigT = TypeVar("LmConfigT", bound="LmConfig")
 LmT = TypeVar("LmT", bound="LmHeadModel")
 
 
-@levanter.config.config_registry(discover_packages="levanter.models")
-class LmConfig(abc.ABC, Generic[LmT]):
+# TODO: for some reason, mypy doesn't like the discover_packages_path argument?
+class LmConfig(draccus.PluginRegistry, abc.ABC, Generic[LmT], discover_packages_path="levanter.models"):  # type: ignore
     @property
     @abc.abstractmethod
     def model_type(cls) -> Type[LmT]:

--- a/src/levanter/models/mpt.py
+++ b/src/levanter/models/mpt.py
@@ -142,7 +142,6 @@ class MptConfig(HFCompatConfig):
 
     @cached_classproperty
     def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["MptConfig"]:  # type: ignore
-        # We trust this code because it's in our hub repo
         return HFCheckpointConverter(
             cls, "mosaicml/mpt-7b@68e1a8e0ebb9b30f3c45c1ef6195980f29063ae2", trust_remote_code=True
         )

--- a/src/levanter/trainer.py
+++ b/src/levanter/trainer.py
@@ -12,9 +12,9 @@ import jmp
 import numpy as np
 import optax
 from chex import PRNGKey
+from draccus import field
 from jax._src.interpreters.pxla import Mesh
 from jaxtyping import PyTree
-from pyrallis import field
 
 import levanter.logging
 from haliax.partitioning import ResourceAxis, ResourceMapping

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,6 @@
 import dataclasses
 
 import fsspec
-import pyrallis
-import pytest
 
 import levanter.config
 from haliax.partitioning import ResourceAxis
@@ -50,30 +48,3 @@ def test_new_style_axis_mapping():
         "a2": ResourceAxis.MODEL,
         "batch": ResourceAxis.DATA,
     }
-
-
-def test_class_registry():
-    @levanter.config.config_registry
-    @dataclasses.dataclass
-    class Person:
-        name: str
-
-    @dataclasses.dataclass
-    class Adult(Person):
-        age: int
-
-    @dataclasses.dataclass
-    class Child(Person):
-        favorite_toy: str
-
-    Person.register_subclass("adult", Adult)
-    Person.register_subclass("child", Child)
-
-    assert pyrallis.decode(Person, {"adult": {"name": "bob", "age": 10}}) == Adult("bob", 10)
-    assert pyrallis.decode(Person, {"child": {"name": "bob", "favorite_toy": "truck"}}) == Child("bob", "truck")
-
-    with pytest.raises(Exception):  # pyrallis raises an Exception, not a ValueError
-        pyrallis.decode(Person, {"adult": {"name": "bob", "age": 10, "favorite_toy": "truck"}})
-
-    with pytest.raises(ValueError):
-        pyrallis.decode(Person, {"baby": {"name": "bob"}})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,10 +3,10 @@ import os
 from functools import reduce
 from typing import Callable, List, Optional, Sequence, TypeVar
 
+import draccus
 import equinox as eqx
 import jax
 import pyarrow as pa
-import pyrallis
 import pytest
 from chex import assert_trees_all_close
 from equinox import nn as nn
@@ -197,6 +197,6 @@ def parameterize_with_configs(pattern, config_path=None):
 
 def check_load_config(config_class, config_file):
     try:
-        pyrallis.parse(config_class, config_file, args=[])
+        draccus.parse(config_class, config_file, args=[])
     except Exception as e:
         raise Exception(f"failed to parse {config_file}") from e


### PR DESCRIPTION
cc @Ivan-Zhou  I had to change all the configs again.

I had to fork Pyrallis and rearchitect it a bit. The result is called [Draccus](https://github.com/dlwh/draccus)...

We now have a fairly clean way of dealing with subtypes, plus I can fix a bunch of other pyrallis issues that have been bugging me.

