### PR TITLE
k_cross unused

### DIFF
--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -235,7 +235,7 @@ class Gpt2Block(StateDictSerializationMixin, eqx.Module):
 
     @staticmethod
     def init(config: Gpt2Config, *, key) -> "Gpt2Block":
-        k_attn, k_cross, k_mlp = jrandom.split(key, 3)
+        k_attn, k_mlp = jrandom.split(key, 2)
 
         ln_1 = hnn.LayerNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.use_bias)
         attn = Gpt2Attention.init(config, key=k_attn)


### PR DESCRIPTION
Not sure what the original `k_cross` use was, but this key now is unused in the current code. I assume it was for another model that had cross attention, but not sure! Apologies if I'm missing a nuance of how this gets implicitly passed somewhere.

(For context @dlwh, I'm currently implementing Whisper in Levanter and these mini-PRs are just different things I notice as I get familiar with the code base. Let me know if you'd prefer I just leave these or leave them to merge as part of a larger PR with a Whisper implementation to come!)