### PR TITLE
Make new tokenization ~67% faster

### DIFF
--- a/scripts/launch_gpt2_small_fast_tpu.sh
+++ b/scripts/launch_gpt2_small_fast_tpu.sh
@@ -1,6 +1,6 @@
 # Launches the "gpt_small_fast" model on a TPU node
 
-python infra/launch.py --foreground --tpu_name levanter-itest-32 --zone us-central2-b --tpu_type v4-32 --preemptible -- \
+python infra/launch.py --foreground --tpu_name $(whoami)-levanter-itest-32 --zone us-central2-b --tpu_type v4-32 --preemptible -- \
     python -m levanter.main.train_lm \
     --config_path config/gpt2_small_fast.yaml \
     --trainer.checkpointer.base_path gs://levanter-checkpoints/gpt-itest/ --trainer.checkpointer.save_interval 30m $*

--- a/src/levanter/store/cache.py
+++ b/src/levanter/store/cache.py
@@ -364,7 +364,6 @@ class _OrderedCacheWriter:
             futures_to_await.append(self._parent._updated_ledger.remote(self._ledger))
 
             if self._ledger.is_finished:
-                self._finish()
                 f = self._parent._finalize.remote()
                 futures_to_await.append(f)
 
@@ -383,6 +382,8 @@ class _OrderedCacheWriter:
             except TimeoutError:
                 pass
             self._attempt_to_write_batches()
+            if self._ledger.is_finished:
+                break
 
     def _dequeue_ready_batches(self):
         for shard, batch in self._batch_queue.drain():

--- a/src/levanter/store/cache.py
+++ b/src/levanter/store/cache.py
@@ -272,6 +272,11 @@ class _OrderedCacheWriter:
             # double check that we're not finished by committing the ledger
             self._attempt_to_write_batches()
 
+            if not self._ledger.is_finished:
+                self._actual_writer_thread = threading.Thread(target=self._write_loop, daemon=True)
+                self._stop_loop = threading.Event()
+                self._actual_writer_thread.start()
+
     def batch_finished(self, shard_name: str, shard_batch_idx: int, batch_result_box):
         with log_failures_to(self._parent):
             if self._failed:
@@ -286,7 +291,6 @@ class _OrderedCacheWriter:
             # we need to keep track of the order of the batches so that we can write them out in order
             self._total_queue_length += len(batch_result)
             self._batch_queue.append_to_group(shard_name, shard_batch_idx, batch_result)
-            self._attempt_to_write_batches()
             next_missing_item = self._batch_queue.next_missing_item_index()
 
             overwhelmed = self.is_overwhelmed()
@@ -303,6 +307,7 @@ class _OrderedCacheWriter:
     def shard_failed(self, shard_name: str, batch_id: int, exc_info: ExceptionInfo):
         with log_failures_to(self._parent):
             self._failed = True
+            self._stop_loop.set()
             logger.error(f"Shard {shard_name} failed at batch {batch_id}", exc_info=exc_info.restore())
             self._parent.shard_failed.remote(shard_name, exc_info)
 
@@ -314,7 +319,10 @@ class _OrderedCacheWriter:
             logger.debug(
                 f"Attempting to write batches because {shard_name} finished reading with {expected_num_rows} batches."
             )
-            self._attempt_to_write_batches()
+            self.flush()
+
+    def flush(self):
+        self._attempt_to_write_batches()
 
     def get_shard_status(self, shard_name: str):
         with log_failures_to(self._parent):
@@ -327,7 +335,7 @@ class _OrderedCacheWriter:
 
     def _attempt_to_write_batches(self):
         if self._ledger.is_finished:
-            raise RuntimeError("Trying to write batches after cache is finished")
+            return
 
         if self._failed:
             logger.warning("Not writing batches because of failure.")
@@ -356,10 +364,25 @@ class _OrderedCacheWriter:
             futures_to_await.append(self._parent._updated_ledger.remote(self._ledger))
 
             if self._ledger.is_finished:
+                self._finish()
                 f = self._parent._finalize.remote()
                 futures_to_await.append(f)
 
         ray.wait(futures_to_await + futures_to_await_shards)
+
+    def _finish(self):
+        self._stop_loop.set()
+        self._actual_writer_thread.join()
+
+    def _write_loop(self):
+        while True:
+            try:
+                self._stop_loop.wait(1)
+                if self._stop_loop.is_set():
+                    break
+            except TimeoutError:
+                pass
+            self._attempt_to_write_batches()
 
     def _dequeue_ready_batches(self):
         for shard, batch in self._batch_queue.drain():
@@ -421,6 +444,9 @@ class _OrderedCacheWriter:
     def is_overwhelmed(self) -> bool:
         max_queue_size = self._min_items_to_write * 3
         return self._total_queue_length > max_queue_size
+
+    def __del__(self):
+        self._finish()
 
 
 def _to_list_of_dicts(batch: dict) -> List[dict]:


### PR DESCRIPTION
Until this PR, the new cache would write every ~8K docs it received, regardless of how many were queued up. (This isn't quite correct, but close enough) Writes are high latency, so this wasn't the best choice.

We now instead write whatever is ready every second or so. In practice this makes us about 67% faster at tokenizing.

![image](https://github.com/user-attachments/assets/31478171-d848-4eab-bb74-0aa53a1d375e)
