### PR TITLE
Fix MPT: set alibi to True and jnp.concatenate()

### DIFF
--- a/src/levanter/models/mpt.py
+++ b/src/levanter/models/mpt.py
@@ -46,7 +46,7 @@ class MptAttentionConfig:
     clip_qkv: Optional[float] = None
     softmax_scale: Optional[float] = None
     qk_ln: bool = False
-    alibi: bool = False
+    alibi: bool = True
     alibi_bias_max: Optional[int] = 8
 
     def __post_init__(self):
@@ -457,7 +457,7 @@ def _mpt_alibi_gen_slopes(n_heads, alibi_bias_max=8):
     m = m * (alibi_bias_max / _n_heads)
     slopes = 1.0 / jnp.power(2, m)
     if _n_heads != n_heads:
-        slopes = jnp.concat([slopes[1::2], slopes[::2]])[:n_heads]
+        slopes = jnp.concatenate([slopes[1::2], slopes[::2]])[:n_heads]
     return slopes
 
 


### PR DESCRIPTION
I encountered two issues when running a training job with `mpt_7b_continued`:
1. alibi is set to be False by default, but there's an assertion to require alibi during training:

```
File "/home/ivan/levanter/src/levanter/main/train_lm.py", line 118, in <lambda>
    state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))
  File "/home/ivan/levanter/src/levanter/models/lm_model.py", line 44, in build
    return self.model_type.init(Vocab, self, key=key)  # type: ignore
  File "/home/ivan/levanter/src/levanter/models/mpt.py", line 406, in init
    assert config.attn_config.alibi, "alibi attention is required for now"
jax._src.traceback_util.UnfilteredStackTrace: AssertionError: alibi attention is required for now
```

2. In `_mpt_alibi_gen_slopes` it uses `jnp.concat`, but that seems to be deprecated and replaced with [jnp.concatenate](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.concatenate.html)
```
File "/home/ivan/levanter/src/levanter/models/mpt.py", line 349, in __call__
    bias = _mpt_build_alibi_bias(self.config.Head, self.config.KeyPos, self.config.attn_config.alibi_bias_max)
  File "/home/ivan/levanter/src/levanter/models/mpt.py", line 467, in _mpt_build_alibi_bias
    slopes = _mpt_alibi_gen_slopes(Heads.size, alibi_bias_max)
  File "/home/ivan/levanter/src/levanter/models/mpt.py", line 460, in _mpt_alibi_gen_slopes
    slopes = jnp.concat([slopes[1::2], slopes[::2]])[:n_heads]
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/deprecations.py", line 53, in getattr
    raise AttributeError(f"module {module!r} has no attribute {name!r}")
AttributeError: module 'jax.numpy' has no attribute 'concat'
```

Here's a training job of 7B: https://wandb.ai/stanford-mercury/levanter/runs/l543zc05