### PR TITLE
Add weight decay masking for optimizer

### DIFF
--- a/src/levanter/trainer.py
+++ b/src/levanter/trainer.py
@@ -756,7 +756,8 @@ class OptimizerConfig:
     """fraction of training steps to use as cooldown, or steps to use. 0.0 means no cooldown"""
     lr_schedule: str = "cosine"  # constant, cosine, linear
     """a regex or a list of strings to identify where to mask weight. """
-    """For nano-GPT, this field can be set as `r"weight|token_embeddings|position_embeddings"`"""
+    """For nano-GPT, this field can be set as
+    `r".*attn.*weight|.*mlp.*weight|.*token_embeddings|.*position_embeddings"`"""
     weight_decay_modules: Optional[Union[List[str], str]] = None
 
     def build(self, num_train_steps: int) -> GradientTransformation:

--- a/src/levanter/trainer.py
+++ b/src/levanter/trainer.py
@@ -691,53 +691,6 @@ class TrainerConfig:
             self.per_device_eval_parallelism = self.per_device_parallelism
 
 
-def _build_mask(weight_decay_modules):
-
-    if weight_decay_modules is None:
-        # default masking based on dimension
-        # def _apply_on(x, key_path: str):
-        #     if is_inexact_arrayish(x):
-        #         ndim = x.ndim
-        #         if key_path.__contains__("stacked"):
-        #             # not counting the `hnn.Stacked` extra dimension
-        #             ndim -= 1
-
-        #         if ndim == 1 or ndim == 3:
-        #             # layer norms' weights have dimension 1
-        #             # Mlp biases have dimension 1 after discounting `hnn.Stacked` dimention
-        #             # `c_attn` biases have dimension as three after discounting `hnn.Stacked` dimention
-        #             # `c_proj` biases in attn have dimension as 1 after discounting `hnn.Stacked` dimention
-        #             #
-        #             # in these cases, no weight decay is applied
-
-        #             # THIS TURNS OUT INCORRECT. `attn.c_proj.weight` has dim = 3
-        #             return False
-
-        #         # otherwise, apply weight decay
-        #         return True
-        #     return False
-
-        return None
-    else:
-        # mask based on regex or module path
-        def _apply_on(x, key_path):
-            if isinstance(weight_decay_modules, str):
-                compiled_regex = re.compile(weight_decay_modules)
-                return compiled_regex.match(key_path) is not None
-            else:
-                return any(key_path.__contains__(target) for target in weight_decay_modules)
-
-    def mask_fn(model):
-        return jax.tree_util.tree_map(
-            _apply_on,
-            model,
-            leaf_key_paths(model, is_leaf=eqx.is_array),
-            is_leaf=eqx.is_array,
-        )
-
-    return mask_fn
-
-
 @dataclass
 class OptimizerConfig:
     # Config related to optimizer (always adam for now)
@@ -773,7 +726,7 @@ class OptimizerConfig:
             components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
 
             if self.weight_decay > 0:
-                components.append(optax.add_decayed_weights(self.weight_decay, _build_mask(self.weight_decay_modules)))
+                components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
 
             # - learning rate for descent
             components.append(optax.scale(-learning_rate))
@@ -783,6 +736,28 @@ class OptimizerConfig:
             return optimizer
 
         return optax.inject_hyperparams(_optimizer)(learning_rate=self.lr_scheduler(num_train_steps))
+
+    def build_weight_decay_mask(self):
+        if self.weight_decay_modules is None:
+            return None
+        else:
+            # mask based on regex or module path
+            def _apply_on(x, key_path):
+                if isinstance(self.weight_decay_modules, str):
+                    compiled_regex = re.compile(self.weight_decay_modules)
+                    return compiled_regex.match(key_path) is not None
+                else:
+                    return any(key_path.__contains__(target) for target in self.weight_decay_modules)
+
+            def mask_fn(model):
+                return jax.tree_util.tree_map(
+                    _apply_on,
+                    model,
+                    leaf_key_paths(model, is_leaf=eqx.is_array),
+                    is_leaf=eqx.is_array,
+                )
+
+            return mask_fn
 
     def lr_scheduler(self, num_train_steps):
         warmup_steps = self._convert_warmup(num_train_steps)

--- a/tests/test_weight_decay_mask.py
+++ b/tests/test_weight_decay_mask.py
@@ -58,9 +58,9 @@ def test_weight_decay_masking():
         ]
     )(model)
 
-    regex_mask = levanter.trainer._build_mask(weight_decay_modules=r"weight|token_embeddings|position_embeddings")(
-        model
-    )
+    regex_mask = levanter.trainer._build_mask(
+        weight_decay_modules=r".*attn.*weight|.*mlp.*weight|.*token_embeddings|.*position_embeddings",
+    )(model)
 
     assert eqx.tree_equal(list_string_mask, true_mask)
     assert eqx.tree_equal(regex_mask, true_mask)

--- a/tests/test_weight_decay_mask.py
+++ b/tests/test_weight_decay_mask.py
@@ -4,8 +4,8 @@ import jax.random as jrandom
 
 import haliax as hax
 
-import levanter.trainer
 from levanter.models.gpt2 import Gpt2Config
+from levanter.trainer import OptimizerConfig
 
 
 def test_weight_decay_masking():
@@ -43,11 +43,7 @@ def test_weight_decay_masking():
     gpt_config = Gpt2Config()
     Vocab = hax.Axis("vocab", 100)
     model = gpt_config.build(Vocab, key=jrandom.PRNGKey(0))
-
-    # masking using `equinox.tree_at`
-    true_mask = tree_at_mask(model)
-    # masking using list of module path
-    list_string_mask = levanter.trainer._build_mask(
+    string_list_config = OptimizerConfig(
         weight_decay_modules=[
             "attn.c_attn.weight",
             "attn.c_proj.weight",
@@ -56,11 +52,16 @@ def test_weight_decay_masking():
             "token_embeddings",
             "position_embeddings",
         ]
-    )(model)
-
-    regex_mask = levanter.trainer._build_mask(
+    )
+    regex_config = OptimizerConfig(
         weight_decay_modules=r".*attn.*weight|.*mlp.*weight|.*token_embeddings|.*position_embeddings",
-    )(model)
+    )
+    # masking using `equinox.tree_at`
+    true_mask = tree_at_mask(model)
+    # masking using list of module path
+    list_string_mask = string_list_config.build_weight_decay_mask()(model)
+
+    regex_mask = regex_config.build_weight_decay_mask()(model)
 
     assert eqx.tree_equal(list_string_mask, true_mask)
     assert eqx.tree_equal(regex_mask, true_mask)

--- a/tests/test_weight_decay_mask.py
+++ b/tests/test_weight_decay_mask.py
@@ -1,0 +1,66 @@
+import equinox as eqx
+import jax
+import jax.random as jrandom
+
+import haliax as hax
+
+import levanter.trainer
+from levanter.models.gpt2 import Gpt2Config
+
+
+def test_weight_decay_masking():
+    def tree_at_mask(params):
+        # let's mask all leaves as False
+        params = jax.tree_util.tree_map(lambda _: False, params)
+
+        def apply_weight_decay(tree):
+            # there is no weight decay performed in LayerNorms and bias
+            nodes = []
+
+            # apply on embedding
+            nodes.append(tree.embeddings.token_embeddings.array)
+            nodes.append(tree.embeddings.position_embeddings.array)
+
+            # apply on attention
+            nodes.append(tree.transformer.blocks.stacked.attn.c_attn.weight.array)
+            nodes.append(tree.transformer.blocks.stacked.attn.c_proj.weight.array)
+
+            # apply on MLP
+            nodes.append(tree.transformer.blocks.stacked.mlp.c_fc.weight.array)
+            nodes.append(tree.transformer.blocks.stacked.mlp.c_proj.weight.array)
+
+            return nodes
+
+        # apply weight decay when necessary
+        params = eqx.tree_at(
+            where=apply_weight_decay,
+            pytree=params,
+            replace_fn=lambda _: True,
+        )
+
+        return params
+
+    gpt_config = Gpt2Config()
+    Vocab = hax.Axis("vocab", 100)
+    model = gpt_config.build(Vocab, key=jrandom.PRNGKey(0))
+
+    # masking using `equinox.tree_at`
+    true_mask = tree_at_mask(model)
+    # masking using list of module path
+    list_string_mask = levanter.trainer._build_mask(
+        weight_decay_modules=[
+            "attn.c_attn.weight",
+            "attn.c_proj.weight",
+            "mlp.c_fc.weight",
+            "mlp.c_proj.weight",
+            "token_embeddings",
+            "position_embeddings",
+        ]
+    )(model)
+
+    regex_mask = levanter.trainer._build_mask(weight_decay_modules=r"weight|token_embeddings|position_embeddings")(
+        model
+    )
+
+    assert eqx.tree_equal(list_string_mask, true_mask)
+    assert eqx.tree_equal(regex_mask, true_mask)


### PR DESCRIPTION
Hi,

Thanks for the awesome library.

I've been training GPT models using Levanter. As noted from nanoGPT repo, weight decay masking is applied on the weights of transformers and embeddings excepts layer norms and biases. 

Since Levanter does not support this yet, I try to make one in this PR.  I added mask parameter `weight_decay_mask` for `OptimizerConfig.build` that allows to customize maskings. 

Currently, I use `equinox.tree_at` to select which nodes of PyTree to apply the weight decay. I wonder if there is a better way.
