### PR TITLE
Fix #418: add flop calculations for models

### DIFF
--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -159,7 +159,11 @@ def main(config: TrainLmConfig):
             )
             trainer.add_hook(cb, every=config.trainer.steps_per_eval)
 
-        trainer.add_hook(callbacks.log_performance_stats(Pos.size, trainer.config.train_batch_size), every=1)
+        flops_per_token = config.model.flops_per_token(vocab_size)
+        flops_per_example = 3 * flops_per_token * Pos.size if flops_per_token is not None else None
+        trainer.add_hook(
+            callbacks.log_performance_stats(Pos.size, trainer.config.train_batch_size, flops_per_example), every=1
+        )
         if config.hf_save_path is not None:
             full_save_path = os.path.join(config.hf_save_path, trainer.run_id)
 

--- a/src/levanter/models/gemma.py
+++ b/src/levanter/models/gemma.py
@@ -29,6 +29,7 @@ from levanter.models.llama import (  # Gemma attention and MLP is identical to L
 )
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.types import BlockFoldable
+from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.py_utils import cached_classproperty
 
 
@@ -183,6 +184,18 @@ class GemmaConfig(HFCompatConfig):
     @property
     def model_type(cls) -> Type["GemmaLMHeadModel"]:
         return GemmaLMHeadModel
+
+    def flops_per_token(self, vocab_size: int) -> Optional[float]:
+        return lm_flops_per_token(
+            hidden_dim=self.hidden_dim,
+            intermediate_dim=self.intermediate_dim,
+            num_layers=self.num_layers,
+            num_kv_heads=self.num_kv_heads,
+            num_heads=self.num_heads,
+            seq_len=self.seq_len,
+            vocab_size=vocab_size,
+            glu=False,
+        )
 
 
 class GemmaRMSNorm(hnn.LayerNorm):

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -28,6 +28,7 @@ from levanter.compat.torch_serialization import (
 from levanter.logging import silence_transformer_nag
 from levanter.models.attention import AttentionBackend, AttentionMask, dot_product_attention
 from levanter.models.lm_model import LmConfig
+from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.py_utils import cached_classproperty
 
 
@@ -121,6 +122,18 @@ class Gpt2Config(HFCompatConfig):
             activation_function=hf_config.activation_function,
             scale_attn_by_inverse_layer_idx=hf_config.scale_attn_by_inverse_layer_idx,
             upcast_attn=hf_config.reorder_and_upcast_attn,
+        )
+
+    def flops_per_token(self, vocab_size: int) -> Optional[float]:
+        return lm_flops_per_token(
+            hidden_dim=self.hidden_dim,
+            intermediate_dim=self.hidden_dim * self.mlp_scale,
+            num_layers=self.num_layers,
+            num_kv_heads=self.num_heads,
+            num_heads=self.num_heads,
+            seq_len=self.seq_len,
+            vocab_size=vocab_size,
+            glu=False,
         )
 
 

--- a/src/levanter/models/lm_model.py
+++ b/src/levanter/models/lm_model.py
@@ -64,6 +64,9 @@ class LmConfig(draccus.PluginRegistry, abc.ABC, Generic[LmT], discover_packages_
     def Pos(self) -> Axis:
         pass
 
+    def flops_per_token(self, vocab_size: int) -> Optional[float]:
+        return None
+
     def build(self, Vocab: Axis, *, key: PRNGKey) -> "LmT":
         return self.model_type.init(Vocab, self, key=key)  # type: ignore
 

--- a/src/levanter/models/mistral.py
+++ b/src/levanter/models/mistral.py
@@ -22,6 +22,7 @@ from levanter.logging import silence_transformer_nag
 from levanter.models.attention import AttentionBackend, AttentionMask
 from levanter.models.llama import LlamaConfig, LlamaEmbedding, LlamaTransformer
 from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.py_utils import cached_classproperty
 
 
@@ -137,6 +138,18 @@ class MistralConfig(LlamaConfig):
     @property
     def model_type(cls) -> Type["MistralLMHeadModel"]:
         return MistralLMHeadModel
+
+    def flops_per_token(self, vocab_size: int) -> Optional[float]:
+        return lm_flops_per_token(
+            hidden_dim=self.hidden_dim,
+            intermediate_dim=self.intermediate_dim,
+            num_layers=self.num_layers,
+            num_kv_heads=self.num_heads,
+            num_heads=self.num_heads,
+            seq_len=self.seq_len,
+            vocab_size=vocab_size,
+            glu=False,
+        )
 
 
 class MistralLMHeadModel(eqx.Module, LmHeadModel[MistralConfig], StateDictSerializationMixin):

--- a/src/levanter/models/mpt.py
+++ b/src/levanter/models/mpt.py
@@ -30,6 +30,7 @@ from levanter.compat.torch_serialization import (
 from levanter.logging import silence_transformer_nag
 from levanter.models.attention import AttentionMask
 from levanter.models.lm_model import LmConfig
+from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.py_utils import cached_classproperty
 
@@ -198,6 +199,18 @@ class MptConfig(HFCompatConfig):
             logit_scale=self.logit_scale,
             vocab_size=vocab_size,
             **config_overrides,
+        )
+
+    def flops_per_token(self, vocab_size: int) -> Optional[float]:
+        return lm_flops_per_token(
+            hidden_dim=self.d_model,
+            intermediate_dim=self.d_model * self.expansion_ratio,
+            num_layers=self.n_layers,
+            num_kv_heads=self.n_heads,
+            num_heads=self.n_heads,
+            seq_len=self.max_seq_len,
+            vocab_size=vocab_size,
+            glu=False,
         )
 
 

--- a/src/levanter/utils/flop_utils.py
+++ b/src/levanter/utils/flop_utils.py
@@ -1,0 +1,23 @@
+def lm_flops_per_token(
+    hidden_dim: int,
+    intermediate_dim: int,
+    num_layers: int,
+    num_kv_heads: int,
+    num_heads: int,
+    seq_len: int,
+    vocab_size: int,
+    glu: bool,
+):
+    head_dim = hidden_dim / num_heads
+    mlp = 2 * (2 if glu else 3) * hidden_dim * intermediate_dim
+    qkv_proj = 2 * hidden_dim * (num_heads * head_dim + 2 * num_kv_heads * head_dim)
+    dense_proj = 2 * hidden_dim * hidden_dim
+    # The following are across the whole sequence
+    key_query_logits = 2 * seq_len * (seq_len / 2) * num_heads * head_dim
+    mask = 3 * seq_len * seq_len * num_heads
+    mask_value = 2 * seq_len * seq_len * head_dim * num_heads
+    seq_flops = key_query_logits + mask + mask_value
+    # so we divide by the sequence length to get the per-token flops
+    attn = seq_flops / seq_len
+    lm_head = 2 * hidden_dim * vocab_size
+    return num_layers * (mlp + qkv_proj + dense_proj + attn) + lm_head

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -45,6 +45,15 @@ def test_llama_config():
         ), f"{k} {getattr(new_hf_config, k)} != {getattr(hf_config, k)}"
 
 
+def test_llama_flops():
+    # Check that the forward flops is within 10% of the naive calculation
+    hf_config = transformers.LlamaConfig.from_pretrained("meta-llama/Llama-2-7b-hf")
+    llama_config = LlamaConfig.from_hf_config(hf_config)
+    n_params = 6.7e9
+    ratio = 2 * n_params / llama_config.flops_per_token(hf_config.vocab_size)
+    assert ratio > 0.85, f"ratio {ratio} < 0.9"
+
+
 @skip_if_no_torch
 def test_llama_rotary_embedding():
     import torch


### PR DESCRIPTION
Implements flop calculations for models. This is then piped into the trainer of `lm_trainer` for throughput logging.