### PR TITLE
fix extra context docker build bug

### DIFF
--- a/docker/tpu/Dockerfile.incremental
+++ b/docker/tpu/Dockerfile.incremental
@@ -22,4 +22,4 @@ ADD . /opt/levanter
 
 # Add $EXTRA_CTX to the same location as in local machine.
 # it's already in the image, so we don't need to copy it. just move it if we set EXTRA_CTX
-RUN if [ -f ".mnt" ]; then mkdir -p $(dirname $EXTRA_CTX) && mv .mnt $EXTRA_CTX; fi
+RUN if [ -f ".mnt" ] || [ -d ".mnt" ]; then mkdir -p $(dirname $EXTRA_CTX) && mv .mnt $EXTRA_CTX; fi

--- a/src/levanter/infra/docker.py
+++ b/src/levanter/infra/docker.py
@@ -159,7 +159,7 @@ def copy_extra_ctx(extra_ctx):
         mount_dst = Path(".mnt")
         _cp(extra_ctx, mount_dst)
         try:
-            yield mount_dst
+            yield extra_ctx
         finally:
             _rm(mount_dst)
     else:


### PR DESCRIPTION
Dockerfile change: `.mnt` can be a directory as well.

docker.py change: should yield `extra_ctx` which is the actual path not `mount_dst=.mnt`