### PR TITLE
Update export_lm_to_hf path name in instructions

### DIFF
--- a/docs/Training-On-Your-Data.md
+++ b/docs/Training-On-Your-Data.md
@@ -447,5 +447,5 @@ tokenizer = AutoTokenizer.from_pretrained("/tmp/my_exported_model")
 After training, you can run a separate script to export levanter checkpoints to Huggingface:
 
 ```bash
-python -m levanter.main.export_to_hf --config_path my_config.yaml --output_dir gs://path/to/output
+python -m levanter.main.export_lm_to_hf --config_path my_config.yaml --output_dir gs://path/to/output
 ```

--- a/docs/tutorials/Training-On-Audio-Data.md
+++ b/docs/tutorials/Training-On-Audio-Data.md
@@ -229,7 +229,7 @@ model = WhisperForConditionalGeneration.from_pretrained("WillHeld/levanter-whisp
 After training, you can run a separate script to export levanter checkpoints to Huggingface:
 
 ```bash
-python -m levanter.main.export_to_hf --config_path my_config.yaml --output_dir gs://path/to/output
+python -m levanter.main.export_lm_to_hf --config_path my_config.yaml --output_dir gs://path/to/output
 ```
 
 ### HuggingFace Inference


### PR DESCRIPTION
To match with the latest path: https://github.com/stanford-crfm/levanter/blob/main/src/levanter/main/export_lm_to_hf.py

Error Message:

```
/nlp/scr/ivanzhou/miniconda3/envs/levanter/bin/python: No module named levanter.main.export_to_hf
```