### PR TITLE
Fixes bug in LoraConfig

### DIFF
--- a/src/levanter/lora.py
+++ b/src/levanter/lora.py
@@ -500,12 +500,10 @@ def to_hf_config(config: LoraConfig, base_model_name_or_path: Optional[str] = No
     return {
         "base_model_name_or_path": base_model_name_or_path,
         "bias": "none",  # TODO: support bias
-        "enable_lora": None,
         "fan_in_fan_out": False,  # TODO: support fan_in_fan_out
         "inference_mode": True,  # TODO: support inference_mode
         "lora_alpha": config.alpha,
         "lora_dropout": 0.00,  # TODO: support dropout
-        "merge_weights": False,
         "modules_to_save": None,  # TODO: support modules_to_save?
         "peft_type": "LORA",
         "r": config.r,


### PR DESCRIPTION
Removes two unnecessary keys when converting into hf lora config.
* `enable_lora`
* `merge_weights`

I don't think these two keys exists in the huggingface PEFT package, so having these keys will cause errors.

Reference:
* https://github.com/huggingface/peft/blob/v0.7.1/src/peft/config.py#L83
* https://huggingface.co/docs/peft/v0.7.1/en/package_reference/config#peft.PeftConfig
* https://huggingface.co/docs/peft/package_reference/lora#peft.LoraConfig