### PR TITLE
Fix string interpolation for joining paths

### DIFF
--- a/src/levanter/logging.py
+++ b/src/levanter/logging.py
@@ -153,6 +153,7 @@ class WandbConfig:
 
     def init(self, hparams=None, **extra_hparams):
         import wandb
+        import os
 
         if hparams is None:
             hparams_to_save = {}
@@ -227,14 +228,14 @@ class WandbConfig:
 
         if dataclasses.is_dataclass(hparams):
             with tempfile.TemporaryDirectory() as tmpdir:
-                config_path = f"{tmpdir}/config.yaml"
+                config_path = os.path.join(tmpdir, "config.yaml")
                 with open(config_path, "w") as f:
                     draccus.dump(hparams, f, encoding="utf-8")
                 wandb.run.log_artifact(str(config_path), name="config.yaml", type="config")
 
         # generate a pip freeze
         with tempfile.TemporaryDirectory() as tmpdir:
-            requirements_path = f"{tmpdir}/requirements.txt"
+            requirements_path = os.path.join(tmpdir, "requirements.txt")
             requirements = _generate_pip_freeze()
             with open(requirements_path, "w") as f:
                 f.write(requirements)

--- a/src/levanter/main/export_lm_to_hf.py
+++ b/src/levanter/main/export_lm_to_hf.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Optional
@@ -54,7 +55,7 @@ def main(config: ConvertLmConfig):
         model = filter_eval_shape(config.model.build(Vocab, key=key), Vocab, config.model, key=key)
 
         with hax.enable_shape_checks(False):
-            model = tree_deserialize_leaves_tensorstore(f"{config.checkpoint_path}/model", model)
+            model = tree_deserialize_leaves_tensorstore(os.path.join(config.checkpoint_path, "model"), model)
 
         model = htu.resize_axis(model, Vocab.resize(vocab_size), key=key)
 

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -271,7 +271,7 @@ def main(config: TrainLmConfig):
 
         engine.add_hook(
             callbacks.compute_and_visualize_log_probs(
-                eval_loader, tokenizer, compute_log_probs, f"{config.trainer.run_dir}/log_probs"
+                eval_loader, tokenizer, compute_log_probs, os.path.join(config.trainer.run_dir, "log_probs")
             ),
             every=config.trainer.steps_per_eval,
         )

--- a/src/levanter/tensorstore_serialization.py
+++ b/src/levanter/tensorstore_serialization.py
@@ -2,6 +2,7 @@
 # * Orbax: https://github.com/google/orbax/blob/11d2934ecfff77e86b5e07d0fef02b67eff4511b/orbax/checkpoint/pytree_checkpoint_handler.py#L312
 import asyncio
 import logging
+import os
 from functools import partial
 
 import jax
@@ -33,7 +34,7 @@ def tree_serialize_leaves_tensorstore(checkpoint_dir, pytree):
 
 
 def _tensorstore_spec_for(checkpoint_dir, key_path: str):
-    checkpoint_path = f"{checkpoint_dir}/{key_path.replace('.', '/')}"
+    checkpoint_path = os.path.join(checkpoint_dir, *key_path.split("."))
     ts_spec = array_ser.get_tensorstore_spec(checkpoint_path)
     return ts_spec
 


### PR DESCRIPTION
Fix string interpolation for joining paths

* Replace string interpolation with `os.path.join` for file and directory paths

Resolves #139 