### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
   - 'Installation and Setup':
       - 'Installation.md'
       - 'Getting-Started-TPU-VM.md'
-      - 'Getting-Started-CUDA.md'
+      - 'Getting-Started-GPU.md'
   - 'User Guide':
       - 'Getting-Started-Training.md'
       - "Training-On-Your-Data.md"


### PR DESCRIPTION
The name is out-dated, which caused index error:

<img width="210" alt="image" src="https://github.com/stanford-crfm/levanter/assets/8097756/d44bccb9-2b74-4b62-8e08-9f2aa8ea57bb">
