### PR TITLE
Removes RuntimeError in cache_dataset.py when no tracker is set

### DIFF
--- a/src/levanter/main/cache_dataset.py
+++ b/src/levanter/main/cache_dataset.py
@@ -37,7 +37,9 @@ def main(args: RayCachedLMDatasetConfig):
             logger.warning(f"Skipping {split} because it is empty.")
             continue
 
-        monitors = [RichMetricsMonitor(source.num_shards), LoggingMetricsMonitor("preprocess/" + split, commit=True)]
+        monitors = [RichMetricsMonitor(source.num_shards)]
+        if not isinstance(args.tracker, NoopConfig):
+            monitors.append(LoggingMetricsMonitor("preprocess/" + split, commit=True))
 
         cache = build_cache(
             cache_dir=split_cache_dir,


### PR DESCRIPTION
When running `cache_dataset.py`, if no tracker is set, it gives out a `RuntimeError` message and stops logging even when the data is still being written. This PR fixes that by only adding the `LoggingMetricsMonitor()` when the tracker is distinct from `noop`.

The error message usually looks like this.

```python
$ python src/levanter/main/cache_dataset.py --config_path ./books.yaml  --tracker.type noop
Traceback (most recent call last):
  File "/levanter/src/levanter/data/shard_cache.py", line 1771, in _monitor_metrics
    monitor(metrics)
  File "/levanter/src/levanter/data/shard_cache.py", line 743, in __call__
    levanter.tracker.log_metrics(to_log, step=None, commit=self.commit)
  File "/levanter/src/levanter/tracker/tracker_fns.py", line 37, in log_metrics
    raise RuntimeError("No global tracker set")
RuntimeError: No global tracker set
Exception in thread Thread-2 (_monitor_metrics):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/levanter/src/levanter/data/shard_cache.py", line 1776, in _monitor_metrics
    raise e
  File "/levanter/src/levanter/data/shard_cache.py", line 1771, in _monitor_metrics
    monitor(metrics)
  File "/levanter/src/levanter/data/shard_cache.py", line 743, in __call__
    levanter.tracker.log_metrics(to_log, step=None, commit=self.commit)
  File "/levanter/src/levanter/tracker/tracker_fns.py", line 37, in log_metrics
    raise RuntimeError("No global tracker set")
RuntimeError: No global tracker set
```