### PR TITLE
Bugfix: GQA with FA

### DIFF
--- a/src/levanter/models/flash_attention.py
+++ b/src/levanter/models/flash_attention.py
@@ -304,16 +304,16 @@ def _flash_attention_backward(
             dAttn_ij = p_ij * (dP_ij - D_i)
             dAttn_ij = dAttn_ij.astype(dQ_i.dtype)
 
-            pdO = hax.dot(QPos.name, p_ij, dO_i).astype(dV_j.dtype)
-            dAq = hax.dot(QPos.name, dAttn_ij, q_i).astype(dK_j.dtype)
+            dV_ji = hax.dot(QPos.name, p_ij, dO_i).astype(dV_j.dtype)
+            dK_ji = hax.dot(QPos.name, dAttn_ij, q_i).astype(dK_j.dtype)
 
             # GQA-specific: eliminate unnecessary axes (e.g. 'q_heads_per_group')
-            unnecessary_axes = hax.eliminate_axes(pdO.axes, v.axes)
-            pdO = hax.sum(pdO, unnecessary_axes)
-            dAq = hax.sum(dAq, unnecessary_axes)
+            unnecessary_axes = hax.eliminate_axes(dV_ji.axes, v.axes)
+            dV_ji = hax.sum(dV_ji, unnecessary_axes)
+            dK_ji = hax.sum(dK_ji, unnecessary_axes)
 
-            dV_j = dV_j + pdO
-            dK_j = dK_j + dAq
+            dV_j = dV_j + dV_ji
+            dK_j = dK_j + dK_ji
 
             dQ_i = dQ_i + hax.dot(KPos.name, dAttn_ij, k_j).astype(dQ.dtype)
             # dQ[i*block_size:(i+1)*block_size] = dQi

--- a/src/levanter/models/flash_attention.py
+++ b/src/levanter/models/flash_attention.py
@@ -307,6 +307,11 @@ def _flash_attention_backward(
             dV_j = dV_j + hax.dot(QPos.name, p_ij, dO_i).astype(dV_j.dtype)
             dK_j = dK_j + hax.dot(QPos.name, dAttn_ij, q_i).astype(dK_j.dtype)
 
+            # GQA-specific: eliminate unnecessary axes (e.g. 'q_heads_per_group')
+            unnecessary_axes = hax.eliminate_axes(dV_j.axes, v.axes)
+            dV_j = hax.sum(dV_j, unnecessary_axes)
+            dK_j = hax.sum(dK_j, unnecessary_axes)
+
             dQ_i = dQ_i + hax.dot(KPos.name, dAttn_ij, k_j).astype(dQ.dtype)
             # dQ[i*block_size:(i+1)*block_size] = dQi
             dQ = dQ.updated_slice({QPos: i * block_size}, dQ_i)

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -3,6 +3,7 @@ import functools
 import equinox
 import jax.numpy as jnp
 import jax.random as jrandom
+import pytest
 
 import haliax as hax
 import haliax.nn as hnn
@@ -55,6 +56,40 @@ def test_grad_attention():
     q = hax.random.normal(jrandom.PRNGKey(0), (QPos, Key))
     k = hax.random.normal(jrandom.PRNGKey(1), (KPos, Key))
     v = hax.random.normal(jrandom.PRNGKey(2), (KPos, Key))
+
+    @equinox.filter_value_and_grad
+    def d_attn(qkv, fn):
+        q, k, v = qkv
+        x_out = fn(KPos, Key, q, k, v, mask=mask)
+        return (x_out * x_out).sum().scalar()
+
+    hax_val, (hax_dq, hax_dk, hax_dv) = d_attn((q, k, v), hnn.attention.dot_product_attention)
+    fa_val, (fa_dq, fa_dk, fa_dv) = d_attn((q, k, v), functools.partial(flash_attention, QPos, inference=True))
+
+    assert jnp.allclose(hax_val, fa_val, atol=1e-4, rtol=1e-4)
+    assert hax_dq.axes == fa_dq.axes
+    assert hax_dk.axes == fa_dk.axes
+    assert hax_dv.axes == fa_dv.axes
+
+    assert jnp.allclose(hax_dq.array, fa_dq.array, atol=1e-4, rtol=1e-4)
+    assert jnp.allclose(hax_dk.array, fa_dk.array, atol=1e-4, rtol=1e-4)
+    assert jnp.allclose(hax_dv.array, fa_dv.array, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+def test_grad_group_query_attention(num_kv_heads):
+    Batch = hax.Axis("batch", 2)
+    KVHeads = hax.Axis("kv_heads", num_kv_heads)
+    QHeadsPerGroup = hax.Axis("q_heads_per_group", 4 // num_kv_heads)
+    Key = hax.Axis("Key", 8)
+    QPos = hax.Axis("QPos", BLOCK_SIZE * 2)
+    KPos = hax.Axis("KPos", BLOCK_SIZE * 2)
+
+    mask = hax.nn.attention.causal_mask(QPos, KPos)
+
+    q = hax.random.normal(jrandom.PRNGKey(0), (Batch, KVHeads, QHeadsPerGroup, QPos, Key))
+    k = hax.random.normal(jrandom.PRNGKey(1), (Batch, KVHeads, KPos, Key))
+    v = hax.random.normal(jrandom.PRNGKey(2), (Batch, KVHeads, KPos, Key))
 
     @equinox.filter_value_and_grad
     def d_attn(qkv, fn):

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -1,5 +1,6 @@
 import tempfile
 
+import equinox as eqx
 import jax
 import numpy as np
 import pytest
@@ -161,6 +162,21 @@ def test_llama_attention(use_flash, num_kv_heads):
     ).all(), f"{hf_out[0]} != {out}"
 
 
+@pytest.mark.parametrize("use_flash", [True, False])
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+def test_llama_attention_bwd(use_flash, num_kv_heads):
+    config = _get_llama_config(use_flash=use_flash, num_kv_heads=num_kv_heads)
+
+    attention = LlamaAttention.init(config=config, key=random.PRNGKey(0))
+    x, mask = _get_random_inputs(config)
+
+    def f(attention, x, mask):
+        out = attention(x, mask)
+        return hax.sum(out).scalar()
+
+    _, grads = eqx.filter_value_and_grad(f)(attention, x, mask)
+
+
 @skip_if_no_torch
 def test_llama_rms_norm():
     import torch
@@ -193,7 +209,7 @@ def test_llama_decoder_layer(num_kv_heads):
 
     state = llama_decoder_layer.to_state_dict()
     state = {k: torch.from_numpy(np.array(v)) for k, v in state.items()}
-    hf_decoder_layer = HFLlamaDecoderLayer(llama_config.to_hf_config(32000))
+    hf_decoder_layer = HFLlamaDecoderLayer(llama_config.to_hf_config(32000), layer_idx=0)
     hf_decoder_layer.load_state_dict(state, strict=True)
 
     x, mask = _get_random_inputs(llama_config)
@@ -222,6 +238,25 @@ def test_llama_lm_head_model(num_kv_heads):
     llama_model = LlamaLMHeadModel.init(Vocab=Vocab, config=llama_config, key=random.PRNGKey(0))
     out = llama_model(input_ids, mask)
     assert out.array.shape == (Batch.size, Pos.size, Vocab.size)
+
+
+@pytest.mark.parametrize("use_flash", [True, False])
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+def test_llama_lm_head_model_bwd(use_flash, num_kv_heads):
+    llama_config = _get_llama_config(use_flash=use_flash, num_kv_heads=num_kv_heads)
+    Batch = hax.Axis("batch", 2)
+    Vocab = hax.Axis("vocab", 1000)
+    Pos = llama_config.Pos
+    input_ids = hax.random.randint(random.PRNGKey(0), (Batch, Pos), 0, Vocab.size)
+    mask = hax.nn.attention.causal_mask(Pos, llama_config.KeyPos)
+
+    llama_model = LlamaLMHeadModel.init(Vocab=Vocab, config=llama_config, key=random.PRNGKey(0))
+
+    def f(llama_model, input_ids, mask):
+        out = llama_model(input_ids, mask)
+        return hax.sum(out).scalar()
+
+    _, grads = eqx.filter_value_and_grad(f)(llama_model, input_ids, mask)
 
 
 @skip_if_no_torch
@@ -297,6 +332,7 @@ def _get_llama_config(use_flash=False, num_kv_heads=4) -> LlamaConfig:
         rope_scaling=rope_scaling,
         gradient_checkpointing=False,  # disable for tests so debugging is easier
         use_flash_attention=use_flash,
+        flash_attention_block_size=8 if use_flash else None,
     )
 
 

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -162,21 +162,6 @@ def test_llama_attention(use_flash, num_kv_heads):
     ).all(), f"{hf_out[0]} != {out}"
 
 
-@pytest.mark.parametrize("use_flash", [True, False])
-@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
-def test_llama_attention_bwd(use_flash, num_kv_heads):
-    config = _get_llama_config(use_flash=use_flash, num_kv_heads=num_kv_heads)
-
-    attention = LlamaAttention.init(config=config, key=random.PRNGKey(0))
-    x, mask = _get_random_inputs(config)
-
-    def f(attention, x, mask):
-        out = attention(x, mask)
-        return hax.sum(out).scalar()
-
-    _, grads = eqx.filter_value_and_grad(f)(attention, x, mask)
-
-
 @skip_if_no_torch
 def test_llama_rms_norm():
     import torch

--- a/tests/test_mistral.py
+++ b/tests/test_mistral.py
@@ -140,6 +140,7 @@ def _get_mistral_config(use_flash=False, num_kv_heads=4) -> MistralConfig:
         num_kv_heads=num_kv_heads,
         gradient_checkpointing=False,  # disable for tests so debugging is easier
         use_flash_attention=use_flash,
+        flash_attention_block_size=8 if use_flash else None,
     )
 
 


### PR DESCRIPTION
Related issue #443 

1. Added new unit tests for llama & mistral to test backward pass for the LMHead model.
2. Newer version of huggingface transformer has a new required argument for `LlamaDecoderLayer`.

Cause of the error in FA backward:
* K,V are broadcasted over Q's axis "q_heads_per_group" during forward pass but the "un-broadcast" cannot be automatically done by the FA backward kernel.

How I fix this issue:
* Since K,V are repeated over this axis, the gradient should simply be a summation over this axis. So for dK and dV, I sum over all the axis that doesn't belong to K and V (but are present in dK_j and dV_j)