### PR TITLE
While waiting for the sharding of long documents, the state becomes invalid

### DIFF
--- a/src/levanter/data/shard_cache.py
+++ b/src/levanter/data/shard_cache.py
@@ -1640,6 +1640,13 @@ class ShardCache(Iterable[pa.RecordBatch]):
                     current_timeout *= 2
                     current_timeout = min(current_timeout, 100)
                     continue
+                except asyncio.exceptions.InvalidStateError:
+                    self.logger.warning(f"Invalid state waiting for chunk {mapped_index} for {int(next_time - time_in)} seconds")
+                    next_time = time.time()
+                    current_timeout *= 2
+                    current_timeout = min(current_timeout, 100)
+                    time.sleep(current_timeout)
+                    continue
 
                 if chunk is None:
                     raise IndexError(f"Chunk index out of bounds. (Mapped index {mapped_index})")


### PR DESCRIPTION
This PR fixes a rare race condition when the cache for very long documents is still being built but the workers are asking for the shards. The state becomes invalid so capturing the specific exception makes the output cleaner. I also added a `sleep()` so the message is not written every other millisecond. 