### PR TITLE
Use the new support for output-first linear layers

### DIFF
--- a/src/levanter/compat/torch_serialization.py
+++ b/src/levanter/compat/torch_serialization.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import fields
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, cast, overload
+from typing import Any, Dict, List, Optional, TypeVar, cast, overload
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -217,23 +217,6 @@ def unflatten_linear_layer(prefix, statedict: StateDict, layer: hnn.Linear, out_
     return ret_dict
 
 
-def reshape_linear_layers(
-    in_dict: StateDict, prefix: Optional[str], in_shape: Tuple[int, ...], out_shape: Tuple[int, ...]
-) -> StateDict:
-    """Reshape the weights and bias for a linear layer in a torch dict to a new shape."""
-    new_dict: StateDict = {}
-    weight_key = cast(str, apply_prefix(prefix, "weight"))
-    bias_key = cast(str, apply_prefix(prefix, "bias"))
-    weight = in_dict[weight_key]
-    bias = in_dict[bias_key]
-    weight = weight.reshape((-1,) + in_shape + out_shape)
-    bias = bias.reshape((-1,) + out_shape)
-    new_dict[weight_key] = weight
-    new_dict[bias_key] = bias
-
-    return new_dict
-
-
 def unstack_state_dict(state_dict: StateDict, prefix: Optional[str] = None) -> StateDict:
     """
     Unstack all keys matching prefix in a new state dict, returning a state dict that has all keys matching
@@ -294,24 +277,3 @@ def stack_state_dict(state_dict: StateDict, prefix: Optional[str] = None) -> Sta
         vectorized_dict[cast(str, apply_prefix(prefix, k))] = numpy.stack(tensors, axis=0)
 
     return vectorized_dict
-
-
-def reshape_mlp_linear_layer(
-    in_dict: StateDict, prefix: Optional[str], in_shape: Tuple[int, ...], out_shape: Tuple[int, ...]
-) -> StateDict:
-    """
-    Reshape the weights and bias for a linear layer in a torch dict to a new shape.
-    This is different from reshape_linear_layer as we removed (-1,) from the shape
-    of the weights and bias.
-    """
-    new_dict: StateDict = {}
-    weight_key = cast(str, apply_prefix(prefix, "weight"))
-    bias_key = cast(str, apply_prefix(prefix, "bias"))
-    weight = in_dict[weight_key]
-    bias = in_dict[bias_key]
-    weight = weight.reshape(in_shape + out_shape)
-    bias = bias.reshape(out_shape)
-    new_dict[weight_key] = weight
-    new_dict[bias_key] = bias
-
-    return new_dict

--- a/src/levanter/compat/torch_serialization.py
+++ b/src/levanter/compat/torch_serialization.py
@@ -191,9 +191,13 @@ def unflatten_linear_layer(prefix, statedict: StateDict, layer: hnn.Linear, out_
 
     if out_dims_first_in_dict:
         weight = hax.named(weight, hax.concat_axis_specs(extra_dims, ("__OUT__", "__IN__")))
-        weight = weight.rearrange((..., "__IN__", "__OUT__"))
     else:
         weight = hax.named(weight, hax.concat_axis_specs(extra_dims, ("__IN__", "__OUT__")))
+
+    if layer.out_first:
+        weight = weight.rearrange((..., "__OUT__", "__IN__"))
+    else:
+        weight = weight.rearrange((..., "__IN__", "__OUT__"))
 
     # now unflatten
     weight = weight.unflatten_axis("__OUT__", layer.Out).unflatten_axis("__IN__", layer.In)
@@ -213,7 +217,7 @@ def unflatten_linear_layer(prefix, statedict: StateDict, layer: hnn.Linear, out_
     return ret_dict
 
 
-def reshape_linear_layer(
+def reshape_linear_layers(
     in_dict: StateDict, prefix: Optional[str], in_shape: Tuple[int, ...], out_shape: Tuple[int, ...]
 ) -> StateDict:
     """Reshape the weights and bias for a linear layer in a torch dict to a new shape."""

--- a/src/levanter/models/backpack.py
+++ b/src/levanter/models/backpack.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional, Type, Union
 
@@ -14,7 +13,6 @@ import haliax.jax_utils
 import haliax.nn as hnn
 from haliax import Axis, AxisSpec, NamedArray
 from haliax.jax_utils import named_call
-from haliax.util import ensure_tuple
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, LmWithHfSerializationMixin
 from levanter.compat.torch_serialization import (
@@ -22,7 +20,6 @@ from levanter.compat.torch_serialization import (
     StateDictSerializationMixin,
     apply_prefix,
     flatten_linear_layer,
-    reshape_mlp_linear_layer,
     unflatten_linear_layer,
 )
 from levanter.models.gpt2 import ACT2FN, Gpt2Config, Gpt2Embeddings, Gpt2Transformer
@@ -131,14 +128,13 @@ class BackpackMlp(eqx.Module, StateDictSerializationMixin):
 
     def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> "BackpackMlp":
         d = {}
-        out_dims = tuple(x.size for x in ensure_tuple(self.c_proj.Out))
         d.update(
-            reshape_mlp_linear_layer(state_dict, apply_prefix(prefix, "c_proj"), (self.c_proj.In.size,), out_dims)
+            unflatten_linear_layer(
+                apply_prefix(prefix, "c_proj"), state_dict, self.c_proj, out_dims_first_in_dict=False
+            )
         )
         d.update(
-            reshape_mlp_linear_layer(
-                state_dict, apply_prefix(prefix, "c_fc"), (self.c_fc.In.size,), (self.c_fc.Out.size,)
-            )
+            unflatten_linear_layer(apply_prefix(prefix, "c_fc"), state_dict, self.c_fc, out_dims_first_in_dict=False)
         )
         return super().from_state_dict(d, prefix)
 
@@ -146,18 +142,8 @@ class BackpackMlp(eqx.Module, StateDictSerializationMixin):
         my_dict: StateDict = {}
         super().update_state_dict(my_dict, prefix)
 
-        out_dims = tuple(x.size for x in ensure_tuple(self.c_proj.Out))
-
-        my_dict.update(
-            reshape_mlp_linear_layer(
-                my_dict, apply_prefix(prefix, "c_proj"), (self.c_proj.In.size,), (math.prod(out_dims),)
-            )
-        )
-        my_dict.update(
-            reshape_mlp_linear_layer(
-                my_dict, apply_prefix(prefix, "c_fc"), (self.c_fc.In.size,), (self.c_fc.Out.size,)
-            )
-        )
+        my_dict.update(flatten_linear_layer(apply_prefix(prefix, "c_proj"), self.c_proj, out_dims_first_in_dict=False))
+        my_dict.update(flatten_linear_layer(apply_prefix(prefix, "c_fc"), self.c_fc, out_dims_first_in_dict=False))
 
         state_dict.update(my_dict)
         return state_dict
@@ -217,11 +203,8 @@ class WeightsOnlyAttention(StateDictSerializationMixin, eqx.Module):
         return attn_weights
 
     def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> "WeightsOnlyAttention":
-        d = {}
-        d.update(
-            unflatten_linear_layer(
-                apply_prefix(prefix, "c_attn"), state_dict, self.c_attn, out_dims_first_in_dict=True
-            )
+        d = unflatten_linear_layer(
+            apply_prefix(prefix, "c_attn"), state_dict, self.c_attn, out_dims_first_in_dict=True
         )
         return super().from_state_dict(d, prefix)
 

--- a/src/levanter/models/mpt.py
+++ b/src/levanter/models/mpt.py
@@ -198,8 +198,8 @@ class MptMlp(eqx.Module, StateDictSerializationMixin):
     @staticmethod
     def init(Embed: Axis, Intermediate: Axis, *, key, use_bias: bool = False):
         k_fc, k_proj = jrandom.split(key, 2)
-        up_proj = hnn.Linear.init(Out=Intermediate, In=Embed, key=k_fc, use_bias=use_bias)
-        down_proj = hnn.Linear.init(Out=Embed, In=Intermediate, key=k_proj, use_bias=use_bias)
+        up_proj = hnn.Linear.init(Out=Intermediate, In=Embed, key=k_fc, use_bias=use_bias, out_first=True)
+        down_proj = hnn.Linear.init(Out=Embed, In=Intermediate, key=k_proj, use_bias=use_bias, out_first=True)
         return MptMlp(up_proj=up_proj, down_proj=down_proj)
 
     @named_call
@@ -208,34 +208,6 @@ class MptMlp(eqx.Module, StateDictSerializationMixin):
         hidden_states = hnn.gelu(hidden_states, approximate=False)
         hidden_states = self.down_proj(hidden_states)
         return hidden_states
-
-    def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None):
-        # this is a bit annoying, Torch's Linear is the opposite of ours, so we need to transpose
-        ret_dict = {}
-
-        for k, v in state_dict.items():
-            if prefix is None or k.startswith(prefix):
-                if k.endswith("weight"):
-                    ret_dict[k] = v.swapaxes(-1, -2)
-                elif k.endswith("bias"):
-                    ret_dict[k] = v
-
-        return super().from_state_dict(ret_dict, prefix=prefix)
-
-    def update_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None):
-        # this is a bit annoying, Torch's Linear is the opposite of ours, so we need to transpose
-        ret_dict: StateDict = {}
-
-        super().update_state_dict(ret_dict, prefix=None)
-
-        for k, v in ret_dict.items():
-            if k.endswith("weight"):
-                state_dict[apply_prefix(prefix, k)] = v.swapaxes(-1, -2)
-            else:
-                assert k.endswith("bias")
-                state_dict[apply_prefix(prefix, k)] = v
-
-        return state_dict
 
 
 # Attention is the same as GPT-2 Attention, modulo alibi
@@ -254,8 +226,12 @@ class MptAttention(StateDictSerializationMixin, eqx.Module):
     ):
         k_c, k_proj = jrandom.split(key, 2)
         qkv = Axis("qkv", 3)
-        Wqkv = hnn.Linear.init(In=config.Embed, Out=(qkv, config.Head, config.HeadDim), key=k_c, use_bias=use_bias)
-        out_proj = hnn.Linear.init(In=(config.Head, config.HeadDim), Out=config.Embed, key=k_proj, use_bias=use_bias)
+        Wqkv = hnn.Linear.init(
+            In=config.Embed, Out=(qkv, config.Head, config.HeadDim), key=k_c, use_bias=use_bias, out_first=True
+        )
+        out_proj = hnn.Linear.init(
+            In=(config.Head, config.HeadDim), Out=config.Embed, key=k_proj, use_bias=use_bias, out_first=True
+        )
         return MptAttention(config=config, Wqkv=Wqkv, out_proj=out_proj)
 
     def __call__(
@@ -298,10 +274,7 @@ class MptAttention(StateDictSerializationMixin, eqx.Module):
         # so we need to reshape the one in the dict before forwarding to the linear
         # keep in mind that everything is vectorized in our implementation, so there's a leading num_layers dim
 
-        d = {}
-        d.update(
-            unflatten_linear_layer(apply_prefix(prefix, "Wqkv"), state_dict, self.Wqkv, out_dims_first_in_dict=True)
-        )
+        d = unflatten_linear_layer(apply_prefix(prefix, "Wqkv"), state_dict, self.Wqkv, out_dims_first_in_dict=True)
         d.update(
             unflatten_linear_layer(
                 apply_prefix(prefix, "out_proj"), state_dict, self.out_proj, out_dims_first_in_dict=True


### PR DESCRIPTION
PyTorch defaults to output-first linear layers. When I made Haliax's I made it Input-first, because gpt2's conv1d is input-first. I'm not gonna change the default now, but I figured it would be good to make it an option.

It simplifies a few things (mostly in MPT), but while I was doing it, I updated the dict serialization code to only use flatten/unflatten linear layers rather than the more confusing (imo) reshape_linear_layers code.

