### PR TITLE
Update c4's weight in dolma dataset

### DIFF
--- a/config/data/dolma_olmo_paloma.yaml
+++ b/config/data/dolma_olmo_paloma.yaml
@@ -108,7 +108,7 @@ train_weights:
   dolma-algebraic-stack: 12.6 # 12.6 * 1.0
   dolma-arxiv: 28.0 # 28.0 * 1.0
   dolma-gutenberg: 5.3 # 5.3 * 1.0
-  dolma-c4: 69.2 # 138.4 * 0.5
+  dolma-c4: 124.95 # 249.9 * 0.5
   dolma-cc: 597.75 # 1,195.5 * 0.5
   dolma-cc-news: 14.3 # 1.0
   dolma-falcon: 456.4 # 1.0, refined web


### PR DESCRIPTION
On [Dolma's page](https://huggingface.co/datasets/allenai/dolma#summary-statistics-v17), it says c4's sampling rate is 50%. However, that introduced a gap with the claimed total. 

In [this thread](https://huggingface.co/datasets/allenai/dolma/discussions/36#6678f77f25771fc36d893eea), Dolma/OLMo's team clarified that it should be 100%. 