### PR TITLE
Fix flake8 repo in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
     -   id: isort
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8


### PR DESCRIPTION
Fix flake8 repo in pre-commit

flake8 fails to run in pre-commit due to gitlab repo no longer exitsing at https://gitlab.com/pycqa/flake8 (returns 404). This is following the Contibuting documentation which indicates the following command:

```
pre-commit run --all-files
```

* Update flake8 to https://github.com/PyCQA/flake8 which is the recommended location based on the current pre-commit docs: https://pre-commit.com/hooks.html

_Note_: While this does fix the installation of flake8, running `pre-commit run --all-files` causes approximately 32 files to be changed on the current *main* branch. This may indicate that if this is now applied, that linting should also be added to CI to protect newer commits with divergent formatting.