### PR TITLE
Seek for Audio

### DIFF
--- a/src/levanter/data/audio.py
+++ b/src/levanter/data/audio.py
@@ -264,7 +264,7 @@ class ProcessedAudioCache(ShardableDataset[AudioTextStorageBatch]):
 
     def __iter__(self):
         shard_index, row_index = self.chunk_cache.get_resume_information()
-        logger.info(f"Starting Real Iterator at Shard {shard_index}, Row {row_index}.")
+        logger.debug(f"Starting Real Iterator at Shard {shard_index}, Row {row_index}.")
         for batch in self._chunks():
             unarrow = dict_from_record_batch(batch)
             # Flatten Singleton Batch Dimension

--- a/src/levanter/data/audio.py
+++ b/src/levanter/data/audio.py
@@ -263,8 +263,9 @@ class ProcessedAudioCache(ShardableDataset[AudioTextStorageBatch]):
         self.chunk_cache = chunk_cache.with_batch_size(1)
 
     def __iter__(self):
-        shard_index, row_index = self.chunk_cache.get_resume_information()
-        logger.debug(f"Starting Real Iterator at Shard {shard_index}, Row {row_index}.")
+        chunk_index = self.chunk_cache.get_resume_shard()
+        row_index = self.chunk_cache.get_resume_row()
+        logger.debug(f"Starting Real Iterator at Shard {chunk_index}, Row {row_index}.")
         for batch in self._chunks():
             unarrow = dict_from_record_batch(batch)
             # Flatten Singleton Batch Dimension

--- a/src/levanter/data/audio.py
+++ b/src/levanter/data/audio.py
@@ -263,7 +263,7 @@ class ProcessedAudioCache(ShardableDataset[AudioTextStorageBatch]):
         self.chunk_cache = chunk_cache.with_batch_size(1)
 
     def __iter__(self):
-        shard_index, row_index = self.chunk_cache.get_cache_location()
+        shard_index, row_index = self.chunk_cache.get_resume_information()
         logger.info(f"Starting Real Iterator at Shard {shard_index}, Row {row_index}.")
         for batch in self._chunks():
             unarrow = dict_from_record_batch(batch)
@@ -277,7 +277,7 @@ class ProcessedAudioCache(ShardableDataset[AudioTextStorageBatch]):
         yield from self.chunk_cache.scan_batches_from_chunks()
 
     def _chunks(self):
-        return self.chunk_cache.iter_batches_from_chunks()
+        return self.chunk_cache.iter_batches_from_chunks(should_resume=True)
 
     @staticmethod
     def build_or_load(

--- a/src/levanter/data/dataset.py
+++ b/src/levanter/data/dataset.py
@@ -13,6 +13,12 @@ class Dataset(Iterable[T], ABC):
     def __iter__(self) -> Iterator[T]:
         raise NotImplementedError
 
+    def seek(self):
+        # Note(will): Only Audio Datasets Have A True Seek Method right now.
+        # This allows calling seek, but falls back to just the default iterator
+        # for datasets without a true seek implementation
+        yield from self.__iter__()
+
 
 class ShardableDataset(Dataset[T], ABC):
     @abstractmethod

--- a/src/levanter/data/shard_cache.py
+++ b/src/levanter/data/shard_cache.py
@@ -1567,8 +1567,8 @@ class ShardCache(Iterable[pa.RecordBatch]):
 
         self._num_readers = num_readers
         self._reader_offset = reader_offset
-        self._start_shard_index: Optional[int] = None
-        self._start_row_index: Optional[int] = None
+        self._resume_shard_index: Optional[int] = None
+        self._resume_row_index: Optional[int] = None
         name = os.path.join(*cache_dir.split("/")[-2:])
         self.logger = pylogging.getLogger(f"ShardCache.{name}")
 
@@ -1670,24 +1670,28 @@ class ShardCache(Iterable[pa.RecordBatch]):
             assert self._broker is not None
             return ray.get(self._broker.final_chunk_count.remote())
 
-    def get_cache_location(self) -> tuple[Optional[int], Optional[int]]:
-        return (self._start_shard_index, self._start_row_index)
+    def get_resume_shard(self) -> Optional[int]:
+        return self._resume_shard_index
 
-    def set_cache_location(self, start_shard: int, start_row: int):
-        self._start_shard_index = start_shard
-        self._start_row_index = start_row
+    def get_resume_row(self) -> Optional[int]:
+        return self._resume_row_index
 
-    def iter_over_chunks(self, yield_lambda, loop: bool = False):
-        if self._start_shard_index is not None and self._start_row_index is not None:
-            shard_offset = self._start_shard_index
+    def set_resume_information(self, resume_shard_index: Optional[int] = None, resume_row_index: Optional[int] = None):
+        if resume_shard_index is not None:
+            self._resume_shard_index = resume_shard_index
+        if resume_row_index is not None:
+            self._resume_row_index = resume_row_index
+
+    def _iter_over_chunks(self, yield_lambda, loop, should_resume):
+        resume_shard = self.get_resume_shard()
+        if resume_shard and should_resume:
+            shard_offset = resume_shard
         else:
             shard_offset = self._reader_offset
-            self._start_shard_index = shard_offset
-            self._start_row_index = 0
+            self.set_resume_information(shard_offset, 0)
 
         if self._ledger is not None:
             num_chunks = len(self._ledger.chunks)
-
             if num_chunks == 0:
                 return
 
@@ -1695,8 +1699,7 @@ class ShardCache(Iterable[pa.RecordBatch]):
                 i = 0
                 for i in range(shard_offset, num_chunks, self._num_readers):
                     chunk = self._ledger.chunks[i]
-                    # Set Chunk Marker For Shard
-                    self._start_shard_index = i
+                    self.set_resume_information(resume_shard_index=i)
                     yield from yield_lambda(chunk)
 
                 if not loop:
@@ -1710,8 +1713,7 @@ class ShardCache(Iterable[pa.RecordBatch]):
                 try:
                     self.logger.debug(f"Reading chunk {i}")
                     chunk = self._get_chunk_unmapped(i)
-                    # Set Chunk Marker For Shard
-                    self._start_shard_index = i
+                    self.set_resume_information(resume_shard_index=i)
                     i += self._num_readers
                     yield from yield_lambda(chunk)
                 except IndexError:
@@ -1720,17 +1722,18 @@ class ShardCache(Iterable[pa.RecordBatch]):
                         assert num_chunks is not None
 
                         i = i % num_chunks
+
                     else:
                         break
                 except Exception as e:
                     self.logger.exception("Error while reading from shard cache.")
                     raise e
 
-    def iter_batches_from_chunks(self, loop: bool = False):
-        return self.iter_over_chunks(self._read_chunk, loop)
+    def iter_batches_from_chunks(self, loop: bool = False, should_resume: bool = False):
+        return self._iter_over_chunks(self._read_chunk, loop, should_resume)
 
-    def scan_batches_from_chunks(self, loop: bool = False):
-        return self.iter_over_chunks(self._scan_chunk, loop)
+    def scan_batches_from_chunks(self, loop: bool = False, should_resume: bool = False):
+        return self._iter_over_chunks(self._scan_chunk, loop, should_resume)
 
     def __iter__(self):
         return self.iter_batches_from_chunks()
@@ -1769,28 +1772,29 @@ class ShardCache(Iterable[pa.RecordBatch]):
 
     def _scan_chunk(self, chunk):
         num_batches = (chunk.num_rows + self._batch_size - 1) // self._batch_size
+        resume_row_index = self.get_resume_row()
         for i in range(num_batches):
             # Seek To Correct Row
-            if i < self._start_row_index:
+            if i < resume_row_index:
                 continue
             # Increment Row Marker
-            self._start_row_index = i + 1
+            self.set_resume_information(resume_row_index=i + 1)
             yield i
         # Reset Row Marker
-        self._start_row_index = 0
+        self.set_resume_information(resume_row_index=0)
 
     def _read_chunk(self, chunk):
         reader = _ChunkReader.from_metadata(self.cache_dir, chunk, self._batch_size)
-
+        resume_row_index = self.get_resume_row()
         for i, batch in enumerate(reader):
             # Seek To Correct Row
-            if i < self._start_row_index:
+            if i < resume_row_index:
                 continue
             # Increment Row Marker
-            self._start_row_index = i + 1
+            self.set_resume_information(resume_row_index=i + 1)
             yield batch
         # Reset Row Marker
-        self._start_row_index = 0
+        self.set_resume_information(resume_row_index=0)
 
     def await_finished(self, timeout: Optional[float] = None):
         return ray.get(self.finished_sentinel(), timeout=timeout)

--- a/src/levanter/data/shard_cache.py
+++ b/src/levanter/data/shard_cache.py
@@ -1698,8 +1698,6 @@ class ShardCache(Iterable[pa.RecordBatch]):
                     # Set Chunk Marker For Shard
                     self._start_shard_index = i
                     yield from yield_lambda(chunk)
-                    # Reset the Row Marker
-                    self._start_row_index = 0
 
                 if not loop:
                     break
@@ -1716,8 +1714,6 @@ class ShardCache(Iterable[pa.RecordBatch]):
                     self._start_shard_index = i
                     i += self._num_readers
                     yield from yield_lambda(chunk)
-                    # Reset the Row Marker
-                    self._start_row_index = 0
                 except IndexError:
                     if loop:
                         num_chunks = ray.get(self._broker.final_chunk_count.remote())
@@ -1772,24 +1768,29 @@ class ShardCache(Iterable[pa.RecordBatch]):
         )
 
     def _scan_chunk(self, chunk):
-        num_batches = (chunk.num_rows + self.batch_size - 1) // self.batch_size
+        num_batches = (chunk.num_rows + self._batch_size - 1) // self._batch_size
         for i in range(num_batches):
             # Seek To Correct Row
             if i < self._start_row_index:
                 continue
             # Increment Row Marker
-            self.start_row_index = i + 1
+            self._start_row_index = i + 1
             yield i
+        # Reset Row Marker
+        self._start_row_index = 0
 
     def _read_chunk(self, chunk):
         reader = _ChunkReader.from_metadata(self.cache_dir, chunk, self._batch_size)
+
         for i, batch in enumerate(reader):
             # Seek To Correct Row
             if i < self._start_row_index:
                 continue
             # Increment Row Marker
-            self.start_row_index = i + 1
+            self._start_row_index = i + 1
             yield batch
+        # Reset Row Marker
+        self._start_row_index = 0
 
     def await_finished(self, timeout: Optional[float] = None):
         return ray.get(self.finished_sentinel(), timeout=timeout)

--- a/src/levanter/data/shard_cache.py
+++ b/src/levanter/data/shard_cache.py
@@ -1770,12 +1770,12 @@ class ShardCache(Iterable[pa.RecordBatch]):
             self.cache_dir, batch_size, self._ledger, self._broker, self._reader_offset, self._num_readers
         )
 
-    def _scan_chunk(self, chunk):
+    def _scan_chunk(self, chunk: ChunkMetadata):
         num_batches = (chunk.num_rows + self._batch_size - 1) // self._batch_size
         resume_row_index = self.get_resume_row()
         for i in range(num_batches):
             # Seek To Correct Row
-            if i < resume_row_index:
+            if resume_row_index is not None and i < resume_row_index:
                 continue
             # Increment Row Marker
             self.set_resume_information(resume_row_index=i + 1)
@@ -1783,12 +1783,12 @@ class ShardCache(Iterable[pa.RecordBatch]):
         # Reset Row Marker
         self.set_resume_information(resume_row_index=0)
 
-    def _read_chunk(self, chunk):
+    def _read_chunk(self, chunk: ChunkMetadata):
         reader = _ChunkReader.from_metadata(self.cache_dir, chunk, self._batch_size)
         resume_row_index = self.get_resume_row()
         for i, batch in enumerate(reader):
             # Seek To Correct Row
-            if i < resume_row_index:
+            if resume_row_index is not None and i < resume_row_index:
                 continue
             # Increment Row Marker
             self.set_resume_information(resume_row_index=i + 1)

--- a/src/levanter/data/shard_cache.py
+++ b/src/levanter/data/shard_cache.py
@@ -651,7 +651,6 @@ class MetricsMonitor(Protocol):
 
 
 class RichMetricsMonitor(MetricsMonitor):
-
     progress: Optional[Progress]  # type: ignore
     task: Optional[TaskID]
 
@@ -1568,6 +1567,8 @@ class ShardCache(Iterable[pa.RecordBatch]):
 
         self._num_readers = num_readers
         self._reader_offset = reader_offset
+        self._start_shard_index: Optional[int] = None
+        self._start_row_index: Optional[int] = None
         name = os.path.join(*cache_dir.split("/")[-2:])
         self.logger = pylogging.getLogger(f"ShardCache.{name}")
 
@@ -1669,8 +1670,20 @@ class ShardCache(Iterable[pa.RecordBatch]):
             assert self._broker is not None
             return ray.get(self._broker.final_chunk_count.remote())
 
-    def iter_batches_from_chunks(self, loop: bool = False):
-        shard_offset = self._reader_offset
+    def get_cache_location(self) -> tuple[Optional[int], Optional[int]]:
+        return (self._start_shard_index, self._start_row_index)
+
+    def set_cache_location(self, start_shard: int, start_row: int):
+        self._start_shard_index = start_shard
+        self._start_row_index = start_row
+
+    def iter_over_chunks(self, yield_lambda, loop: bool = False):
+        if self._start_shard_index is not None and self._start_row_index is not None:
+            shard_offset = self._start_shard_index
+        else:
+            shard_offset = self._reader_offset
+            self._start_shard_index = shard_offset
+            self._start_row_index = 0
 
         if self._ledger is not None:
             num_chunks = len(self._ledger.chunks)
@@ -1682,7 +1695,11 @@ class ShardCache(Iterable[pa.RecordBatch]):
                 i = 0
                 for i in range(shard_offset, num_chunks, self._num_readers):
                     chunk = self._ledger.chunks[i]
-                    yield from self._read_chunk(chunk)
+                    # Set Chunk Marker For Shard
+                    self._start_shard_index = i
+                    yield from yield_lambda(chunk)
+                    # Reset the Row Marker
+                    self._start_row_index = 0
 
                 if not loop:
                     break
@@ -1695,8 +1712,12 @@ class ShardCache(Iterable[pa.RecordBatch]):
                 try:
                     self.logger.debug(f"Reading chunk {i}")
                     chunk = self._get_chunk_unmapped(i)
+                    # Set Chunk Marker For Shard
+                    self._start_shard_index = i
                     i += self._num_readers
-                    yield from self._read_chunk(chunk)
+                    yield from yield_lambda(chunk)
+                    # Reset the Row Marker
+                    self._start_row_index = 0
                 except IndexError:
                     if loop:
                         num_chunks = ray.get(self._broker.final_chunk_count.remote())
@@ -1708,6 +1729,12 @@ class ShardCache(Iterable[pa.RecordBatch]):
                 except Exception as e:
                     self.logger.exception("Error while reading from shard cache.")
                     raise e
+
+    def iter_batches_from_chunks(self, loop: bool = False):
+        return self.iter_over_chunks(self._read_chunk, loop)
+
+    def scan_batches_from_chunks(self, loop: bool = False):
+        return self.iter_over_chunks(self._scan_chunk, loop)
 
     def __iter__(self):
         return self.iter_batches_from_chunks()
@@ -1744,9 +1771,24 @@ class ShardCache(Iterable[pa.RecordBatch]):
             self.cache_dir, batch_size, self._ledger, self._broker, self._reader_offset, self._num_readers
         )
 
+    def _scan_chunk(self, chunk):
+        num_batches = (chunk.num_rows + self.batch_size - 1) // self.batch_size
+        for i in range(num_batches):
+            # Seek To Correct Row
+            if i < self._start_row_index:
+                continue
+            # Increment Row Marker
+            self.start_row_index = i + 1
+            yield i
+
     def _read_chunk(self, chunk):
         reader = _ChunkReader.from_metadata(self.cache_dir, chunk, self._batch_size)
-        for batch in reader:
+        for i, batch in enumerate(reader):
+            # Seek To Correct Row
+            if i < self._start_row_index:
+                continue
+            # Increment Row Marker
+            self.start_row_index = i + 1
             yield batch
 
     def await_finished(self, timeout: Optional[float] = None):

--- a/src/levanter/data/shard_cache.py
+++ b/src/levanter/data/shard_cache.py
@@ -1676,11 +1676,17 @@ class ShardCache(Iterable[pa.RecordBatch]):
     def get_resume_row(self) -> Optional[int]:
         return self._resume_row_index
 
-    def set_resume_information(self, resume_chunk_index: Optional[int] = None, resume_row_index: Optional[int] = None):
-        if resume_chunk_index is not None:
-            self._resume_chunk_index = resume_chunk_index
-        if resume_row_index is not None:
-            self._resume_row_index = resume_row_index
+    def set_resume_information(
+        self, resume_chunk_index: Optional[int] = None, resume_row_index: Optional[int] = None, reset: bool = False
+    ):
+        if reset:
+            self._resume_chunk_index = None
+            self._resume_row_index = None
+        else:
+            if resume_chunk_index is not None:
+                self._resume_chunk_index = resume_chunk_index
+            if resume_row_index is not None:
+                self._resume_row_index = resume_row_index
 
     def _iter_over_chunks(self, yield_lambda, loop, should_resume):
         resume_chunk_index = self.get_resume_shard()
@@ -1728,6 +1734,7 @@ class ShardCache(Iterable[pa.RecordBatch]):
                 except Exception as e:
                     self.logger.exception("Error while reading from shard cache.")
                     raise e
+        self.set_resume_information(reset=True)
 
     def iter_batches_from_chunks(self, loop: bool = False, should_resume: bool = False):
         return self._iter_over_chunks(self._read_chunk, loop, should_resume)

--- a/src/levanter/main/train_asr.py
+++ b/src/levanter/main/train_asr.py
@@ -186,8 +186,7 @@ def main(config: TrainASRConfig):
             import tqdm
 
             for _ in tqdm.tqdm(range(state.step), desc="seeking data for resume"):
-                next(train_loader)
-
+                next(train_loader.seek())
         ## OK, actually run training!
         trainer.train(state, train_loader)
         # checkpointer.on_step(last_step, force=True)


### PR DESCRIPTION
Implementing seek in the much simpler case of audio. Need to do more testing to make sure this behaves appropriately, but putting the PR up now under WIP status since this has the main idea implemented.

Uses the chunk metadata to create a dummy iterator of the same shape as the true iterator and keeps track of the shard id and the row index reached during the resume process. Then, initializes the actual iterator from the location reached during the dummy iteration.