### PR TITLE
Improve Llama's training throughput

### DIFF
--- a/config/llama2_7b.yaml
+++ b/config/llama2_7b.yaml
@@ -7,7 +7,6 @@ data:
   tokenizer: "meta-llama/Llama-2-70b-hf"
 model:
   type: llama
-  upcast_attn: false
 # TODO: uncomment this once we resolve the resource exhaustion issue
 # initialize_from_hf: "meta-llama/Llama-2-7b-hf"
 # use_hf_model_config: true

--- a/config/llama2_7b.yaml
+++ b/config/llama2_7b.yaml
@@ -7,6 +7,7 @@ data:
   tokenizer: "meta-llama/Llama-2-70b-hf"
 model:
   type: llama
+  upcast_attn: false
 # TODO: uncomment this once we resolve the resource exhaustion issue
 # initialize_from_hf: "meta-llama/Llama-2-7b-hf"
 # use_hf_model_config: true

--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -55,7 +55,7 @@ class LlamaConfig(HFCompatConfig):
     activation_function: str = "silu"
     initializer_range: float = 0.02
     layer_norm_epsilon: float = 1e-5
-    upcast_attn: bool = True
+    upcast_attn: bool = False
 
     gradient_checkpointing: bool = True
     gradient_checkpointing_block_size: int = 5

--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -268,8 +268,7 @@ class LlamaAttention(StateDictSerializationMixin, eqx.Module):
     def __call__(self, x: NamedArray, mask: Optional[NamedArray], *, key=None) -> NamedArray:
         key_q, key_k, key_v, key_o = maybe_rng_split(key, 4)
 
-        # reordering the qkv matmul for better training throughput
-        # original: batch, position, heads, head_size
+        # reorder heads and position for better training throughput
         q = self.q_proj(x, key=key_q).rearrange((..., "heads", "position", "head_size"))
         k = self.k_proj(x, key=key_k).rearrange((..., "heads", "position", "head_size"))
         v = self.v_proj(x, key=key_v).rearrange((..., "heads", "position", "head_size"))

--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -269,9 +269,10 @@ class LlamaAttention(StateDictSerializationMixin, eqx.Module):
         key_q, key_k, key_v, key_o = maybe_rng_split(key, 4)
 
         # reordering the qkv matmul for better training throughput
-        q = self.q_proj(x, key=key_q).rearrange((..., "q", "heads", "position", "head_size"))
-        k = self.k_proj(x, key=key_k).rearrange((..., "k", "kv_heads", "position", "head_size"))
-        v = self.v_proj(x, key=key_v).rearrange((..., "v", "kv_heads", "position", "head_size"))
+        # original: batch, position, heads, head_size
+        q = self.q_proj(x, key=key_q).rearrange((..., "heads", "position", "head_size"))
+        k = self.k_proj(x, key=key_k).rearrange((..., "heads", "position", "head_size"))
+        v = self.v_proj(x, key=key_v).rearrange((..., "heads", "position", "head_size"))
 
         cos, sin = self.rotary_emb(seq_len=self.config.seq_len)
 


### PR DESCRIPTION
This PR adds two changes to improve Llama's training throughput:
1. Not upcast q, k and attention outputs to float 32 by default. This is consistent with the implementation in HF. As a result of this, we are able to fit a larger batch size and therefore increase training throughput. We still keep an argument for upcasting if needed. 
2. reordering the position and heads in qkv matmul for better training throughput.

## Benchmarking
Below is the comparison of the training throughput before/after the changes, measured on v3-32:
- Before changes: 23.5K
- Turns off upcasting: 26.7K
- Reorder qkv: 27.0K

<img width="200" alt="image" src="https://github.com/stanford-crfm/levanter/assets/8097756/6a4deef7-4852-4635-a18e-bde2843a97f9">

Below is the comparison of Llama's training throuhgput after the changes, vs GPT2-7B and MPT-7B:
- GPT-2 7B: 28.3K
- Llama-2 7B: 27.1K
- MPT 7B: 26.4K

<img width="200" alt="image" src="https://github.com/stanford-crfm/levanter/assets/8097756/60c7b585-73d7-4fc2-8f90-4aafeef1a685">


## Testing
- [x] I have validated the changes with all 8 tests in the test_llama.py