### PR TITLE
Fix typo in GLU MLP calculation

### DIFF
--- a/src/levanter/utils/flop_utils.py
+++ b/src/levanter/utils/flop_utils.py
@@ -15,11 +15,12 @@ def lm_flops_per_token(
     glu: bool,
 ):
     head_dim = hidden_dim / num_heads
-    mlp = 2 * (2 if glu else 3) * hidden_dim * intermediate_dim
+    mlp = 2 * (3 if glu else 2) * hidden_dim * intermediate_dim
     qkv_proj = 2 * hidden_dim * (num_heads * head_dim + 2 * num_kv_heads * head_dim)
     dense_proj = 2 * hidden_dim * hidden_dim
     # The following are across the whole sequence
-    key_query_logits = 2 * seq_len * (seq_len / 2) * num_heads * head_dim
+    # assume full attention map like megatron-lm
+    key_query_logits = 2 * seq_len**2 * num_heads * head_dim
     mask = 3 * seq_len * seq_len * num_heads
     mask_value = 2 * seq_len * seq_len * head_dim * num_heads
     seq_flops = key_query_logits + mask + mask_value

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -47,11 +47,13 @@ def test_llama_config():
 
 def test_llama_flops():
     # Check that the forward flops is within 10% of the naive calculation
-    hf_config = transformers.LlamaConfig.from_pretrained("huggyllama/llama-7b")
+    hf_config = transformers.LlamaConfig.from_pretrained("NousResearch/Llama-2-7b-hf")
     llama_config = LlamaConfig.from_hf_config(hf_config)
-    n_params = 6.7e9
-    ratio = 2 * n_params / llama_config.flops_per_token(hf_config.vocab_size)
-    assert ratio > 0.85, f"ratio {ratio} < 0.9"
+    n_params = 6.738415616e9
+    ratio = llama_config.flops_per_token(hf_config.vocab_size) / (2 * n_params)
+    print(ratio)
+    assert ratio > 1.1, f"ratio {ratio} < 1.1"
+    assert ratio < 1.2, f"ratio {ratio} > 1.2"
 
 
 @skip_if_no_torch


### PR DESCRIPTION
This was a big dumb on my part. 
* Our `calculated_flops / (2*n_param)` should be _greater_ than 1.0 (about 1.13) since we take into account more than just the projections.
* I had a typo that multiplied the MLP flops by 2 instead of 3 if the model is a GLU. My bad!