### PR TITLE
Add chunked device->host copy for torch serialization.

### DIFF
--- a/src/levanter/compat/torch_serialization.py
+++ b/src/levanter/compat/torch_serialization.py
@@ -442,7 +442,7 @@ def to_numpy_state_dict(model, prefix: Optional[str] = None) -> StateDict:
 
                 shardings = [None if i != axis_to_shard else "device" for i in range(len(arr.shape))]
                 sharding = NamedSharding(process_mesh, PartitionSpec(*shardings))
-                out = jax.jit(_identity_fn, out_shardings=sharding)(arr)
+                out = jax.device_put(arr, sharding)
                 return np.array(out)
 
         # need to make sure the model is on *this machine* and *this machine's CPU* before saving


### PR DESCRIPTION
Previously we applied a naive sharding to arrays when copying to the host to
avoid risking a device OOM. This instead flattens and copies arrays in chunks
to the CPU to achieve the same effect but avoids some issues with how JAX
handles device meshes.