### PR TITLE
Visualization Fixes

### DIFF
--- a/src/levanter/callbacks.py
+++ b/src/levanter/callbacks.py
@@ -324,7 +324,7 @@ def compute_and_visualize_log_probs(test_data, tokenizer, log_prob_fn, html_dir:
     def compute_and_viz_log_probs(step: StepInfo):
         model = step.model
         os.makedirs(html_dir, exist_ok=True)
-        path = os.path.join(html_dir, f"step_{step}.html")
+        path = os.path.join(html_dir, f"step_{step.step}.html")
 
         viz_probs(path, model, tokenizer, log_prob_fn, test_data, max_docs=max_docs)
         # TODO: convert to generic logging

--- a/src/levanter/visualization.py
+++ b/src/levanter/visualization.py
@@ -19,7 +19,7 @@ def visualize_log_probs(tokens: List[List[str]], log_probs: np.ndarray, output_p
                               of each token in each document.
     - output_path (str): The path to the output HTML file.
     """
-    probs = np.exp(log_probs)
+    probs = np.exp(-1 * log_probs)
 
     # We encode the log probabilities as a linear gradient
     norm = cm.colors.Normalize(vmin=-10.0, vmax=0.0)


### PR DESCRIPTION
Tiny fixes I made to get visuals working appropriately while I was debugging my training runs.

1) Switch to `step.step` since StepInfo's string representation has changed.
2) `np.exp` on the Negative Log Probs rather than the Positive Log Probs to get appropriate probability.