### PR TITLE
Add gemma model and test with 2b.

### DIFF
--- a/config/gemma_2b.yaml
+++ b/config/gemma_2b.yaml
@@ -1,0 +1,30 @@
+data:
+  train_urls:
+    - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_train.{1..128}-of-128.jsonl.gz"
+  validation_urls:
+    - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..1}-of-8.jsonl.gz"
+  cache_dir: "gs://wasabi-tpu-training/openwebtext-mini"
+  tokenizer: "google/gemma-2b"
+model:
+  type: gemma
+initialize_from_hf: "google/gemma-2b"
+use_hf_model_config: true
+trainer:
+  checkpointer:
+    base_path: "gs://wasabi-tpu-training/gemma-2b/"
+  tracker:
+    type: wandb
+    project: "levanter"
+    tags: ["openwebtext", "gemma"]
+
+  mp: p=bfloat16,c=bfloat16
+  train_batch_size: 16  # set for v5e-16 TPU
+  num_train_steps: 100000
+  steps_per_eval: 50
+  tensor_parallel_axes: ["mlp", "heads"]
+  fsdp_axis: "embed"
+  batch_axis: "batch"
+optimizer:
+  learning_rate: 1.2E-5  # set low for fine-tuning
+  weight_decay: 0.1
+  min_lr_ratio: 0.1

--- a/src/levanter/main/eval_lm.py
+++ b/src/levanter/main/eval_lm.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 import equinox as eqx
@@ -32,9 +32,9 @@ logger = logging.getLogger(__name__)
 class EvalLmConfig:
     checkpoint_path: Optional[str] = None
     hf_checkpoint: Optional[RepoRef] = None
-    trainer: TrainerConfig = TrainerConfig()
-    data: LMDatasetConfig = LMDatasetConfig()
-    model: LmConfig = Gpt2Config()
+    trainer: TrainerConfig = field(default_factory=TrainerConfig)
+    data: LMDatasetConfig = field(default_factory=LMDatasetConfig)
+    model: LmConfig = field(default_factory=Gpt2Config)
 
     compare_torch: bool = False
     eval_on_train: bool = False

--- a/src/levanter/main/viz_logprobs.py
+++ b/src/levanter/main/viz_logprobs.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import equinox as eqx
 import jax
@@ -28,9 +28,9 @@ logger = logging.getLogger(__name__)
 class VizGpt2Config:
     checkpoint_path: str
     path: str = "logprobs.html"
-    trainer: TrainerConfig = TrainerConfig()
-    data: LMDatasetConfig = LMDatasetConfig()
-    model: LmConfig = Gpt2Config()
+    trainer: TrainerConfig = field(default_factory=TrainerConfig)
+    data: LMDatasetConfig = field(default_factory=LMDatasetConfig)
+    model: LmConfig = field(default_factory=Gpt2Config)
 
     num_docs: int = 256
 

--- a/src/levanter/models/gemma.py
+++ b/src/levanter/models/gemma.py
@@ -1,0 +1,369 @@
+import dataclasses
+from dataclasses import dataclass
+from typing import Dict, Optional, Type, Union
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jrandom
+from jaxtyping import PRNGKeyArray
+
+import haliax as hax
+import haliax.nn as hnn
+from haliax import Axis, AxisSpec, NamedArray
+from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
+from haliax.nn.scan import Stacked
+
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
+from levanter.compat.torch_serialization import (
+    StateDict,
+    StateDictSerializationMixin,
+    apply_prefix,
+    stack_state_dict,
+    unstack_state_dict,
+)
+from levanter.logging import silence_transformer_nag
+from levanter.models.llama import (
+    LlamaAttention,
+    LlamaEmbedding,
+    LlamaMlp,
+)  # Gemma attention and MLP is identical to LLama
+from levanter.models.attention import AttentionMask
+from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.types import BlockFoldable
+from levanter.utils.py_utils import cached_classproperty
+
+
+silence_transformer_nag()
+from transformers import GemmaConfig as HfGemmaConfig  # noqa: E402
+from transformers import PretrainedConfig as HfConfig  # noqa: E402
+
+# Gemma is... very similar to Llama, so we use much of the same modeling code.
+#
+# The key differences are:
+# * Activation is changed to approximate gelu
+# * Embedding weights are tied to the LM head
+# * Gemma allows specifying a head dimension independently of the hidden and intermediate dims.
+
+
+@LmConfig.register_subclass("gemma")
+@dataclass(frozen=True)
+class GemmaConfig(HFCompatConfig):
+    """Config for GemmaModel.
+
+    Defaults are set for Gemma-2B.
+
+    Args:
+        seq_len (int, optional): maximum length of the input sequence. Defaults to 8192.
+        hidden_dim (int, optional): dimension of the hidden state. Defaults to 2048.
+        intermediate_dim (int, optional): dimension of the intermediate state. Defaults to 16384.
+        num_layers (int, optional): number of hidden layers in the Transformer encoder. Defaults to 18.
+        num_heads (int, optional): number of attention heads for each attention layer. Defaults to 8.
+        num_kv_heads (int, optional): number of attention heads for keys and values in each attention layer.
+            Setting to 1 means MQA. Setting to num_heads means MHA. Otherwise GQA.
+            Note that num_heads must be divisible by this number. Defaults to 1.
+        activation_function (str, optional): activation function for the hidden layer. Defaults to "gelu".
+        rope_scaling (Dict, ignored): dict containing the scaling configuration for the Rotary Positional Embedding.
+    """
+
+    activation_function: str = "gelu"
+    initializer_range: float = 0.02
+    layer_norm_epsilon: float = 1e-5
+
+    seq_len: int = 8192
+    hidden_dim: int = 2048
+    intermediate_dim: int = 16384
+    vocab_size: int = 256_000
+    num_layers: int = 18
+    num_heads: int = 8
+    head_dim: int = 256
+    num_kv_heads: int = 1
+    attn_dropout = 0.0
+    norm_eps = 1e-6
+
+    rope_base: int = 10_000
+    norm_embeddings: bool = True
+
+    # Attention-related config
+    upcast_attn: bool = False
+    use_flash_attention: bool = True
+    flash_attention_block_size: Optional[int] = None
+
+    gradient_checkpointing: bool = True
+    gradient_checkpointing_block_size: int = 5
+    scan_layers: bool = True
+
+    use_bias: bool = False
+    rope_scaling: Optional[dict] = None
+
+    # Axis
+    Pos = property(lambda self: Axis(name="position", size=self.seq_len))
+    KeyPos = property(lambda self: self.Pos.alias("key_position"))
+    Embed = property(lambda self: Axis(name="embed", size=self.hidden_dim))
+    Heads = property(lambda self: Axis(name="heads", size=self.num_heads))
+    KVHeads = property(lambda self: Axis(name="kv_heads", size=self.num_kv_heads))
+    Layers = property(lambda self: Axis(name="layers", size=self.num_layers))
+    Mlp = property(lambda self: Axis(name="mlp", size=self.intermediate_dim))
+    HeadSize = property(lambda self: Axis(name="head_size", size=self.hidden_dim // self.num_heads))
+
+    def __post_init__(self):
+        assert (
+            self.num_heads % self.num_kv_heads == 0
+        ), f"num_heads={self.num_heads} not divisible by num_kv_heads={self.num_kv_heads}."
+
+    @cached_classproperty
+    def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["GemmaConfig"]:  # type: ignore
+        return HFCheckpointConverter(
+            cls,  # type: ignore
+            reference_checkpoint="google/gemma-2b",
+            trust_remote_code=True,
+            HfConfigClass=HfGemmaConfig,
+        )
+
+    # The activation function specified in the Gemma HF repo is "gelu", but this is incorrect, it should
+    # be "gelu_pytorch_tanh". For backwards compatibility, HF did not change the value in the repo, but
+    # instead patches around it. We mimic this behavior and use the approximate gelu internally, and
+    # specify the approximate gelu for HF when appropriate.
+    # See https://github.com/huggingface/transformers/pull/29402 for more detail.
+    @classmethod
+    def from_hf_config(cls, hf_config: HfConfig):
+        if hf_config.hidden_activation:
+            activation_function = hf_config.hidden_activation
+        else:
+            activation_function = hf_config.hidden_act
+
+        if activation_function == "gelu_pytorch_tanh":
+            activation_function = "gelu"
+
+        assert activation_function is not None, "No activation function found in HF configuration."
+        return GemmaConfig(
+            seq_len=hf_config.max_position_embeddings,
+            activation_function=activation_function,
+            hidden_dim=hf_config.hidden_size,
+            intermediate_dim=hf_config.intermediate_size,
+            num_layers=hf_config.num_hidden_layers,
+            num_heads=hf_config.num_attention_heads,
+            num_kv_heads=hf_config.num_key_value_heads,
+            initializer_range=hf_config.initializer_range,
+            layer_norm_epsilon=hf_config.rms_norm_eps,
+            rope_base=hf_config.rope_theta,
+        )
+
+    def to_hf_config(self, vocab_size: int, config_overrides: Optional[Dict] = None) -> HfGemmaConfig:
+        """Convert to HuggingFace's GemmaConfig
+
+        Args:
+            vocab_size (int, optional): Vocabulary size of the tokenizer. Defaults to 32000.
+            config_overrides (dict, optional): Overrides for the config. Defaults to None.
+
+        Returns:
+            HfGemmaConfig: HuggingFace's GemmaConfig
+        """
+        if config_overrides is None:
+            config_overrides = {}
+
+        config = HfGemmaConfig(
+            max_position_embeddings=self.seq_len,
+            hidden_size=self.hidden_dim,
+            intermediate_size=self.intermediate_dim,
+            num_hidden_layers=self.num_layers,
+            num_attention_heads=self.num_heads,
+            num_key_value_heads=self.num_kv_heads,
+            head_dim=self.hidden_dim // self.num_heads,
+            hidden_activation=(
+                "gelu_pytorch_tanh" if self.activation_function == "gelu" else self.activation_function
+            ),
+            initializer_range=self.initializer_range,
+            rms_norm_eps=self.layer_norm_epsilon,
+            vocab_size=vocab_size,
+            **config_overrides,
+        )
+        return config
+
+    @property
+    def model_type(cls) -> Type["GemmaLMHeadModel"]:
+        return GemmaLMHeadModel
+
+
+class GemmaRMSNorm(hnn.LayerNorm):
+    """
+    Like Llama, Gemma uses an RMSNorm instead of a layer norm.
+
+    The canonical Gemma model computes the variances calculation in fp32 explicity, so
+    we do the same for compatibility.
+    """
+
+    @staticmethod
+    def init(axis: AxisSpec, eps: float = 1e-6, use_weight: bool = True, use_bias: bool = False):
+        assert use_weight, "GemmaRMSNorm does not support use_weight=False"
+        assert not use_bias, "GemmaRMSNorm does not support use_bias=True"
+
+        weight = hax.zeros(axis)
+        bias = None
+
+        return GemmaRMSNorm(axis, weight, bias, eps)
+
+    def __call__(self, x: NamedArray) -> NamedArray:
+        # Gemma's norm is calculated in fp32 explicitly
+        # See https://github.com/google/gemma_pytorch/blob/main/gemma/model.py#L173
+        dtype = x.dtype
+        x = x.astype(jnp.float32)
+
+        var = hax.mean(hax.square(x), axis=self.axis)
+        inv = hax.rsqrt(var + self.eps)
+        out = x * inv
+        out = out * (1.0 + self.weight)
+        return out.astype(dtype)
+
+
+class GemmaDecoderLayer(StateDictSerializationMixin, eqx.Module):
+    config: GemmaConfig = eqx.static_field()
+    self_attn: LlamaAttention
+    mlp: LlamaMlp
+    input_layernorm: GemmaRMSNorm
+    post_attention_layernorm: GemmaRMSNorm
+
+    @staticmethod
+    def init(config: GemmaConfig, *, key) -> "GemmaDecoderLayer":
+        k_attn, k_mlp = jrandom.split(key, 2)
+
+        attn = LlamaAttention.init(config, key=k_attn)
+        mlp = LlamaMlp.init(
+            config.Embed,
+            config.Mlp,
+            config.activation_function,
+            key=k_mlp,
+            use_bias=config.use_bias,
+        )
+        ln_1 = GemmaRMSNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.use_bias)
+        ln_2 = GemmaRMSNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.use_bias)
+
+        return GemmaDecoderLayer(config, attn, mlp, ln_1, ln_2)
+
+    @named_call
+    def __call__(self, x: NamedArray, mask: Optional[NamedArray | AttentionMask], *, key=None) -> NamedArray:
+        k_attn, k_mlp = maybe_rng_split(key, 2)
+        # self attention and skip connection
+        residual = x
+        x = self.input_layernorm(x)
+        attn_output = self.self_attn(x=x, mask=mask, key=k_attn)
+        x = residual + attn_output
+
+        # MLP and skip connection
+        residual = x
+        x = self.post_attention_layernorm(x)
+        mlp_output = self.mlp(x, key=k_mlp)
+        output = residual + mlp_output
+        return output
+
+
+class GemmaTransformer(StateDictSerializationMixin, eqx.Module):
+    config: GemmaConfig = eqx.static_field()
+    layers: BlockFoldable[GemmaDecoderLayer]
+    norm: GemmaRMSNorm
+
+    @staticmethod
+    def init(config: GemmaConfig, *, key) -> "GemmaTransformer":
+        S = Stacked
+        if not config.scan_layers:
+            from haliax.nn.scan import BlockSeq
+
+            S = BlockSeq
+
+        layers = S.init(config.Layers, GemmaDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+            config,
+            key=shaped_rng_split(key, config.num_layers),
+        )
+        ln_f = GemmaRMSNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.use_bias)
+
+        return GemmaTransformer(config, layers, ln_f)
+
+    @named_call
+    def __call__(self, x: NamedArray, attn_mask: Optional[NamedArray | AttentionMask], *, key) -> NamedArray:
+        keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
+        x = self.layers.fold(x, mask=attn_mask, key=keys)
+        x = self.norm(x)
+
+        return x
+
+    def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None):
+        if isinstance(self.layers, Stacked):
+            state_dict = stack_state_dict(state_dict, prefix=apply_prefix(prefix, "layers"))
+
+        out = super().from_state_dict(state_dict, prefix=prefix)
+        return out
+
+    def update_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> StateDict:
+        my_state_dict: StateDict = {}
+        super().update_state_dict(my_state_dict, prefix=prefix)
+
+        if isinstance(self.layers, Stacked):
+            stacked_dict = unstack_state_dict(my_state_dict, prefix=apply_prefix(prefix, "layers"))
+            state_dict.update(stacked_dict)
+
+        return state_dict
+
+
+class GemmaLMHeadModel(eqx.Module, LmHeadModel[GemmaConfig], StateDictSerializationMixin):
+    transformer: GemmaTransformer
+
+    # Gemma ties the weights of the embedding matrix and LM head.  Rather than
+    # use eqx.Shared which is a bit cumbersome, we juse re-use the embedding matrix
+    # as we do in GPT-2.
+    embeddings: LlamaEmbedding
+
+    @property
+    def config(self):
+        return self.transformer.config
+
+    @property
+    def vocab_size(self) -> int:
+        return self.Vocab.size
+
+    @property
+    def Vocab(self) -> Axis:
+        return self.embeddings.Vocab
+
+    @classmethod
+    def init(cls, Vocab: Axis, config: GemmaConfig, *, key) -> "GemmaLMHeadModel":
+        k_t, k_emb = jrandom.split(key, 2)
+        transformer = GemmaTransformer.init(config, key=k_t)
+        embeddings = LlamaEmbedding.init(Vocab, config, key=k_emb)
+        return GemmaLMHeadModel(transformer, embeddings)
+
+    def __call__(
+        self,
+        input_ids: NamedArray,
+        attn_mask: Optional[Union[NamedArray, AttentionMask]] = None,
+        *,
+        key=None,
+    ) -> NamedArray:
+        """
+        Args:
+            input_ids (NamedArray): [batch, position]
+                Indices of input sequence tokens in the vocabulary.
+            attn_mask (Union[NamedArray, AttentionMask], optional): [batch, position]
+                Mask to avoid performing attention on the padding token indices of the encoder input.
+                The attn_mask from training pipeline may be an AttentionMask object instead of NamedArray
+        """
+        x = self.embeddings.embed(input_ids)
+        x = self.transformer(x, attn_mask=attn_mask, key=key)
+        lm_logits = self.embeddings.unembed(x)
+        return lm_logits
+
+    def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[GemmaConfig]":
+        new_embeddings = self.embeddings.resize_embeddings(new_size, key=key)
+
+        return dataclasses.replace(self, embeddings=new_embeddings)
+
+    def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
+        """Map from Levanter model names to HF."""
+        return {"transformer": "model", "embeddings": None}
+
+    def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None):
+        return super().from_state_dict(state_dict, prefix)
+
+    def update_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> StateDict:
+        my_dict: StateDict = {}
+        super().update_state_dict(my_dict, prefix=prefix)
+        state_dict.update(my_dict)
+        return state_dict

--- a/tests/test_gemma.py
+++ b/tests/test_gemma.py
@@ -1,0 +1,256 @@
+import tempfile
+
+import equinox as eqx
+import jax
+import numpy as np
+import pytest
+import transformers
+from jax import random
+
+import haliax as hax
+
+from levanter.models.attention import AttentionMask
+from levanter.models.gemma import GemmaConfig, GemmaDecoderLayer, GemmaLMHeadModel, GemmaRMSNorm
+from levanter.utils.jax_utils import parameter_count
+from test_utils import check_load_config, check_model_works_with_seqlen, parameterize_with_configs, skip_if_no_torch
+
+
+# N.B. Gemma uses LLamaAttention directly so we skip tests for attention and rotary embeddings.
+
+@skip_if_no_torch
+def test_gemma_config():
+    # load HF config and convert to levanter config
+    hf_config = transformers.GemmaConfig.from_pretrained("google/gemma-2b")
+    gemma_config = GemmaConfig.from_hf_config(hf_config)
+
+    # convert back to HF config
+    config_overrides = {
+        "_name_or_path": hf_config._name_or_path,
+        "architectures": hf_config.architectures,
+        "torch_dtype": hf_config.torch_dtype,
+    }
+    new_hf_config = gemma_config.to_hf_config(
+        vocab_size=hf_config.vocab_size,
+        config_overrides=config_overrides,
+    )
+
+    # Gemma has some weird patched behavior in the HF configuration to deal with the original
+    # version not using an approximate gelu layer: the configuration has both `hidden_act` and
+    # `hidden_activation` fields. We don't touch the `hidden_act` field, and it is overridden
+    # by `hidden_activation`.
+    # See https://github.com/huggingface/transformers/pull/29402 for more info.
+    assert gemma_config.activation_function == "gelu"
+    assert new_hf_config.hidden_activation == "gelu_pytorch_tanh"
+    assert new_hf_config.hidden_act == "gelu_pytorch_tanh"
+
+    # assert the content in new_hf_config is the same as hf_config
+    for k in new_hf_config.__dict__.keys():
+        if k in ["_commit_hash", "transformers_version"]:
+            continue
+
+        if k in ["hidden_act", "hidden_activation"]:
+            continue
+
+        assert getattr(new_hf_config, k) == getattr(
+            hf_config, k
+        ), f"{k} {getattr(new_hf_config, k)} != {getattr(hf_config, k)}"
+
+
+def test_gemma_param_counts_dont_change_with_seqlen():
+    model = GemmaLMHeadModel.init(hax.Axis("v", 2048), _get_gemma_config(seq_len=128), key=random.PRNGKey(0))
+    model2 = GemmaLMHeadModel.init(hax.Axis("v", 2048), _get_gemma_config(seq_len=256), key=random.PRNGKey(0))
+    assert parameter_count(model) == parameter_count(model2)
+
+
+@skip_if_no_torch
+def test_gemma_rms_norm():
+    import torch
+    from transformers.models.gemma.modeling_gemma import GemmaRMSNorm as HFGemmaRMSNorm
+
+    config = _get_gemma_config()
+    ln = GemmaRMSNorm.init(config.Embed, eps=config.layer_norm_epsilon, use_bias=config.use_bias)
+    hf_ln = HFGemmaRMSNorm(config.Embed.size, eps=config.layer_norm_epsilon)
+
+    x, _ = _get_random_inputs(config)
+    x_torch = torch.from_numpy(np.array(x.array))
+
+    out = ln(x)
+    hf_out = hf_ln(x_torch)
+
+    assert np.isclose(
+        hf_out.detach().cpu().numpy(), np.array(out.array), rtol=1e-6, atol=1e-6
+    ).all(), f"{hf_out} != {out}"
+
+
+@skip_if_no_torch
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+def test_gemma_decoder_layer(num_kv_heads):
+    import torch
+    from transformers.models.gemma.modeling_gemma import GemmaDecoderLayer as HFGemmaDecoderLayer
+
+    gemma_config = _get_gemma_config(num_kv_heads=num_kv_heads)
+    key = random.PRNGKey(0)
+    gemma_decoder_layer = GemmaDecoderLayer.init(config=gemma_config, key=key)
+
+    state = gemma_decoder_layer.to_state_dict()
+    state = {k: torch.from_numpy(np.array(v)) for k, v in state.items()}
+    hf_decoder_layer = HFGemmaDecoderLayer(gemma_config.to_hf_config(32000), layer_idx=0)
+    hf_decoder_layer.load_state_dict(state, strict=True)
+
+    x, mask = _get_random_inputs(gemma_config)
+    x_torch = torch.from_numpy(np.array(x.array))
+    batch_size = x_torch.shape[0]
+    explicit_mask = torch.from_numpy(np.array(mask.materialize(gemma_config.Pos, gemma_config.KeyPos).array))
+    mask_torch = explicit_mask.broadcast_to((batch_size, 1, -1, -1))
+    mask_torch = (mask_torch == 0).float() * -1e9
+
+    position_ids = torch.arange(gemma_config.Pos.size).reshape(1, -1)
+
+    out = gemma_decoder_layer(x, mask)
+    hf_out = hf_decoder_layer(x_torch, position_ids=position_ids, attention_mask=mask_torch)
+
+    assert np.isclose(
+        hf_out[0].detach().cpu().numpy(), np.array(out.array), rtol=1e-4, atol=1e-4
+    ).all(), f"{hf_out[0]} != {out}"
+
+
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+def test_gemma_lm_head_model(num_kv_heads):
+    gemma_config = _get_gemma_config(num_kv_heads=num_kv_heads)
+    Batch = hax.Axis("batch", 2)
+    Vocab = hax.Axis("vocab", 1000)
+    Pos = gemma_config.Pos
+    input_ids = hax.random.randint(random.PRNGKey(0), (Batch, Pos), 0, Vocab.size)
+    mask = AttentionMask.causal()
+
+    gemma_model = GemmaLMHeadModel.init(Vocab=Vocab, config=gemma_config, key=random.PRNGKey(0))
+    out = gemma_model(input_ids, mask)
+    assert out.array.shape == (Batch.size, Pos.size, Vocab.size)
+
+
+@pytest.mark.parametrize("use_flash", [True, False])
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+def test_gemma_lm_head_model_bwd(use_flash, num_kv_heads):
+    gemma_config = _get_gemma_config(use_flash=use_flash, num_kv_heads=num_kv_heads)
+    Batch = hax.Axis("batch", 2)
+    Vocab = hax.Axis("vocab", 1000)
+    Pos = gemma_config.Pos
+    input_ids = hax.random.randint(random.PRNGKey(0), (Batch, Pos), 0, Vocab.size)
+    mask = AttentionMask.causal()
+
+    gemma_model = GemmaLMHeadModel.init(Vocab=Vocab, config=gemma_config, key=random.PRNGKey(0))
+
+    def f(gemma_model, input_ids, mask):
+        out = gemma_model(input_ids, mask)
+        return hax.sum(out).scalar()
+
+    _, grads = eqx.filter_value_and_grad(f)(gemma_model, input_ids, mask)
+
+
+@skip_if_no_torch
+@pytest.mark.parametrize("scan_layers", [True, False])
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+def test_gemma_roundtrip(scan_layers, num_kv_heads):
+    import torch
+    from transformers import AutoModelForCausalLM, GemmaForCausalLM
+
+    converter = GemmaConfig.default_hf_checkpoint_converter
+
+    config = GemmaConfig(
+        seq_len=128,
+        hidden_dim=16,
+        num_heads=4,
+        num_kv_heads=num_kv_heads,
+        gradient_checkpointing=False,
+        scan_layers=scan_layers,
+    )
+    Vocab = hax.Axis("vocab", 1000)
+    hf_config = config.to_hf_config(Vocab.size)
+
+    # Make input and attn_mask
+    input = hax.random.randint(random.PRNGKey(0), config.Pos, 0, Vocab.size)
+    attn_mask = AttentionMask.causal()
+    input_torch = torch.from_numpy(np.array(input.array)).to(torch.int32).unsqueeze(0)
+
+    torch.random.manual_seed(0)
+
+    torch_model = GemmaForCausalLM(hf_config)
+    torch_model.eval()
+
+    torch_out = torch_model(input_torch)
+    torch_out = torch_out.logits[0].detach().cpu().numpy()
+    torch_out = jax.nn.softmax(torch_out, axis=-1)
+
+    tmpdir = tempfile.mkdtemp()
+    torch_model.save_pretrained(f"{tmpdir}/torch_model")
+    print(f"Saved to {tmpdir}/torch_model")
+
+    model = converter.load_pretrained(GemmaLMHeadModel, f"{tmpdir}/torch_model", resize_vocab_to_match_tokenizer=False)
+
+    def compute(input):
+        model_output = model(input, attn_mask=attn_mask)
+        return hax.nn.softmax(model_output, axis=model.Vocab)
+
+    compute = jax.jit(compute)
+    jax_out = compute(input).array
+
+    assert torch_out.shape == jax_out.shape, f"{torch_out.shape} != {jax_out.shape}"
+    assert np.isclose(torch_out, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out} != {jax_out}"
+
+    converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False)
+    torch_model2 = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/lev_model")
+    torch_model2.eval()
+
+    torch_out2 = torch_model2(input_torch)
+    torch_out2 = torch_out2.logits[0].detach().cpu().numpy()
+    torch_out2 = jax.nn.softmax(torch_out2, axis=-1)
+    assert torch_out2.shape == jax_out.shape, f"{torch_out2.shape} != {jax_out.shape}"
+    assert np.isclose(torch_out2, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out2} != {jax_out}"
+
+
+def _get_gemma_config(use_flash=False, num_kv_heads=4, seq_len=128) -> GemmaConfig:
+    rope_scaling = {
+        "type": "linear",
+        "factor": 2.0,
+    }
+    return GemmaConfig(
+        seq_len=seq_len,
+        hidden_dim=16,
+        num_heads=4,
+        num_kv_heads=num_kv_heads,
+        rope_scaling=rope_scaling,
+        gradient_checkpointing=False,  # disable for tests so debugging is easier
+        use_flash_attention=use_flash,
+        flash_attention_block_size=8 if use_flash else None,
+    )
+
+
+def _get_random_inputs(config: GemmaConfig):
+    Embed = config.Embed
+    Pos = config.Pos
+    Batch = hax.Axis("batch", 2)
+    x = hax.random.normal(random.PRNGKey(0), (Batch, Pos, Embed))
+    mask = AttentionMask.causal()
+    return x, mask
+
+
+@parameterize_with_configs("gemma*.yaml")
+def test_gemma_configs(config_file):
+    from levanter.main.train_lm import TrainLmConfig
+
+    config_class = TrainLmConfig
+
+    check_load_config(config_class, config_file)
+
+
+@pytest.mark.parametrize("num_kv_heads", [1, 2])
+def test_pass_different_length_seq(num_kv_heads):
+    config = GemmaConfig(
+        seq_len=64,
+        hidden_dim=64,
+        intermediate_dim=32,
+        num_heads=2,
+        num_kv_heads=num_kv_heads,
+        use_flash_attention=True,
+    )
+    check_model_works_with_seqlen(GemmaLMHeadModel, config, 16)


### PR DESCRIPTION
No expert on Gemma and I know it's probably less useful than Llama3, but I saw the issue open and thought I would try adding it to learn more about Levanter. Despite not reading the documentation yet, I found it really hackable!

Some notes:

* Gemma ties the embedding weights and model weights together in the HF files. I don't preserve this explicitly here, so they can diverge during fine-tuning. I'm not sure _how_ to tie weights with Haliax, but if there are some tips please let me know!
* I'm not sure if the logic I use for handling this mapping is "correct" (in the `from_state_dict` code). I found the prefix logic a bit hard to follow there.
* I adjusted the parameter dtype to bfloat16 to get training working, otherwise the model OOMs on v5e. I suspect this is the fault of the giant embedding layer for Gemma. I'm sure we can shard over the embedding layer but I will need to learn more on the 
* For testing, the roundtrip tests past, but if there was an inference tool to test with some prompts I'd feel more confident about the results. I didn't see anything off-hand.