### PR TITLE
Address capacity_type and env variables

### DIFF
--- a/docs/Getting-Started-TPU-VM.md
+++ b/docs/Getting-Started-TPU-VM.md
@@ -108,7 +108,7 @@ zone: us-west4-a
 tpu_name: test-spin-up-32
 tpu_type: "v5litepod-16"
 vm_image: "tpu-ubuntu2204-base"
-preemptible: true
+capacity_type: "preemptible"
 autodelete: false
 subnetwork: "default"
 

--- a/infra/launch.py
+++ b/infra/launch.py
@@ -158,11 +158,7 @@ if __name__ == "__main__":
     cli.add_arg(parser, config, ["--github_token"], type=str)
 
     parser.add_argument(
-        "-e", "--env", 
-        action="append", 
-        nargs=2, 
-        metavar=("KEY", "VALUE"), 
-        default=list(config.get("env", {}).items())
+        "-e", "--env", action="append", nargs=2, metavar=("KEY", "VALUE"), default=list(config.get("env", {}).items())
     )
     parser.add_argument("command", nargs=argparse.REMAINDER)
 

--- a/infra/launch.py
+++ b/infra/launch.py
@@ -158,7 +158,11 @@ if __name__ == "__main__":
     cli.add_arg(parser, config, ["--github_token"], type=str)
 
     parser.add_argument(
-        "-e", "--env", action="append", nargs=2, metavar=("KEY", "VALUE"), default=config.get("env", {}).items()
+        "-e", "--env", 
+        action="append", 
+        nargs=2, 
+        metavar=("KEY", "VALUE"), 
+        default=list(config.get("env", {}).items())
     )
     parser.add_argument("command", nargs=argparse.REMAINDER)
 


### PR DESCRIPTION
1. With the new `capacity_type` argument, the way to set preemptible instance via .config should be updated -- https://github.com/stanford-crfm/levanter/issues/657
2. Fix setting environment variable in launch.py