### PR TITLE
Add cast to compute datatype in tagged evaluator

### DIFF
--- a/src/levanter/eval.py
+++ b/src/levanter/eval.py
@@ -172,7 +172,7 @@ class TaggedEvaluator:
         device_mesh=None,
         axis_mapping=None,
         max_examples_per_dataset=None,
-        mp: jmp.Policy = None,
+        mp: Optional[jmp.Policy] = None,
     ):
         self.EvalBatch = EvalBatch
         self.dataset = DomainTaggedDataset(tagged_eval_sets, max_examples_per_dataset)
@@ -199,7 +199,9 @@ class TaggedEvaluator:
             m: LmHeadModel, state: tuple[RunningMean, RunningMean], batch: LmExample, tags: hax.NamedArray
         ):
             m = inference_mode(m, True)
-            m = self.mp.cast_to_compute(m)
+
+            if self.mp is not None:
+                m = self.mp.cast_to_compute(m)
             with hax.axis_mapping(axis_mapping):
                 total_mean, mean_per_tag = state
                 losses = m.compute_loss(batch, reduction=None, reduction_axis=())

--- a/src/levanter/eval.py
+++ b/src/levanter/eval.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Callable, Optional, Sequence, TypeVar
 
 import jax.numpy as jnp
+import jmp
 import numpy as np
 import tqdm
 from jax.sharding import Mesh
@@ -90,6 +91,7 @@ def cb_tagged_lm_evaluate(
     axis_mapping: ResourceMapping = None,
     max_examples_per_dataset: Optional[int] = None,
     prefix: str = "eval",
+    mp: jmp.Policy = None,
 ) -> Callable[[StepInfo], EvalResult]:
     """
     Evaluates multiple tagged datasets using a given evaluation function.
@@ -110,7 +112,9 @@ def cb_tagged_lm_evaluate(
         axis_mapping: The axis mapping to use for evaluation
     """
 
-    evaluator = TaggedEvaluator(EvalBatch, tagged_eval_sets, device_mesh, axis_mapping, max_examples_per_dataset)
+    evaluator = TaggedEvaluator(
+        EvalBatch, tagged_eval_sets, device_mesh, axis_mapping, max_examples_per_dataset, mp=mp
+    )
 
     def eval_callback(step: StepInfo):
         with levanter.tracker.capture_time() as time_fn:
@@ -162,13 +166,20 @@ class TaggedEvaluator:
     """
 
     def __init__(
-        self, EvalBatch: hax.Axis, tagged_eval_sets, device_mesh=None, axis_mapping=None, max_examples_per_dataset=None
+        self,
+        EvalBatch: hax.Axis,
+        tagged_eval_sets,
+        device_mesh=None,
+        axis_mapping=None,
+        max_examples_per_dataset=None,
+        mp: jmp.Policy = None,
     ):
         self.EvalBatch = EvalBatch
         self.dataset = DomainTaggedDataset(tagged_eval_sets, max_examples_per_dataset)
         self.loader = ReplicatedBatchLoader(
             self.dataset, mesh=device_mesh, axis_resources=axis_mapping, Batch=EvalBatch
         )
+        self.mp = mp
 
         # tags are arranged hierarchically with "/" as separator. We want to log the average loss for each tag.
         hierarchy: dict[str, list[int]] = {}
@@ -188,6 +199,7 @@ class TaggedEvaluator:
             m: LmHeadModel, state: tuple[RunningMean, RunningMean], batch: LmExample, tags: hax.NamedArray
         ):
             m = inference_mode(m, True)
+            m = self.mp.cast_to_compute(m)
             with hax.axis_mapping(axis_mapping):
                 total_mean, mean_per_tag = state
                 losses = m.compute_loss(batch, reduction=None, reduction_axis=())

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -158,7 +158,12 @@ def main(config: TrainLmConfig):
                 max_eval_examples_per_ds *= config.trainer.eval_batch_size
 
             cb = levanter.eval.cb_tagged_lm_evaluate(
-                EvalBatch, causal_datasets, trainer.device_mesh, compute_axis_mapping, max_eval_examples_per_ds
+                EvalBatch,
+                causal_datasets,
+                trainer.device_mesh,
+                compute_axis_mapping,
+                max_eval_examples_per_ds,
+                mp=config.trainer.mp,
             )
             trainer.add_hook(cb, every=config.trainer.steps_per_eval)
 


### PR DESCRIPTION
Ran into an issue with the evaluator on TPUs when some parameters are in float32 and some are in bfloat16. I was adding LoRAs to the attention projections and there must've been some odd casting going on, but it would work on CPU and not on TPU 🤷. Adding a cast to the compute datatype in the jitted accumulator of the evaluator fixed the issue. 