### PR TITLE
Temporarily pin pydantic < 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "tblib>=1.7.0,<2.0.0",
     "dataclasses_json",
     "ray[default]",
+    "pydantic<2",  # temporary pin until Ray supports pydantic 2.0
     "rich>=13",
 ]
 


### PR DESCRIPTION
1. Pin Pydantic < 2.0 to address the issue https://github.com/stanford-crfm/levanter/issues/224. This can be reverted once Ray supports Pydantic 2.0
2. Remove requiremetns.txt because it is empty. 