### PR TITLE
Support `inference` as a non-static field in Dropout and other fields.

### DIFF
--- a/src/levanter/grad_accum.py
+++ b/src/levanter/grad_accum.py
@@ -102,7 +102,7 @@ def accumulate_gradients_sharded(
 
             with jax.named_scope("accum"):
                 loss += this_loss
-                grad = jax.tree_map(jnp.add, grad, this_grad)
+                grad = eqx.apply_updates(grad, this_grad)
                 grad = hax.shard_with_axis_mapping(grad, parameter_axis_mapping)
 
             return loss, grad

--- a/src/levanter/main/eval_lm.py
+++ b/src/levanter/main/eval_lm.py
@@ -67,8 +67,9 @@ def main(config: EvalLmConfig):
 
         @fsdp(parameter_axis_mapping, compute_axis_mapping)
         def compute_loss(model: LmHeadModel, example: LmExample):
+            model = eqx.tree_inference(model, True)
             model = mp.cast_to_compute(model)
-            return model.compute_loss(example, key=None, inference=True)
+            return model.compute_loss(example, key=None)
 
         total = config.trainer.max_eval_batches
 

--- a/src/levanter/main/lora_lm.py
+++ b/src/levanter/main/lora_lm.py
@@ -109,9 +109,9 @@ def main(config: LoraLmConfig):
         del hf_model
         del combined_model
 
-        def compute_loss(base_model, adapter_model, example: LmExample, inference, key=None):
+        def compute_loss(base_model, adapter_model, example: LmExample, key=None):
             model = combine_lora_params(base_model, lora_params=adapter_model)
-            return model.compute_loss(example, inference=inference, key=key).scalar()
+            return model.compute_loss(example, key=key).scalar()
 
         # Our trainer is a wrapper around the optimizer and compute_loss function that handles checkpointing and fsdp
         trainer = Trainer(config.trainer, optimizer, functools.partial(compute_loss, base_model))

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -92,8 +92,8 @@ def main(config: TrainLmConfig):
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
 
-    def compute_loss(model: LmHeadModel, example: LmExample, inference, key=None):
-        return model.compute_loss(example, inference=inference, key=key).scalar()
+    def compute_loss(model: LmHeadModel, example: LmExample, key=None):
+        return model.compute_loss(example, key=key).scalar()
 
     optimizer = config.optimizer.build(config.trainer.num_train_steps)
 
@@ -154,7 +154,7 @@ def main(config: TrainLmConfig):
         )
         def compute_log_probs(model, example: LmExample):
             model = trainer.mp.cast_to_compute(model)
-            logprobs = model.compute_loss(example, inference=True, key=None, reduction=None)
+            logprobs = model.compute_loss(example, key=None, reduction=None)
             # roll forward to get the loss for each predicted token
             logprobs = hax.roll(logprobs, 1, Pos)
             return logprobs.rearrange((EvalBatch, Pos)).array

--- a/src/levanter/main/viz_logprobs.py
+++ b/src/levanter/main/viz_logprobs.py
@@ -70,8 +70,9 @@ def main(config: VizGpt2Config):
 
         @fsdp(parameter_axis_mapping, compute_axis_mapping)
         def compute_log_probs(model: LmHeadModel, example: LmExample):
+            model = eqx.tree_inference(model, True)
             model = mp.cast_to_compute(model)
-            logprobs = model.compute_loss(example, inference=True, key=None, reduction=None)
+            logprobs = model.compute_loss(example, reduction=None)
             # roll forward to get the loss for each predicted token
             logprobs = hax.roll(logprobs, 1, Pos)
             return logprobs.rearrange((EvalBatch, Pos)).array

--- a/src/levanter/models/backpack.py
+++ b/src/levanter/models/backpack.py
@@ -399,9 +399,7 @@ class BackpackLMHeadModel(eqx.Module, LmWithHfSerializationMixin):
         )
 
     @named_call
-    def __call__(
-        self, input_ids: NamedArray, attn_mask: Optional[AttnMask] = None, *, key=None
-    ) -> NamedArray:
+    def __call__(self, input_ids: NamedArray, attn_mask: Optional[AttnMask] = None, *, key=None) -> NamedArray:
         k_embed, k_transformer, k_senses, k_sa = haliax.jax_utils.maybe_rng_split(key, 4)
 
         # Compute contextualization weights
@@ -413,9 +411,7 @@ class BackpackLMHeadModel(eqx.Module, LmWithHfSerializationMixin):
 
         ## Compute sense vectors
         sense_input_embeds = self.embeddings.embed_input_ids(input_ids)  # (seq, embed
-        sense_vectors = self.sense_net.sense_embed(
-            sense_input_embeds, key=k_senses
-        )  # (seq, senses, embed)
+        sense_vectors = self.sense_net.sense_embed(sense_input_embeds, key=k_senses)  # (seq, senses, embed)
         sense_vectors = sense_vectors.rename({self.Pos: self.config.KeyPos})
 
         ## Weight-and-sum

--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -473,7 +473,6 @@ class LlamaLMHeadModel(eqx.Module, LmHeadModel[LlamaConfig], StateDictSerializat
         input_ids: NamedArray,
         attn_mask: Optional[NamedArray] = None,
         *,
-        inference: bool = False,
         key=None,
     ) -> NamedArray:
         """

--- a/src/levanter/models/lm_model.py
+++ b/src/levanter/models/lm_model.py
@@ -69,9 +69,7 @@ class LmHeadModel(Generic[LmConfigT], abc.ABC):
         pass
 
     @abc.abstractmethod
-    def __call__(
-        self, input_ids: NamedArray, attn_mask: Optional[NamedArray] = None, *, key=None
-    ) -> NamedArray:
+    def __call__(self, input_ids: NamedArray, attn_mask: Optional[NamedArray] = None, *, key=None) -> NamedArray:
         pass
 
     @abc.abstractmethod

--- a/src/levanter/models/lm_model.py
+++ b/src/levanter/models/lm_model.py
@@ -70,7 +70,7 @@ class LmHeadModel(Generic[LmConfigT], abc.ABC):
 
     @abc.abstractmethod
     def __call__(
-        self, input_ids: NamedArray, attn_mask: Optional[NamedArray] = None, *, inference: bool, key=None
+        self, input_ids: NamedArray, attn_mask: Optional[NamedArray] = None, *, key=None
     ) -> NamedArray:
         pass
 
@@ -86,7 +86,6 @@ class LmHeadModel(Generic[LmConfigT], abc.ABC):
         self,
         example: LmExample,
         *,
-        inference: bool,
         key=None,
         reduction: Optional[hax.ReductionFunction] = hax.mean,
         reduction_axis: Optional[hax.AxisSelection] = None,
@@ -96,7 +95,7 @@ class LmHeadModel(Generic[LmConfigT], abc.ABC):
         across the reduction axis (with reduction_axis=None meaning all axes). If reduction is None, the loss is not
         reduced, and the result is a named array with axes (*batch axes, sequence_length).
         """
-        logits = self(example.tokens, example.attn_mask, inference=inference, key=key)
+        logits = self(example.tokens, example.attn_mask, key=key)
         target_y = hax.nn.one_hot(example.targets, self.Vocab, dtype=logits.dtype)
         return cross_entropy_loss(
             logits, self.Vocab, target_y, reduction, reduction_axis=reduction_axis, where=example.loss_mask

--- a/src/levanter/models/mpt.py
+++ b/src/levanter/models/mpt.py
@@ -402,10 +402,9 @@ class MptLmHeadModel(eqx.Module, LmWithHfSerializationMixin):
         return MptLmHeadModel(wte, transformer, config)
 
     @named_call
-    def __call__(self, input_ids: NamedArray, attn_mask: Optional[AttnMask], *, inference, key=None) -> NamedArray:
+    def __call__(self, input_ids: NamedArray, attn_mask: Optional[AttnMask], *, key=None) -> NamedArray:
         # TODO: add back in dropout
         del key
-        del inference
         hidden_states = self.wte.embed(input_ids)
         hidden_states = self.transformer(hidden_states, attention_mask=attn_mask)
         output_logits = self.wte.unembed(hidden_states)

--- a/src/levanter/trainer.py
+++ b/src/levanter/trainer.py
@@ -270,10 +270,12 @@ class Trainer:
         from levanter import callbacks
 
         if eval_loader and (self.config.max_eval_batches is None or self.config.max_eval_batches > 0):
+
             @eqx.filter_jit
             def eval_loss(model, *batch, **batch_kwargs):
                 model = eqx.tree_inference(model, True)
                 return self.loss_fn(model, *batch, **batch_kwargs, key=None)
+
             self.add_hook(
                 callbacks.compute_validation_loss(eval_loss, eval_loader, max_batches=self.config.max_eval_batches),
                 every=self.config.steps_per_eval,

--- a/src/levanter/trainer.py
+++ b/src/levanter/trainer.py
@@ -234,7 +234,7 @@ class Trainer:
             # TODO: refactor logging
             wandb.log({"throughput/loading_time": loading_time()}, step=state.step)
 
-            info = self.train_step(state, example, inference=False)
+            info = self.train_step(state, example)
             state = info.state
 
             if run_hooks:
@@ -270,7 +270,10 @@ class Trainer:
         from levanter import callbacks
 
         if eval_loader and (self.config.max_eval_batches is None or self.config.max_eval_batches > 0):
-            eval_loss = functools.partial(self.loss_fn, inference=True, key=None)
+            @eqx.filter_jit
+            def eval_loss(model, *batch, **batch_kwargs):
+                model = eqx.tree_inference(model, True)
+                return self.loss_fn(model, *batch, **batch_kwargs, key=None)
             self.add_hook(
                 callbacks.compute_validation_loss(eval_loss, eval_loader, max_batches=self.config.max_eval_batches),
                 every=self.config.steps_per_eval,
@@ -310,6 +313,7 @@ class Trainer:
             donate_args=(True, True),
         )
         def fn(model, opt_state, *batch, **batch_kwargs):
+            model = eqx.tree_inference(model, False)
             loss, grads = accumulate_gradients_sharded(
                 self.loss_fn, self.TrainBatch, self.config.per_device_parallelism, self.parameter_axis_mapping
             )(model, *batch, **batch_kwargs)

--- a/tests/gpt2_test.py
+++ b/tests/gpt2_test.py
@@ -34,10 +34,8 @@ def test_gradient_checkpointing():
 
         causal_mask = hax.nn.attention.causal_mask(config.Pos, config.KeyPos)
 
-        a1 = model(input_ids, inference=False, key=key, attn_mask=causal_mask)
-        if num_blocks == 4:
-            print(jax.make_jaxpr(lambda ids: model(ids, inference=True, key=key, attn_mask=causal_mask))(input_ids))
-        a2 = model_checkpoint(input_ids, inference=False, key=key, attn_mask=causal_mask)
+        a1 = model(input_ids, key=key, attn_mask=causal_mask)
+        a2 = model_checkpoint(input_ids, key=key, attn_mask=causal_mask)
 
         assert hax.all(hax.isclose(a1, a2, rtol=1e-4, atol=1e-5)), f"failed with num_blocks={num_blocks}"
 

--- a/tests/gpt2_test.py
+++ b/tests/gpt2_test.py
@@ -1,6 +1,5 @@
 import dataclasses
 
-import jax
 import jax.numpy as jnp
 from jax.random import PRNGKey
 

--- a/tests/test_levanter_hf_consistency.py
+++ b/tests/test_levanter_hf_consistency.py
@@ -1,3 +1,4 @@
+import equinox
 import numpy as onp
 import transformers
 from jax.random import PRNGKey
@@ -78,6 +79,8 @@ def test_hf_gpt2_consistency():
 
 def _compare_models_output(model_1, model_2):
     import torch
+    model_1 = equinox.tree_inference(model_1, True)
+    model_2 = equinox.tree_inference(model_2, True)
 
     input = hax.random.randint(PRNGKey(0), model_1.Pos, 0, model_1.Vocab.size)
     out_1, out_2 = None, None
@@ -87,7 +90,7 @@ def _compare_models_output(model_1, model_2):
 
         def compute(input):
             return hax.nn.softmax(
-                model_1(input, inference=True, key=None, attn_mask=attn_mask),
+                model_1(input, key=None, attn_mask=attn_mask),
                 axis=model_1.Vocab,
             )
 

--- a/tests/test_levanter_hf_consistency.py
+++ b/tests/test_levanter_hf_consistency.py
@@ -79,6 +79,7 @@ def test_hf_gpt2_consistency():
 
 def _compare_models_output(model_1, model_2):
     import torch
+
     model_1 = equinox.tree_inference(model_1, True)
     model_2 = equinox.tree_inference(model_2, True)
 

--- a/tests/test_mpt.py
+++ b/tests/test_mpt.py
@@ -1,7 +1,7 @@
 import tempfile
 
-import jax
 import equinox as eqx
+import jax
 import numpy as np
 import pytest
 from jax.random import PRNGKey

--- a/tests/test_mpt.py
+++ b/tests/test_mpt.py
@@ -1,6 +1,7 @@
 import tempfile
 
 import jax
+import equinox as eqx
 import numpy as np
 import pytest
 from jax.random import PRNGKey
@@ -59,12 +60,12 @@ def test_mpt_nano_compare(use_bias):
 
     Vocab = haliax.Axis("vocab", vocab_size)
     lev_model = MptLmHeadModel.init(Vocab, lev_config, key=PRNGKey(0))
+    lev_model = eqx.tree_inference(lev_model, True)
     lev_model = lev_model.from_state_dict(loaded_checkpoint)
 
     hax_input = haliax.named(input, lev_config.Pos)
     causal_mask = haliax.nn.attention.causal_mask(lev_config.Pos, lev_config.KeyPos)
-    with jax.disable_jit():
-        lev_out = lev_model(hax_input, causal_mask, inference=True, key=None).array
+    lev_out = lev_model(hax_input, causal_mask).array
 
     np.testing.assert_allclose(torch_out, np.array(lev_out), atol=1e-3, rtol=1e-3)
 


### PR DESCRIPTION
Equinox supports an `inference` field on modules rather than passing around an `inference` arg around everywhere.

It will simplify adding dropout to lora. It will make #287 easier.