### PR TITLE
Adjust test precision and miscellaneous cleanups.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ dmypy.json
 # JetBrains
 .idea/
 
+# vscode
+.vscode
 
 # Wandb stuff
 /wandb

--- a/config/llama2_3b_pretrain.yaml
+++ b/config/llama2_3b_pretrain.yaml
@@ -9,7 +9,8 @@ model:
   use_flash_attention: True
   flash_attention_block_size: 2048
 trainer:
-  wandb:
+  tracker:
+    type: wandb
     project: "levanter"
     tags: ["redpajama", "llama"]
 

--- a/docs/Levanter-1.0-Release.md
+++ b/docs/Levanter-1.0-Release.md
@@ -158,7 +158,7 @@ W = hax.random.uniform(PRNGKey(2), (Feature,))
 def mse(pred, target):
     return hax.mean((pred - target) * (pred - target), axis=Batch)
 
-y_pred = hax.dot(Feature, x, W)
+y_pred = hax.dot(x, W, axis=Feature)
 mse(y_pred, y)
 ```
 
@@ -218,7 +218,7 @@ Embed = hax.Axis("embed", 512)  # embedding size
 
 def attention(Key, KPos, query, key, value, mask):
     # how similar is each query to each key
-    scores = hax.dot(Key, query, key) / jnp.sqrt(Key.size)
+    scores = hax.dot(query, key, axis=Key) / jnp.sqrt(Key.size)
 
     # mask out invalid positions
     if mask is not None:
@@ -228,7 +228,7 @@ def attention(Key, KPos, query, key, value, mask):
     scores = hax.nn.softmax(scores, axis=KPos)
 
     # weighted sum of values
-    return hax.dot(KPos, scores, value)
+    return hax.dot(scores, value, axis=KPos)
 ```
 
 With named tensors, we can write the code in a way that conveys the semantics of the operation, rather than the

--- a/src/levanter/compat/torch_serialization.py
+++ b/src/levanter/compat/torch_serialization.py
@@ -247,7 +247,7 @@ def flatten_linear_layers(prefix: Optional[str], tree: PyTree, out_dims_first_in
         return ret_dict
 
     tree_prefixes = leaf_key_paths(tree, prefix, is_leaf=lambda x: isinstance(x, hnn.Linear), use_state_dict_keys=True)
-    jax.tree_map(_flatten_linear, tree, tree_prefixes, is_leaf=lambda x: isinstance(x, hnn.Linear))
+    jax.tree_util.tree_map(_flatten_linear, tree, tree_prefixes, is_leaf=lambda x: isinstance(x, hnn.Linear))
     return ret_dict
 
 
@@ -318,7 +318,7 @@ def unflatten_linear_layers(
     tree_prefixes = leaf_key_paths(
         layer, prefix, is_leaf=lambda x: isinstance(x, hnn.Linear), use_state_dict_keys=True
     )
-    jax.tree_map(_unflatten_linear, layer, tree_prefixes, is_leaf=lambda x: isinstance(x, hnn.Linear))
+    jax.tree_util.tree_map(_unflatten_linear, layer, tree_prefixes, is_leaf=lambda x: isinstance(x, hnn.Linear))
     return ret_dict
 
 

--- a/src/levanter/lora.py
+++ b/src/levanter/lora.py
@@ -150,7 +150,7 @@ class LowRankLinear(eqx.Module):
         return LowRankLinear(lora_A, lora_B, dropout, alpha / r)
 
     def merge(self) -> hax.NamedArray:
-        return hax.dot(LORA_R, self.lora_A.weight, self.lora_B.weight) * self.scale
+        return hax.dot(self.lora_A.weight, self.lora_B.weight, axis=LORA_R) * self.scale
 
 
 class LoraLinear(eqx.Module, StateDictSerializationMixin):

--- a/src/levanter/models/attention.py
+++ b/src/levanter/models/attention.py
@@ -154,7 +154,7 @@ def simple_attention_with_dropout(
         Key, KPos, query, key, mask=m, bias=bias, attention_dtype=attention_dtype, precision=precision
     )
     weights = haliax.nn.dropout(weights, dropout, key=prng, inference=inference)
-    return haliax.dot(KPos, weights, value)
+    return haliax.dot(weights, value, axis=KPos)
 
 
 def _try_te_attention(

--- a/src/levanter/models/backpack.py
+++ b/src/levanter/models/backpack.py
@@ -342,7 +342,7 @@ class BackpackGpt2Embeddings(eqx.Module):
         return x
 
     def unembed(self, x: NamedArray):
-        return hax.dot("embed", x, self.token_embeddings)
+        return hax.dot(x, self.token_embeddings, axis="embed")
 
     def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
         return {"token_embeddings": "wte.weight", "position_embeddings": "wpe.weight"}
@@ -416,7 +416,9 @@ class BackpackLMHeadModel(eqx.Module, LmWithHfSerializationMixin):
         sense_vectors = sense_vectors.rename({self.Pos: self.config.KeyPos})
 
         ## Weight-and-sum
-        hidden_states = hax.dot(self.config.KeyPos, contextualization_weights, sense_vectors)  # (seq, senses, embed)
+        hidden_states = hax.dot(
+            contextualization_weights, sense_vectors, axis=self.config.KeyPos
+        )  # (seq, senses, embed)
         hidden_states = hax.sum(hidden_states, axis=self.config.Senses)
 
         # Rescale - this is important for large num_senses

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -340,7 +340,7 @@ class Gpt2Embeddings(StateDictSerializationMixin, eqx.Module):
         return x
 
     def unembed(self, x: NamedArray):
-        return hax.dot("embed", x, self.token_embeddings.weight)
+        return hax.dot(x, self.token_embeddings.weight, axis="embed")
 
     def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
         return {"token_embeddings": "wte", "position_embeddings": "wpe"}

--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -439,9 +439,7 @@ class LlamaEmbedding(StateDictSerializationMixin, eqx.Module):
 
     @staticmethod
     def init(Vocab: Axis, config: LlamaConfig, *, key) -> "LlamaEmbedding":
-        k_wte = jrandom.split(key, 1)
-
-        token_embeddings = hax.random.normal(k_wte, (Vocab, config.Embed))
+        token_embeddings = hax.random.normal(key, (Vocab, config.Embed))
         return LlamaEmbedding(Vocab, config, token_embeddings)
 
     @named_call
@@ -451,7 +449,7 @@ class LlamaEmbedding(StateDictSerializationMixin, eqx.Module):
         return x
 
     def unembed(self, x: NamedArray):
-        return hax.dot("embed", x, self.token_embeddings)
+        return hax.dot(x, self.token_embeddings, axis="embed")
 
     def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
         return {"token_embeddings": "model.embed_tokens.weight"}

--- a/src/levanter/models/whisper.py
+++ b/src/levanter/models/whisper.py
@@ -447,7 +447,7 @@ class WhisperDecoderEmbeddings(eqx.Module):
         return x
 
     def unembed(self, x: NamedArray):
-        return hax.dot("embed_dim", x, self.token_embeddings.weight)
+        return hax.dot(x, self.token_embeddings.weight, axis="embed_dim")
 
     def resize_embeddings(self, new_size: int, key: Optional[PRNGKeyArray] = None):
         new_token_embeddings = self.token_embeddings.resize_embeddings(new_size, key=key)

--- a/tests/test_grad_accum.py
+++ b/tests/test_grad_accum.py
@@ -28,9 +28,9 @@ class Mlp(eqx.Module):
         return Mlp(w_in, w_out, In, Out, Mid)
 
     def __call__(self, x):
-        x = hax.dot(self.In, self.w_in, x)
+        x = hax.dot(self.w_in, x, axis=self.In)
         x = hnn.relu(x)
-        x = hax.dot(self.Mid, self.w_out, x)
+        x = hax.dot(self.w_out, x, axis=self.Mid)
         return x
 
 

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -62,7 +62,7 @@ def test_llama_rotary_embedding():
 
     levanter_output = llama_rotary_pos_emb(HeadSize=HeadSize, Pos=Pos)
     hf_rope = HFLlamaRotaryEmbedding(dim=hidden_dim, max_position_embeddings=seq_len, device=device)
-    hf_output = hf_rope(x_torch, torch.arange(seq_len).reshape(1, -1), seq_len=seq_len)
+    hf_output = hf_rope(x_torch, torch.arange(seq_len).reshape(1, -1))
 
     for jax_out, torch_out in zip(levanter_output, hf_output):
         torch_out = torch_out.numpy()
@@ -295,7 +295,7 @@ def test_llama_roundtrip(scan_layers, num_kv_heads):
         jax_out = compute(input).array
 
         assert torch_out.shape == jax_out.shape, f"{torch_out.shape} != {jax_out.shape}"
-        assert np.isclose(torch_out, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out} != {jax_out}"
+        assert np.isclose(torch_out, np.array(jax_out), rtol=1e-4, atol=1e-4).all(), f"{torch_out} != {jax_out}"
 
         converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False)
         torch_model2 = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/lev_model")
@@ -305,7 +305,7 @@ def test_llama_roundtrip(scan_layers, num_kv_heads):
         torch_out2 = torch_out2.logits[0].detach().cpu().numpy()
         torch_out2 = jax.nn.softmax(torch_out2, axis=-1)
         assert torch_out2.shape == jax_out.shape, f"{torch_out2.shape} != {jax_out.shape}"
-        assert np.isclose(torch_out2, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out2} != {jax_out}"
+        assert np.isclose(torch_out2, np.array(jax_out), rtol=1e-4, atol=1e-4).all(), f"{torch_out2} != {jax_out}"
 
 
 def _get_llama_config(use_flash=False, num_kv_heads=4, seq_len=128) -> LlamaConfig:

--- a/tests/test_mistral.py
+++ b/tests/test_mistral.py
@@ -122,7 +122,7 @@ def test_mistral_roundtrip(num_kv_heads):
         jax_out = compute(input).array
 
         assert torch_out.shape == jax_out.shape, f"{torch_out.shape} != {jax_out.shape}"
-        assert np.isclose(torch_out, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out} != {jax_out}"
+        assert np.isclose(torch_out, np.array(jax_out), rtol=1e-4, atol=1e-4).all(), f"{torch_out} != {jax_out}"
 
         converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False)
         torch_model2 = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/lev_model")
@@ -132,7 +132,7 @@ def test_mistral_roundtrip(num_kv_heads):
         torch_out2 = torch_out2.logits[0].detach().cpu().numpy()
         torch_out2 = jax.nn.softmax(torch_out2, axis=-1)
         assert torch_out2.shape == jax_out.shape, f"{torch_out2.shape} != {jax_out.shape}"
-        assert np.isclose(torch_out2, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out2} != {jax_out}"
+        assert np.isclose(torch_out2, np.array(jax_out), rtol=1e-4, atol=1e-4).all(), f"{torch_out2} != {jax_out}"
 
 
 def _get_mistral_config(use_flash=False, num_kv_heads=4) -> MistralConfig:


### PR DESCRIPTION
While testing a factorized model I noticed the threshold for the roundtrip tests was too large: with random initialization and 1000 outputs, _all_ outputs of the final softmax will tend to be within 1e-2 of each other!  I tightened the tolerance to 1e-4 for Llama and Mistral accordingly.

Gemma requires more wiggle room, which I'm not happy about: I assume there's a precision difference between our implementation and PyTorch, but if it's this close after several layers at least the model architecture is right.

I also cleaned up some warning noise: adjusted all of the `hax.dot` calls to use named axis arguments, fixed a few places where we generated 1 random split, and updated calls to treemap.