### PR TITLE
Allow mounting extrenal directory to docker image

### DIFF
--- a/docker/tpu/Dockerfile.incremental
+++ b/docker/tpu/Dockerfile.incremental
@@ -4,7 +4,7 @@ ARG TAG=latest
 FROM ${IMAGE}:${TAG}
 
 # This usually is a config directory so users can have their own config directory outside the repo.
-ARG MOUNT_PATH=./config
+ARG MOUNT_PATH=/config
 
 ENV TENSORSTORE_CURL_LOW_SPEED_TIME_SECONDS=60\
     TENSORSTORE_CURL_LOW_SPEED_LIMIT_BYTES=1024\

--- a/docker/tpu/Dockerfile.incremental
+++ b/docker/tpu/Dockerfile.incremental
@@ -4,7 +4,7 @@ ARG TAG=latest
 FROM ${IMAGE}:${TAG}
 
 # This usually is a config directory so users can have their own config directory outside the repo.
-ARG MOUNT_PATH=/config
+ARG EXTRA_CTX=/config
 
 ENV TENSORSTORE_CURL_LOW_SPEED_TIME_SECONDS=60\
     TENSORSTORE_CURL_LOW_SPEED_LIMIT_BYTES=1024\
@@ -19,6 +19,6 @@ ADD pyproject.toml README.md /opt/levanter/
 RUN pip install -e '.[test]'
 ADD . /opt/levanter
 
-# Mount $MOUNT_PATH to the same location as in local machine.
+# Add $EXTRA_CTX to the same location as in local machine.
 # so that the same (config) path(s) specified in train_lm.py argument still works
-COPY .mnt $MOUNT_PATH
+COPY .mnt $EXTRA_CTX

--- a/docker/tpu/Dockerfile.incremental
+++ b/docker/tpu/Dockerfile.incremental
@@ -3,6 +3,9 @@ ARG TAG=latest
 
 FROM ${IMAGE}:${TAG}
 
+# This usually is a config directory so users can have their own config directory outside the repo.
+ARG MOUNT_PATH=./config
+
 ENV TENSORSTORE_CURL_LOW_SPEED_TIME_SECONDS=60\
     TENSORSTORE_CURL_LOW_SPEED_LIMIT_BYTES=1024\
     RAY_USAGE_STATS_ENABLED=0\
@@ -15,3 +18,7 @@ WORKDIR /opt/levanter
 ADD pyproject.toml README.md /opt/levanter/
 RUN pip install -e '.[test]'
 ADD . /opt/levanter
+
+# Mount $MOUNT_PATH to the same location as in local machine.
+# so that the same (config) path(s) specified in train_lm.py argument still works
+COPY .mnt $MOUNT_PATH

--- a/docs/Getting-Started-TPU-VM.md
+++ b/docs/Getting-Started-TPU-VM.md
@@ -138,6 +138,13 @@ To run in the foreground, use `--foreground` with the `launch.py` script. You sh
 python infra/launch.py -- python src/levanter/main/train_lm.py --config_path config/gpt2_small.yaml --trainer.checkpointer.base_path gs://<somewhere>'
 ```
 
+### Using external directory/file
+
+In case that you want to reference some external directory/file outside of the levanter repo, you can do it by mounting the external directory/file to the docker image so that it becomes accessible in TPU instances. You can specify the path you want to mount by `--mount_path` with the `launch.py` script. Then, you should be able to use the mounted files in arguments in `train_lm.py` etc.
+```bash
+python infra/launch.py --mount_path <external path> -- python src/levanter/main/train_lm.py --config_path <external path> --trainer.checkpointer.base_path gs://<somewhere>'
+```
+
 ### Babysitting Script
 
 If you are using a preemptible TPU VM, you probably want to use the "babysitting" script that automatically re-creates

--- a/docs/Getting-Started-TPU-VM.md
+++ b/docs/Getting-Started-TPU-VM.md
@@ -140,7 +140,7 @@ python infra/launch.py -- python src/levanter/main/train_lm.py --config_path con
 
 ### Using external directory/file
 
-In case that you want to reference some external directory/file outside of the levanter repo, you can do it by mounting the external directory/file to the docker image so that it becomes accessible in TPU instances. You can specify the path you want to mount by `--extra_context` with the `launch.py` script. Then, you should be able to use the mounted files in arguments in `train_lm.py` etc.
+In case that you want to reference some external directory/file outside of the levanter repo, you can do it by adding the external directory/file to the docker image so that it becomes accessible in TPU instances. You can specify the path you want to add as extra buildl context by `--extra_context` with the `launch.py` script. Then, you should be able to use the external files in arguments in `train_lm.py` etc.
 ```bash
 python infra/launch.py --extra_context <external path> -- python src/levanter/main/train_lm.py --config_path <external path> --trainer.checkpointer.base_path gs://<somewhere>'
 ```

--- a/docs/Getting-Started-TPU-VM.md
+++ b/docs/Getting-Started-TPU-VM.md
@@ -140,9 +140,9 @@ python infra/launch.py -- python src/levanter/main/train_lm.py --config_path con
 
 ### Using external directory/file
 
-In case that you want to reference some external directory/file outside of the levanter repo, you can do it by mounting the external directory/file to the docker image so that it becomes accessible in TPU instances. You can specify the path you want to mount by `--mount_path` with the `launch.py` script. Then, you should be able to use the mounted files in arguments in `train_lm.py` etc.
+In case that you want to reference some external directory/file outside of the levanter repo, you can do it by mounting the external directory/file to the docker image so that it becomes accessible in TPU instances. You can specify the path you want to mount by `--extra_context` with the `launch.py` script. Then, you should be able to use the mounted files in arguments in `train_lm.py` etc.
 ```bash
-python infra/launch.py --mount_path <external path> -- python src/levanter/main/train_lm.py --config_path <external path> --trainer.checkpointer.base_path gs://<somewhere>'
+python infra/launch.py --extra_context <external path> -- python src/levanter/main/train_lm.py --config_path <external path> --trainer.checkpointer.base_path gs://<somewhere>'
 ```
 
 ### Babysitting Script

--- a/infra/launch.py
+++ b/infra/launch.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     cli.add_arg(parser, config, ["--docker_registry"], default="gcp", choices=["gcp", "ghcr"])
     cli.add_arg(parser, config, ["--github_user"], type=str)
     cli.add_arg(parser, config, ["--github_token"], type=str)
-    cli.add_arg(parser, config, ["--mount_path"], type=Path, default=Path("config"))
+    cli.add_arg(parser, config, ["--extra_context"], type=Path, default=Path("config"))
 
     parser.add_argument(
         "-e", "--env", action="append", nargs=2, metavar=("KEY", "VALUE"), default=list(config.get("env", {}).items())
@@ -241,7 +241,7 @@ if __name__ == "__main__":
     registry = args.docker_registry
     github_user = args.github_user
     github_token = args.github_token
-    mount_path = args.mount_path
+    extra_context = args.extra_context
 
     region = "-".join(zone.split("-")[:-1])
     env = {k: v for k, v in args.env}
@@ -262,7 +262,7 @@ if __name__ == "__main__":
             github_user=github_user,
             github_token=github_token,
             docker_file="docker/tpu/Dockerfile.incremental",
-            mount_path=mount_path,
+            extra_context=extra_context,
         )
     elif registry == "gcp":
         full_image_id = push_docker.push_to_gcp(
@@ -272,7 +272,7 @@ if __name__ == "__main__":
             image_name=image_id,
             tag=tag,
             docker_file="docker/tpu/Dockerfile.incremental",
-            mount_path=mount_path,
+            extra_context=extra_context,
         )
     else:
         raise ValueError(f"Unknown docker registry: {args.docker_registry}")

--- a/infra/launch.py
+++ b/infra/launch.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import time
+from pathlib import Path
 
 from infra import push_docker
 from infra.helpers import cli
@@ -210,6 +211,7 @@ if __name__ == "__main__":
     cli.add_arg(parser, config, ["--docker_registry"], default="gcp", choices=["gcp", "ghcr"])
     cli.add_arg(parser, config, ["--github_user"], type=str)
     cli.add_arg(parser, config, ["--github_token"], type=str)
+    cli.add_arg(parser, config, ["--mount_path"], type=Path, default=Path("config"))
 
     parser.add_argument(
         "-e", "--env", action="append", nargs=2, metavar=("KEY", "VALUE"), default=list(config.get("env", {}).items())
@@ -239,6 +241,7 @@ if __name__ == "__main__":
     registry = args.docker_registry
     github_user = args.github_user
     github_token = args.github_token
+    mount_path = args.mount_path
 
     region = "-".join(zone.split("-")[:-1])
     env = {k: v for k, v in args.env}
@@ -259,6 +262,7 @@ if __name__ == "__main__":
             github_user=github_user,
             github_token=github_token,
             docker_file="docker/tpu/Dockerfile.incremental",
+            mount_path=mount_path,
         )
     elif registry == "gcp":
         full_image_id = push_docker.push_to_gcp(
@@ -268,6 +272,7 @@ if __name__ == "__main__":
             image_name=image_id,
             tag=tag,
             docker_file="docker/tpu/Dockerfile.incremental",
+            mount_path=mount_path,
         )
     else:
         raise ValueError(f"Unknown docker registry: {args.docker_registry}")

--- a/infra/push_docker.py
+++ b/infra/push_docker.py
@@ -160,14 +160,14 @@ def build_docker(docker_file, image_name, tag, mount_src) -> str:
 
     # Get mounting path in docker image.
     levanter_path = Path("/opt/levanter")
-    mount_path = levanter_path / mount_src
+    extra_context = levanter_path / mount_src
     _run(
         [
             "docker",
             "buildx",
             "build",
             "--build-arg",
-            f"MOUNT_PATH={mount_path.resolve()}",
+            f"EXTRA_CTX={extra_context.resolve()}",
             "--platform=linux/amd64",
             "-t",
             f"{image_name}:{tag}",

--- a/infra/push_docker.py
+++ b/infra/push_docker.py
@@ -9,9 +9,12 @@ script will automatically build and deploy an image based on your current code.
 
 import argparse
 import json
+import os
 import pty
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 from infra.helpers import cli
 
@@ -33,6 +36,25 @@ GCP_CLEANUP_POLICY = [
         },
     },
 ]
+
+
+def _cp(src, dst):
+    assert not dst.exists(), f"Copy failed. Destination path ({dst}) already exists."
+    if src.is_dir():
+        shutil.copytree(src, dst)
+    elif src.is_file():
+        shutil.copy(src, dst)
+    else:
+        raise RuntimeError(f"Copy failed. Source path ({src}) is neither a directory nor a file. Check if it exists.")
+
+
+def _rm(path):
+    if path.is_dir():
+        shutil.rmtree(".mnt", ignore_errors=True)
+    elif path.is_file():
+        os.remove(".mnt")
+    elif path.exists():
+        raise RuntimeError(f"Remove failed. Path ({path}) is neither a directory nor a file.")
 
 
 def _run(argv):
@@ -128,14 +150,20 @@ def configure_gcp_docker(project_id, region, repository):
     _run(["gcloud", "auth", "configure-docker", "--quiet", f"{region}-docker.pkg.dev"])
 
 
-def build_docker(docker_file, image_name, tag) -> str:
+def build_docker(docker_file, image_name, tag, mount_src) -> str:
     """Builds a Docker image, enables artifact access, and pushes to Artifact Registry."""
+    # Copy external files temporarily to .mnt
+    mount_dst = Path(".mnt")
+    _rm(mount_dst)  # Remove previous .mnt if necessary
+    _cp(mount_src, mount_dst)
 
     _run(
         [
             "docker",
             "buildx",
             "build",
+            "--build-arg",
+            f"MOUNT_PATH={mount_src.absolute()}",
             "--platform=linux/amd64",
             "-t",
             f"{image_name}:{tag}",
@@ -144,12 +172,14 @@ def build_docker(docker_file, image_name, tag) -> str:
             ".",
         ]
     )
+    # clean up after building
+    _rm(mount_dst)
 
     return f"{image_name}:{tag}"
 
 
 # Disabled until we can figure out how Docker hub organizations work
-def push_to_github(local_image, tag, github_user=None, github_token=None, docker_file=None):
+def push_to_github(local_image, tag, github_user=None, github_token=None, docker_file=None, mount_path=None):
     """Pushes a local Docker image to Docker Hub."""
 
     # Authenticate the docker service with Github if a token exists
@@ -160,17 +190,17 @@ def push_to_github(local_image, tag, github_user=None, github_token=None, docker
         print(login_process.communicate(input=github_token.encode(), timeout=10))
 
     remote_name = f"ghcr.io/{github_user}/{local_image}:{tag}"
-    local_name = build_docker(docker_file=docker_file, image_name=local_image, tag=tag)
+    local_name = build_docker(docker_file=docker_file, image_name=local_image, tag=tag, mont_src=mount_path)
 
     _run(["docker", "tag", local_name, remote_name])
     _run(["docker", "push", remote_name])
     return remote_name
 
 
-def push_to_gcp(project_id, region, repository, image_name, tag, docker_file) -> str:
+def push_to_gcp(project_id, region, repository, image_name, tag, docker_file, mount_path) -> str:
     """Pushes a local Docker image to Artifact Registry."""
     configure_gcp_docker(project_id, region, repository)
-    local_image = build_docker(docker_file=docker_file, image_name=image_name, tag=tag)
+    local_image = build_docker(docker_file=docker_file, image_name=image_name, tag=tag, mount_src=mount_path)
 
     artifact_repo = f"{region}-docker.pkg.dev/{project_id}/{repository}"
 
@@ -214,4 +244,5 @@ if __name__ == "__main__":
             args.image,
             args.tag,
             docker_file=args.docker_file,
+            mount_path=Path("config"),
         )

--- a/infra/push_docker.py
+++ b/infra/push_docker.py
@@ -50,9 +50,9 @@ def _cp(src, dst):
 
 def _rm(path):
     if path.is_dir():
-        shutil.rmtree(".mnt", ignore_errors=True)
+        shutil.rmtree(path, ignore_errors=True)
     elif path.is_file():
-        os.remove(".mnt")
+        os.remove(path)
     elif path.exists():
         raise RuntimeError(f"Remove failed. Path ({path}) is neither a directory nor a file.")
 

--- a/infra/push_docker.py
+++ b/infra/push_docker.py
@@ -183,7 +183,7 @@ def build_docker(docker_file, image_name, tag, mount_src) -> str:
 
 
 # Disabled until we can figure out how Docker hub organizations work
-def push_to_github(local_image, tag, github_user=None, github_token=None, docker_file=None, mount_path=None):
+def push_to_github(local_image, tag, github_user=None, github_token=None, docker_file=None, extra_context=None):
     """Pushes a local Docker image to Docker Hub."""
 
     # Authenticate the docker service with Github if a token exists
@@ -194,17 +194,17 @@ def push_to_github(local_image, tag, github_user=None, github_token=None, docker
         print(login_process.communicate(input=github_token.encode(), timeout=10))
 
     remote_name = f"ghcr.io/{github_user}/{local_image}:{tag}"
-    local_name = build_docker(docker_file=docker_file, image_name=local_image, tag=tag, mont_src=mount_path)
+    local_name = build_docker(docker_file=docker_file, image_name=local_image, tag=tag, mount_src=extra_context)
 
     _run(["docker", "tag", local_name, remote_name])
     _run(["docker", "push", remote_name])
     return remote_name
 
 
-def push_to_gcp(project_id, region, repository, image_name, tag, docker_file, mount_path) -> str:
+def push_to_gcp(project_id, region, repository, image_name, tag, docker_file, extra_context) -> str:
     """Pushes a local Docker image to Artifact Registry."""
     configure_gcp_docker(project_id, region, repository)
-    local_image = build_docker(docker_file=docker_file, image_name=image_name, tag=tag, mount_src=mount_path)
+    local_image = build_docker(docker_file=docker_file, image_name=image_name, tag=tag, mount_src=extra_context)
 
     artifact_repo = f"{region}-docker.pkg.dev/{project_id}/{repository}"
 
@@ -248,5 +248,5 @@ if __name__ == "__main__":
             args.image,
             args.tag,
             docker_file=args.docker_file,
-            mount_path=Path("config"),
+            extra_context=Path("config"),
         )


### PR DESCRIPTION
This PR supports the case when users want to add an external directory (e.g. configs) to the docker image and send to TPU.

Specify `--mount_path` to point to the directory/file to mount, and the docker will copy the content of this directory/file to the built docker image (under the same path). Users can then reference to the content in this path in subsequent commands (e.g. reference an external config in `train_lm.py --config_path`)

Note that `--mount_path` can be using relative path (e.g. `--mount_path ../my_config/`) but any reference of external path in subsequent commands must be using absolute path (e.g. `python train_lm.py --config_path /home/shared/my_config/`). This is because the levanter repo is always mapped to `/opt/levanter` so the relative path may not be valid.