### PR TITLE
Ensure Ray cores >= BatchTokenizer cores and Levanter works with Pyenv

### DIFF
--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -21,6 +21,7 @@ from chex import PRNGKey
 from draccus import field
 from jaxtyping import PyTree
 
+from levanter.utils.py_utils import logical_cpu_core_count
 import haliax as hax
 from haliax import Axis
 
@@ -359,14 +360,6 @@ def _batch_encoding_from_record_batch(b: pa.RecordBatch, flatten_docs: bool):
         )
 
 
-def _cpu_count():
-    """Returns the number of CPUs in the system."""
-    try:
-        return os.cpu_count()
-    except NotImplementedError:
-        return 1
-
-
 def _maybe_force_tokenizer_parallelism(tokenizer: PreTrainedTokenizerBase):
     if tokenizer.is_fast and os.getenv("TOKENIZERS_PARALLELISM") is None:
         # if we're using a fast tokenizer, we want to force parallelism
@@ -401,7 +394,7 @@ class BatchTokenizer(BatchProcessor[str]):
 
     @property
     def num_cpus(self) -> int:
-        return max(1, _cpu_count() - 2)
+        return max(1, logical_cpu_core_count() - 2)
 
 
 def concatenate_and_group_texts(

--- a/src/levanter/logging.py
+++ b/src/levanter/logging.py
@@ -258,7 +258,7 @@ class WandbConfig:
         for frame in stack:
             dirname = os.path.dirname(frame.filename)
             # bit hacky but we want to skip anything that's in the python env
-            if any(x in dirname for x in ["site-packages", "dist-packages", "venv", "opt/homebrew", "conda"]):
+            if any(x in dirname for x in ["site-packages", "dist-packages", "venv", "opt/homebrew", "conda", "pyenv"]):
                 continue
             # see if it's under a git root
             try:

--- a/src/levanter/utils/py_utils.py
+++ b/src/levanter/utils/py_utils.py
@@ -1,6 +1,13 @@
 from dataclasses import dataclass
+import os
 from typing import Callable, TypeVar
 
+def logical_cpu_core_count():
+    """Returns the number of logical CPU cores in the system."""
+    try:
+        return os.cpu_count()
+    except NotImplementedError:
+        return 1
 
 def non_caching_cycle(iterable):
     """Like itertools.cycle, but doesn't cache the iterable."""

--- a/tests/test_eval_lm.py
+++ b/tests/test_eval_lm.py
@@ -13,10 +13,12 @@ from levanter.checkpoint import save_checkpoint
 from levanter.distributed import RayConfig
 from levanter.logging import WandbConfig
 from levanter.models.gpt2 import Gpt2LMHeadModel
+from levanter.utils.py_utils import logical_cpu_core_count
 
 
 def setup_module(module):
-    ray.init("local", num_cpus=10)
+    ray_designated_cores = max(1, logical_cpu_core_count())
+    ray.init("local", num_cpus=ray_designated_cores)
 
 
 def teardown_module(module):

--- a/tests/test_shard_cache.py
+++ b/tests/test_shard_cache.py
@@ -15,10 +15,10 @@ from levanter.data.shard_cache import (
     _get_broker_actor,
     cache_dataset,
 )
-
+from levanter.utils.py_utils import logical_cpu_core_count
 
 def setup_module(module):
-    ray.init("local", num_cpus=min(20, 2 * os.cpu_count()))  # 2x cpu count is faster on my m1
+    ray.init("local", num_cpus=2 * logical_cpu_core_count())  # 2x cpu count is faster on my m1
 
 
 def teardown_module(module):

--- a/tests/test_tokenized_document_cache.py
+++ b/tests/test_tokenized_document_cache.py
@@ -7,6 +7,7 @@ from transformers import AutoTokenizer, BatchEncoding
 
 from levanter.data.shard_cache import ShardedDataSource, cache_dataset
 from levanter.data.text import TokenizedDocumentCache
+from levanter.utils.py_utils import logical_cpu_core_count
 from test_utils import IdentityProcessor, ShardsDataSource, SingleShardDocumentSource
 
 
@@ -16,7 +17,8 @@ T = TypeVar("T")
 
 
 def setup_module(module):
-    ray.init("local", num_cpus=10)
+    ray_designated_cores = max(1, logical_cpu_core_count())
+    ray.init("local", num_cpus=ray_designated_cores)
 
 
 def teardown_module(module):

--- a/tests/test_train_lm.py
+++ b/tests/test_train_lm.py
@@ -9,10 +9,12 @@ import levanter.main.train_lm as train_lm
 import tiny_test_corpus
 from levanter.distributed import RayConfig
 from levanter.logging import WandbConfig
+from levanter.utils.py_utils import logical_cpu_core_count
 
 
 def setup_module(module):
-    ray.init("local", num_cpus=10)
+    ray_designated_cores = max(1, logical_cpu_core_count())
+    ray.init("local", num_cpus=ray_designated_cores)
 
 
 def teardown_module(module):

--- a/tests/test_viz_lm.py
+++ b/tests/test_viz_lm.py
@@ -13,10 +13,12 @@ from levanter.checkpoint import save_checkpoint
 from levanter.distributed import RayConfig
 from levanter.logging import WandbConfig
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
+from levanter.utils.py_utils import logical_cpu_core_count
 
 
 def setup_module(module):
-    ray.init("local", num_cpus=10)
+    ray_designated_cores = max(1, logical_cpu_core_count())
+    ray.init("local", num_cpus=ray_designated_cores)
 
 
 def teardown_module(module):


### PR DESCRIPTION
** Reasons for Merge Request **

** Reason 1 - Commit 1 **

Tests in 5 files fail when PyTest tests are run on machines with more than 10 cores. To fix this issue, Ray is initialized with more cores to ensure adequate logical cpus are available. In addition, one line of code causes failures on machines with more than 20 cores. This issue was also fixed.

Tests in the following 5 files will hang:

1. tests/test_eval_lm.py
2. tests/test_shard_cache.py
3. tests/test_tokenized_document_cache.py
4. tests/test_train_lm.py
5. tests/test_viz_lm.py

** Local test results **

`pytest tests`

======== short test summary info ======================================
FAILED tests/test_logging.py::test_infer_experiment_git_root - AssertionError: /home/flashback/levanter-code/levanter/tests/test_logging.py is not relative to /home/flashback/.pyenv
======== 1 failed, 66 passed, 18 skipped, 863 warnings in 476.23s (0:07:56) =====

The test, which fails, is unrelated to this pull request.

** Reason 2 - Commit 2 **

In order to fix the failing test above, the second commit was added. This commit ensures that Levanter works with Pyenv.

The result of running tests is shown below:

➜  levanter git:(sp-ray-cores) pytest tests 
========== test session starts ==============
platform linux -- Python 3.10.11, pytest-7.4.0, pluggy-1.2.0
rootdir: /home/flashback/levanter-code/levanter
...
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========= 67 passed, 18 skipped, 863 warnings in 488.95s (0:08:08) ==============