### PR TITLE
fix pre-commit checks

### DIFF
--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -19,7 +19,6 @@ import pyarrow as pa
 import regex
 from draccus import field
 from jaxtyping import PRNGKeyArray
-from tokenizers import normalizers
 
 import haliax as hax
 from haliax import Axis
@@ -366,7 +365,6 @@ class BatchTokenizer(BatchProcessor[str]):
         self._need_to_add_bos = should_append_bos
 
     def __call__(self, batch: Sequence[str]) -> BatchEncoding:
-        orig_lengths = [len(d) for d in batch]
         if self._need_to_add_bos:
             batch = [self.tokenizer.bos_token + " " + d for d in batch]
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,14 +1,12 @@
 import tempfile
 
 import jax.numpy as jnp
-from transformers import AutoTokenizer
 
 import haliax as hax
 
-from levanter.data.text import BatchTokenizer, LMDatasetConfig
+from levanter.data.text import LMDatasetConfig
 from levanter.models.lm_model import LmExample
 from levanter.models.loss import next_token_loss
-from test_utils import skip_if_hf_model_not_accessible
 
 
 def test_dont_blow_up_without_validation_set():


### PR DESCRIPTION
```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

src/levanter/data/text.py:22:1: F401 'tokenizers.normalizers' imported but unused
src/levanter/data/text.py:369:9: F841 local variable 'orig_lengths' is assigned to but never used
tests/test_text.py:4:1: F401 'transformers.AutoTokenizer' imported but unused
tests/test_text.py:8:1: F401 'levanter.data.text.BatchTokenizer' imported but unused
tests/test_text.py:11:1: F401 'test_utils.skip_if_hf_model_not_accessible' imported but unused
```