### PR TITLE
A few "cleanups" for model instantiation.

### DIFF
--- a/docs/dev/Port-Models.md
+++ b/docs/dev/Port-Models.md
@@ -231,7 +231,8 @@ assert np.isclose(
 For the end-to-end model, you can save the model weight to disk as a checkpoint and load it into the reference model. For example, in Llama, we can do the following:
 
 ```python
-converter = LlamaConfig.default_hf_checkpoint_converter
+config = LLamaConfig()
+converter = config.default_hf_converter()
 
 # initialize the model in HF...
 hf_model = transformer.AutoModelForCausalLM(...)
@@ -242,7 +243,8 @@ with tempfile.TemporaryDirectory() as tmpdir:
     hf_model.save_pretrained(ck_path)
 
     model = converter.load_pretrained(
-        LlamaLMHeadModel,
+        config.model_type,
+        config,
         ck_path,
         resize_vocab_to_match_tokenizer=False
     )

--- a/examples/alpaca-lora/alpaca_lora.py
+++ b/examples/alpaca-lora/alpaca_lora.py
@@ -90,7 +90,7 @@ def train(config: TrainArgs):
         logger.info(f"Loading pretrained model from {converter.reference_checkpoint}")
         # load untrainable params in compute precision to save memory
         model: LmHeadModel = converter.load_pretrained(  # type: ignore
-            model_config, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.compute_dtype
+            model_config.model_type, model_config, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.compute_dtype
         )
 
         # Major difference from Alpaca: we loraize the model.
@@ -119,7 +119,7 @@ def train(config: TrainArgs):
 
         logger.info(f"Total parameter count: {all_param_count}")
         logger.info(f"Trainable parameter count: {just_lora_params}")
-        logger.info(f"Fraction of parameters that are trainable: {just_lora_params * 1.0 / all_param_count%.3}")
+        logger.info(f"Fraction of parameters that are trainable: {just_lora_params * 1.0 / all_param_count:.3f}")
 
         # Levanter has two kinds of data loaders: sharded and replicated. Replicated is simpler and allows for
         # single pass training. Sharded only loads a subset of the data on each device, and is more efficient for large

--- a/examples/alpaca/alpaca.py
+++ b/examples/alpaca/alpaca.py
@@ -234,7 +234,7 @@ def train(config: TrainArgs):
         # load the underlying hf model
         logger.info(f"Loading pretrained model from {converter.reference_checkpoint}")
         model: LmHeadModel = converter.load_pretrained(  # type: ignore
-            model_config, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.param_dtype
+            model_config.model_type, model_config, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.param_dtype
         )
 
         # this must be in jit b/c it uses arrays across accelerators (b/c of FSDP)

--- a/src/levanter/main/doremi_lm.py
+++ b/src/levanter/main/doremi_lm.py
@@ -13,7 +13,7 @@ from levanter.compat.hf_checkpoints import HFCompatConfig
 from levanter.data.text import CausalLmDataset, LMMixtureDatasetConfig
 from levanter.doremi import DoReMiConfig, estimate_mixture_weights
 from levanter.models.gpt2 import Gpt2Config
-from levanter.models.lm_model import LmConfig
+from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.tree_utils import inference_mode
@@ -54,7 +54,7 @@ def main(config: TrainLmConfig):
             raise ValueError("Cannot specify both initialize_from_hf and initialize_from")
 
         assert isinstance(config.model, HFCompatConfig)
-        converter = config.model.default_hf_checkpoint_converter
+        converter = config.model.hf_checkpoint_converter()
         if hasattr(tokenizer, "vocab") and tokenizer.vocab != converter.tokenizer.vocab:
             logger.warning("The tokenizers appear to be different. You may want to check this.")
 
@@ -68,7 +68,7 @@ def main(config: TrainLmConfig):
             # NB: gross mutability
             config.model = converter.config_from_hf_config(converter.default_hf_config)
     elif isinstance(config.model, HFCompatConfig):
-        converter = config.model.default_hf_checkpoint_converter
+        converter = config.model.hf_checkpoint_converter()
         converter = converter.replaced(tokenizer=tokenizer)
     else:
         converter = None
@@ -86,7 +86,9 @@ def main(config: TrainLmConfig):
         # initialize the ref model
         if config.ref_model_from_hf:
             assert converter is not None
-            ref_model = converter.load_pretrained(type(config.model), dtype=config.trainer.mp.compute_dtype)
+            ref_model = converter.load_pretrained(
+                config.model.model_type, config.model, dtype=config.trainer.mp.compute_dtype
+            )
         else:
             ref_model_shape = eqx.filter_eval_shape(config.model.build, Vocab, key=jrandom.PRNGKey(0))
             ref_model = levanter.checkpoint.load_checkpoint(
@@ -94,6 +96,7 @@ def main(config: TrainLmConfig):
             )
 
         ref_model = inference_mode(ref_model, True)
+        assert isinstance(ref_model, LmHeadModel)
 
         training_key, model_key = jrandom.split(jrandom.PRNGKey(config.trainer.seed), 2)
 

--- a/src/levanter/main/eval_lm.py
+++ b/src/levanter/main/eval_lm.py
@@ -102,7 +102,7 @@ def main(config: EvalLmConfig):
             converter: HFCheckpointConverter = model_config.hf_checkpoint_converter
             converter = converter.replaced(reference_checkpoint=config.hf_checkpoint, tokenizer=tokenizer)
             model_from_hf_checkpoint = converter.load_pretrained(
-                model_config.model_type, config.hf_checkpoint, dtype=mp.compute_dtype
+                model_config.model_type, model_config, config.hf_checkpoint, dtype=mp.compute_dtype
             )
             loss = callbacks.eval_loss_loop(compute_loss, model_from_hf_checkpoint, eval_loader, max_batches=total)
 

--- a/src/levanter/main/export_lm_to_hf.py
+++ b/src/levanter/main/export_lm_to_hf.py
@@ -59,7 +59,7 @@ def main(config: ConvertLmConfig):
         if config.override_vocab_size:
             model = model.resize_vocab(config.override_vocab_size)
 
-        converter = model.config.default_hf_checkpoint_converter.replaced(tokenizer=tokenizer)
+        converter = model.config.hf_checkpoint_converter().replaced(tokenizer=tokenizer)
 
         converter.save_pretrained(
             model,

--- a/src/levanter/main/lora_lm.py
+++ b/src/levanter/main/lora_lm.py
@@ -91,7 +91,7 @@ def main(config: LoraLmConfig):
         # load the underlying hf model
         logger.info(f"Loading pretrained model from {converter.reference_checkpoint}")
         model = converter.load_pretrained(
-            model_config, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.compute_dtype
+            model_config.model_type, model_config, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.compute_dtype
         )
 
         @haliax.named_jit(axis_resources=parameter_axis_mapping, donate_args=(True))

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -60,7 +60,7 @@ def main(config: TrainLmConfig):
             raise ValueError("Cannot specify both initialize_from_hf and initialize_from")
 
         assert isinstance(config.model, HFCompatConfig)
-        converter = config.model.default_hf_checkpoint_converter
+        converter = config.model.hf_checkpoint_converter()
         if hasattr(tokenizer, "vocab") and tokenizer.vocab != converter.tokenizer.vocab:
             logger.warning("The tokenizers appear to be different. You may want to check this.")
 
@@ -74,7 +74,7 @@ def main(config: TrainLmConfig):
             # NB: gross mutability
             config.model = converter.config_from_hf_config(converter.default_hf_config)
     elif isinstance(config.model, HFCompatConfig):
-        converter = config.model.default_hf_checkpoint_converter
+        converter = config.model.hf_checkpoint_converter()
         converter = converter.replaced(tokenizer=tokenizer)
     else:
         converter = None
@@ -134,7 +134,10 @@ def main(config: TrainLmConfig):
                 state = dataclasses.replace(state, model=None)
                 gc.collect()
                 model = converter.load_pretrained(
-                    config.model, axis_mapping=parameter_axis_mapping, dtype=trainer.mp.compute_dtype
+                    config.model.model_type,
+                    config.model,
+                    axis_mapping=parameter_axis_mapping,
+                    dtype=trainer.mp.compute_dtype,
                 )
                 model = named_jit(trainer.mp.cast_to_param, parameter_axis_mapping)(model)
                 state = dataclasses.replace(state, model=model)

--- a/src/levanter/models/backpack.py
+++ b/src/levanter/models/backpack.py
@@ -25,7 +25,6 @@ from levanter.logging import silence_transformer_nag
 from levanter.models.attention import AttentionMask, materialize_mask
 from levanter.models.gpt2 import ACT2FN, Gpt2Config, Gpt2Transformer
 from levanter.models.lm_model import LmConfig
-from levanter.utils.py_utils import cached_classproperty
 
 
 silence_transformer_nag()
@@ -43,11 +42,12 @@ class BackpackConfig(Gpt2Config):
     def model_type(self) -> Type["BackpackLMHeadModel"]:
         return BackpackLMHeadModel
 
-    @cached_classproperty
-    def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["BackpackConfig"]:  # type: ignore
+    def hf_checkpoint_converter(self) -> HFCheckpointConverter["BackpackConfig"]:  # type: ignore
         # We trust this code because it's in our hub repo
         return HFCheckpointConverter(
-            cls, "stanford-crfm/levanter-backpack-1b@9face7bd6182155fe3f1a6a5a14ca1c4810bb079", trust_remote_code=True
+            self,
+            reference_checkpoint="stanford-crfm/levanter-backpack-1b@9face7bd6182155fe3f1a6a5a14ca1c4810bb079",
+            trust_remote_code=True,
         )
 
     # Axes

--- a/src/levanter/models/gemma.py
+++ b/src/levanter/models/gemma.py
@@ -30,7 +30,6 @@ from levanter.models.llama import (  # Gemma attention and MLP is identical to L
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.types import BlockFoldable
 from levanter.utils.flop_utils import lm_flops_per_token
-from levanter.utils.py_utils import cached_classproperty
 
 
 silence_transformer_nag()
@@ -112,10 +111,9 @@ class GemmaConfig(HFCompatConfig):
             self.num_heads % self.num_kv_heads == 0
         ), f"num_heads={self.num_heads} not divisible by num_kv_heads={self.num_kv_heads}."
 
-    @cached_classproperty
-    def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["GemmaConfig"]:  # type: ignore
+    def hf_checkpoint_converter(self) -> HFCheckpointConverter["GemmaConfig"]:  # type: ignore
         return HFCheckpointConverter(
-            cls,  # type: ignore
+            self,
             reference_checkpoint="google/gemma-2b",
             trust_remote_code=True,
             HfConfigClass=HfGemmaConfig,

--- a/src/levanter/models/gpt2.py
+++ b/src/levanter/models/gpt2.py
@@ -29,7 +29,6 @@ from levanter.logging import silence_transformer_nag
 from levanter.models.attention import AttentionBackend, AttentionMask, dot_product_attention
 from levanter.models.lm_model import LmConfig
 from levanter.utils.flop_utils import lm_flops_per_token
-from levanter.utils.py_utils import cached_classproperty
 
 
 silence_transformer_nag()
@@ -82,10 +81,9 @@ class Gpt2Config(HFCompatConfig):
     def model_type(self) -> Type["Gpt2LMHeadModel"]:
         return Gpt2LMHeadModel
 
-    @cached_classproperty
-    def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["Gpt2Config"]:  # type: ignore
+    def hf_checkpoint_converter(self) -> HFCheckpointConverter["Gpt2Config"]:  # type: ignore
         # We trust this code because it's in our hub repo
-        return HFCheckpointConverter(cls, "gpt2", ignore_prefix="transformer")
+        return HFCheckpointConverter(self.__class__, reference_checkpoint="gpt2", ignore_prefix="transformer")
 
     def to_hf_config(self, vocab_size, config_overrides=None) -> HfGpt2Config:
         if config_overrides is None:

--- a/src/levanter/models/mistral.py
+++ b/src/levanter/models/mistral.py
@@ -23,7 +23,6 @@ from levanter.models.attention import AttentionBackend, AttentionMask
 from levanter.models.llama import LlamaConfig, LlamaEmbedding, LlamaTransformer
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.utils.flop_utils import lm_flops_per_token
-from levanter.utils.py_utils import cached_classproperty
 
 
 silence_transformer_nag()
@@ -82,10 +81,9 @@ class MistralConfig(LlamaConfig):
     Mlp = property(lambda self: Axis(name="mlp", size=self.intermediate_dim))
     HeadSize = property(lambda self: Axis(name="head_size", size=self.hidden_dim // self.num_heads))
 
-    @cached_classproperty
-    def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["MistralConfig"]:  # type: ignore
+    def hf_checkpoint_converter(self) -> HFCheckpointConverter["MistralConfig"]:  # type: ignore
         return HFCheckpointConverter(
-            cls,  # type: ignore
+            self,
             "mistralai/Mistral-7B-v0.1",
             trust_remote_code=True,
             tokenizer="mistralai/Mistral-7B-v0.1",

--- a/src/levanter/models/mpt.py
+++ b/src/levanter/models/mpt.py
@@ -32,7 +32,6 @@ from levanter.models.attention import AttentionMask
 from levanter.models.lm_model import LmConfig
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import use_cpu_device
-from levanter.utils.py_utils import cached_classproperty
 
 
 silence_transformer_nag()
@@ -157,9 +156,8 @@ class MptConfig(HFCompatConfig):
     def model_type(self) -> Type["MptLmHeadModel"]:
         return MptLmHeadModel
 
-    @cached_classproperty
-    def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["MptConfig"]:  # type: ignore
-        return HFCheckpointConverter(cls, "mosaicml/mpt-7b", trust_remote_code=False)
+    def hf_checkpoint_converter(self) -> HFCheckpointConverter["MptConfig"]:  # type: ignore
+        return HFCheckpointConverter(self, "mosaicml/mpt-7b", trust_remote_code=False)
 
     @classmethod
     def from_hf_config(cls, config):

--- a/src/levanter/models/whisper.py
+++ b/src/levanter/models/whisper.py
@@ -29,7 +29,6 @@ from levanter.logging import silence_transformer_nag
 from levanter.models.asr_model import ASRConfig, ASRMixin
 from levanter.models.attention import AttentionBackend, AttentionMask, dot_product_attention
 from levanter.models.lm_model import LmConfig
-from levanter.utils.py_utils import cached_classproperty
 
 
 silence_transformer_nag()
@@ -74,9 +73,8 @@ class WhisperConfig(HFCompatConfig, ASRConfig):
     def asr_model_type(self) -> Type["WhisperASRModel"]:
         return WhisperASRModel
 
-    @cached_classproperty
-    def default_hf_checkpoint_converter(cls) -> HFCheckpointConverter["WhisperModel"]:  # type: ignore
-        return HFCheckpointConverter(cls, "openai/whisper-base", ignore_prefix="model")
+    def hf_checkpoint_converter(self) -> HFCheckpointConverter["WhisperModel"]:  # type: ignore
+        return HFCheckpointConverter(self, "openai/whisper-base", ignore_prefix="model")
 
     # Axis
     MelPos = property(lambda self: Axis(name="position", size=self.max_source_positions * 2))

--- a/tests/test_backpack.py
+++ b/tests/test_backpack.py
@@ -54,7 +54,7 @@ def test_backpack_nano_compare():
     vocab_size = 5257
     torch.manual_seed(0)
 
-    converter = BackpackConfig.default_hf_checkpoint_converter
+    converter = BackpackConfig().hf_checkpoint_converter()
 
     # a bit hacky, using some internal-y APIs of transformers
     cls = converter.HFAutoModelClass()

--- a/tests/test_gemma.py
+++ b/tests/test_gemma.py
@@ -155,8 +155,6 @@ def test_gemma_roundtrip(scan_layers, num_kv_heads):
     import torch
     from transformers import AutoModelForCausalLM, GemmaForCausalLM
 
-    converter = GemmaConfig.default_hf_checkpoint_converter
-
     config = GemmaConfig(
         seq_len=128,
         hidden_dim=16,
@@ -165,6 +163,8 @@ def test_gemma_roundtrip(scan_layers, num_kv_heads):
         gradient_checkpointing=False,
         scan_layers=scan_layers,
     )
+    converter = config.hf_checkpoint_converter()
+
     Vocab = hax.Axis("vocab", 1000)
     hf_config = config.to_hf_config(Vocab.size)
 
@@ -186,7 +186,10 @@ def test_gemma_roundtrip(scan_layers, num_kv_heads):
         torch_model.save_pretrained(f"{tmpdir}/torch_model")
 
         model = converter.load_pretrained(
-            GemmaLMHeadModel, f"{tmpdir}/torch_model", resize_vocab_to_match_tokenizer=False
+            converter.default_config.model_type,
+            converter.default_config,
+            f"{tmpdir}/torch_model",
+            resize_vocab_to_match_tokenizer=False,
         )
 
         def compute(input):

--- a/tests/test_hf_checkpoints.py
+++ b/tests/test_hf_checkpoints.py
@@ -21,7 +21,7 @@ from test_utils import skip_if_no_torch
 def test_save_backpack_model_with_code():
     import torch
 
-    converter = BackpackConfig.default_hf_checkpoint_converter
+    converter = BackpackConfig().hf_checkpoint_converter()
     tokenizer = converter.tokenizer
     cls = converter.HFAutoModelClass()
     config = converter.HfConfigClass(
@@ -59,7 +59,9 @@ def test_save_backpack_model_with_code():
         new_converter = converter.replaced(reference_checkpoint=tmpdir, trust_remote_code=True)
 
         assert new_converter.config_from_hf_config(config) == lev_config
-        loaded_model = new_converter.load_pretrained(BackpackLMHeadModel)
+        loaded_model = new_converter.load_pretrained(
+            new_converter.default_config.model_type, new_converter.default_config
+        )
         loaded_model = inference_mode(loaded_model, True)
 
         assert loaded_model.config == lev_model.config
@@ -99,9 +101,8 @@ def test_conversion_to_jnp_bfloat16():
 
 
 def test_save_sharded_checkpoints():
-    converter = Gpt2Config.default_hf_checkpoint_converter
-
     nano_config = Gpt2Config(hidden_dim=64, num_heads=2, num_layers=2, resid_pdrop=0.0, use_flash_attention=False)
+    converter = nano_config.hf_checkpoint_converter()
 
     nano_model = Gpt2LMHeadModel.init(converter.Vocab, nano_config, key=PRNGKey(3))
 
@@ -116,7 +117,7 @@ def test_save_sharded_checkpoints():
 
         assert len(glob.glob(tmpdir + "/*.safetensors")) > 1
 
-        loaded_model = converter.load_pretrained(nano_model.config, ref=tmpdir, dtype=mp.param_dtype)
+        loaded_model = converter.load_pretrained(Gpt2LMHeadModel, nano_model.config, ref=tmpdir, dtype=mp.param_dtype)
 
         assert loaded_model.config == nano_model.config
         assert loaded_model.Vocab == nano_model.Vocab

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -264,7 +264,7 @@ def test_llama_roundtrip(scan_layers, num_kv_heads):
     import torch
     from transformers import AutoModelForCausalLM, LlamaForCausalLM
 
-    converter = LlamaConfig.default_hf_checkpoint_converter
+    converter = LlamaConfig().hf_checkpoint_converter()
 
     config = LlamaConfig(
         seq_len=128,
@@ -295,7 +295,7 @@ def test_llama_roundtrip(scan_layers, num_kv_heads):
         torch_model.save_pretrained(f"{tmpdir}/torch_model")
 
         model = converter.load_pretrained(
-            LlamaLMHeadModel, f"{tmpdir}/torch_model", resize_vocab_to_match_tokenizer=False
+            LlamaLMHeadModel, config, f"{tmpdir}/torch_model", resize_vocab_to_match_tokenizer=False
         )
 
         def compute(input):

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -112,8 +112,10 @@ def test_lora_peft_integration():
 
     hf_dict = get_peft_model_state_dict(model)
 
-    converter = Gpt2Config.default_hf_checkpoint_converter
-    lev_model = converter.load_pretrained(Gpt2LMHeadModel, "stanford-crfm/expanse-gpt2-small-x777")
+    converter = Gpt2Config().hf_checkpoint_converter
+    lev_model = converter.load_pretrained(
+        converter.default_config, converter.default_config.model_type, "stanford-crfm/expanse-gpt2-small-x777"
+    )
 
     lora_lev_model = loraize(lev_model, LoraConfig(r=8, target_modules=["c_attn"]), key=jax.random.PRNGKey(0))
     # for some dumb reason, the hf state dict starts with this prefix
@@ -180,7 +182,7 @@ def test_merge_lora():
 def test_lora_load_in_peft():
     import torch
 
-    converter: HFCheckpointConverter = Gpt2Config.default_hf_checkpoint_converter
+    converter: HFCheckpointConverter = Gpt2Config().hf_checkpoint_converter()
     config = Gpt2Config(seq_len=128, num_layers=2, num_heads=2)
     Vocab = converter.Vocab
 
@@ -229,7 +231,7 @@ def test_lora_load_in_peft():
 def test_lora_merged_load_in_hf():
     import torch
 
-    converter: HFCheckpointConverter = Gpt2Config.default_hf_checkpoint_converter
+    converter: HFCheckpointConverter = Gpt2Config().hf_checkpoint_converter()
     config = Gpt2Config(seq_len=128, num_layers=2, num_heads=2)
     Vocab = converter.Vocab
 

--- a/tests/test_mistral.py
+++ b/tests/test_mistral.py
@@ -81,8 +81,6 @@ def test_mistral_roundtrip(num_kv_heads):
     import torch
     from transformers import AutoModelForCausalLM, MistralForCausalLM
 
-    converter = MistralConfig.default_hf_checkpoint_converter
-
     config = MistralConfig(
         seq_len=128,
         hidden_dim=16,
@@ -90,6 +88,8 @@ def test_mistral_roundtrip(num_kv_heads):
         num_kv_heads=num_kv_heads,
         gradient_checkpointing=False,
     )
+    converter = config.hf_checkpoint_converter()
+
     Vocab = hax.Axis("vocab", 1000)
     hf_config = config.to_hf_config(Vocab.size)
 
@@ -111,7 +111,10 @@ def test_mistral_roundtrip(num_kv_heads):
         torch_model.save_pretrained(f"{tmpdir}/torch_model")
 
         model = converter.load_pretrained(
-            MistralLMHeadModel, f"{tmpdir}/torch_model", resize_vocab_to_match_tokenizer=False
+            converter.default_config.model_type,
+            converter.default_config,
+            f"{tmpdir}/torch_model",
+            resize_vocab_to_match_tokenizer=False,
         )
 
         def compute(input):

--- a/tests/test_mpt.py
+++ b/tests/test_mpt.py
@@ -24,7 +24,7 @@ def test_mpt_nano_compare(attn_impl):
     torch.manual_seed(0)
 
     # a bit hacky, using some internal-y APIs of transformers
-    converter = MptConfig.default_hf_checkpoint_converter
+    converter = MptConfig().hf_checkpoint_converter()
     cls = converter.HFAutoModelClass()
     config = converter.HfConfigClass(
         d_model=32,

--- a/tests/whisper_test.py
+++ b/tests/whisper_test.py
@@ -129,7 +129,7 @@ def test_namedarray_mask_forward_whisper():
 @skip_if_no_torch
 def test_hf_roundtrip():
     model_id = "openai/whisper-tiny"
-    converter = WhisperConfig.default_hf_checkpoint_converter
+    converter = WhisperConfig().hf_checkpoint_converter()
     c = HfWhisperConfig.from_pretrained(model_id)
     config = WhisperConfig.from_hf_config(c)
     processor = WhisperProcessor.from_pretrained(model_id)
@@ -137,7 +137,7 @@ def test_hf_roundtrip():
     torch_model: HfWhisperModel = HfWhisperModel.from_pretrained(model_id)
     torch_model.eval()
 
-    model: WhisperModel = cast(WhisperModel, converter.load_pretrained(config, RepoRef(model_id)))
+    model: WhisperModel = cast(WhisperModel, converter.load_pretrained(config.model_type, config, RepoRef(model_id)))
     model = inference_mode(model, True)
 
     ds = load_dataset("WillHeld/test_librispeech_parquet", split="validation")


### PR DESCRIPTION
* Makes the HF converter an instance method instead of a class property. This
  makes it easier to instantiate a model family like LLama with a different
  reference checkpoint.

* Change the HF checkpoint converter to always accept an LmConfig instead of a
  bare model or config object. There were only a few places where the model was
  still being passed in.