### PR TITLE
Add option to use ghcr in launch.py

### DIFF
--- a/docs/Getting-Started-TPU-VM.md
+++ b/docs/Getting-Started-TPU-VM.md
@@ -117,6 +117,14 @@ EOF
 
 If you want to customize the docker image that is created and uploaded to GCP Artifact Registry, you can add config `image_name: "YOUR-DOCKER-NAME"`.
 
+Note that you can also configure docker to push to GHCR by setting
+```
+docker_registry: ghcr
+github_user: <YOUR USERNAME>
+github_token: <YOUR TOKEN>
+```
+By default, the tpu instance won't be able to access the docker image, so you may need to make it public.
+
 Now run `launch.py`. This will package your current directory into a Docker image and run it on your workers. Everything after the `--` is run on each worker.
 
 ```bash

--- a/infra/launch.py
+++ b/infra/launch.py
@@ -153,6 +153,9 @@ if __name__ == "__main__":
     cli.add_arg(parser, config, ["--zone"], required=True)
     cli.add_arg(parser, config, ["--retries"], default=0, type=int)
     cli.add_arg(parser, config, ["--run_id"], default=_default_run_id(), type=str)
+    cli.add_arg(parser, config, ["--docker_registry"], default="gcp", choices=["gcp", "ghcr"])
+    cli.add_arg(parser, config, ["--github_user"], type=str)
+    cli.add_arg(parser, config, ["--github_token"], type=str)
 
     parser.add_argument(
         "-e", "--env", action="append", nargs=2, metavar=("KEY", "VALUE"), default=config.get("env", {}).items()
@@ -178,6 +181,9 @@ if __name__ == "__main__":
     version = args.version
     zone = args.zone
     run_id = args.run_id
+    registry = args.docker_registry
+    github_user = args.github_user
+    github_token = args.github_token
 
     region = "-".join(zone.split("-")[:-1])
     env = {k: v for k, v in args.env}
@@ -210,14 +216,25 @@ if __name__ == "__main__":
             # make an image tag based on the unix timestamp to ensure we always pull the latest image
             tag = int(time.time())
 
-            full_image_id = push_docker.push_to_gcp(
-                project_id=project,
-                region=region,
-                repository=docker_repository,
-                image_name=image_id,
-                tag=tag,
-                docker_file="docker/tpu/Dockerfile.incremental",
-            )
+            if registry == "ghcr":
+                full_image_id = push_docker.push_to_github(
+                    local_image=image_id,
+                    tag=tag,
+                    github_user=github_user,
+                    github_token=github_token,
+                    docker_file="docker/tpu/Dockerfile.incremental",
+                )
+            elif registry == "gcp":
+                full_image_id = push_docker.push_to_gcp(
+                    project_id=project,
+                    region=region,
+                    repository=docker_repository,
+                    image_name=image_id,
+                    tag=tag,
+                    docker_file="docker/tpu/Dockerfile.incremental",
+                )
+            else:
+                raise ValueError(f"Unknown docker registry: {args.docker_registry}")
 
             git_commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
 


### PR DESCRIPTION
Adds the option for pushing containers to GHCR instead of GCP container registry into launch.py and adds a note in the TPU docs for it.