### PR TITLE
Support multiprocessing for backgrounditerable to mitigate TensorStore crash

### DIFF
--- a/src/levanter/utils/background_iterable.py
+++ b/src/levanter/utils/background_iterable.py
@@ -1,55 +1,88 @@
 import asyncio
+import multiprocessing as mp
 import queue
 import sys
 import threading
-from typing import AsyncIterator, Callable, Iterable, Iterator, Optional, TypeVar, Union
+from multiprocessing import get_context
+from queue import Full as QueueFull
+from typing import Any, AsyncIterator, Callable, Iterable, Iterator, Literal, Optional, TypeVar, Union
 
+import dill
 import tblib
-
-from levanter.utils.thread_utils import AsyncIteratorWrapper
 
 
 Ex = TypeVar("Ex", covariant=True)
 
+BackgroundMethod = Literal["thread"] | Literal["forkserver"] | Literal["spawn"]
+
 
 class BackgroundIterable(Iterable[Ex]):
     """
-    A wrapper around an iterable that runs the iterable in a background thread and fills a queue with the results.
+    A wrapper around an iterable that runs the iterable in a background thread/process and fills a queue with the results.
 
-    This allows the iterable to be consumed in a separate thread, and for the results to be consumed in the main thread.
-    This will only work particularly well if the main thread is doing some kind of IO or other blocking operation,
-    like running XLA kernels...
+    This allows the iterable to be consumed in a separate thread or process, and for the results to be consumed in the main thread.
     """
 
     def __init__(
         self,
         producer_fn: Callable[[], Union[Iterator[Ex], AsyncIterator[Ex]]],
         max_capacity: Optional[int] = None,
+        method: Optional[BackgroundMethod] = "forkserver",
     ):
         self.max_capacity = max_capacity
         self._producer_fn = producer_fn
+        self.method = method
 
-    def __iter__(self):
-        return BackgroundIterator(self._producer_fn, self.max_capacity)
+    def __iter__(self) -> "BackgroundIterator[Ex]":
+        return BackgroundIterator(self._producer_fn, self.max_capacity, self.method)
 
 
 class BackgroundIterator(Iterator[Ex]):
-    def __init__(self, producer_fn: Callable[[], Union[Iterator[Ex], AsyncIterator[Ex]]], max_capacity: Optional[int]):
+    def __init__(
+        self,
+        producer_fn: Callable[[], Union[Iterator[Ex], AsyncIterator[Ex]]],
+        max_capacity: Optional[int],
+        method: Optional[BackgroundMethod] = "forkserver",
+    ):
         self.max_capacity = max_capacity
         self._producer_fn = producer_fn
-        self._stop_event = threading.Event()
+        self.method = method
+        self._stop_event: Any
+        self.q: Union[queue.Queue, mp.Queue]
 
-        if self.max_capacity is None or self.max_capacity >= 0:
-            self.q: queue.Queue = queue.Queue(self.max_capacity or 0)
-            self.thread: Optional[threading.Thread] = threading.Thread(target=self._fill_queue_with_batches)
-            self.thread.daemon = True
-            self.thread.start()
-        else:
-            # No background thread; consume items on demand
-            self.thread = None
-            self.iterator = self._producer_fn()
-            if not isinstance(self.iterator, Iterator):
-                self.iterator = AsyncIteratorWrapper(self.iterator)
+        match method:
+            case None:
+                self._stop_event = threading.Event()
+                # No background thread/process; consume items on demand
+                self.iterator = self._producer_fn()
+                if not isinstance(self.iterator, Iterator):
+                    # put this here to defer the import for forkserver, since it's slow.
+                    from levanter.utils.thread_utils import AsyncIteratorWrapper
+
+                    self.iterator = AsyncIteratorWrapper(self.iterator)
+            case "thread":
+                self._stop_event = threading.Event()
+                self.q = queue.Queue(self.max_capacity or 0)
+                self.thread = threading.Thread(target=self._fill_queue_with_batches)
+                self.thread.daemon = True
+                self.thread.start()
+            case meth:
+                if meth == "fork":
+                    raise ValueError("fork and JAX do not play well together. Use forkserver or spawn")
+                elif meth not in ("forkserver", "spawn"):
+                    raise ValueError(f"Unknown backgrounding method: {meth}")
+                mp.set_forkserver_preload(
+                    ["multiprocessing", "dill", "tblib", "sys", "typing", "threading", "time", "asyncio"]
+                )
+                _ctx = get_context(meth)
+                self._stop_event = _ctx.Event()
+                self.q = _ctx.Queue(self.max_capacity or 0)
+                encoded_fn = dill.dumps(self._producer_fn)
+                self.process = _ctx.Process(  # type: ignore
+                    target=self._forkserver_worker, args=(encoded_fn, self.q, self._stop_event)
+                )
+                self.process.daemon = True
+                self.process.start()
 
     def __iter__(self):
         return self
@@ -57,10 +90,21 @@ class BackgroundIterator(Iterator[Ex]):
     def __next__(self):
         if self._stop_event.is_set():
             raise StopIteration
-        if self.thread is not None:
+
+        if hasattr(self, "thread") and self.thread is not None:
+            # Thread-based queue consumption
             while not self._stop_event.is_set():
-                batch = self.q.get()
+                batch = self._do_poll(self.q)
                 if batch is _SENTINEL:
+                    raise StopIteration
+                elif isinstance(batch, _ExceptionWrapper):
+                    batch.reraise()
+                return batch
+        elif hasattr(self, "process") and self.process is not None:
+            # Process-based queue consumption
+            while not self._stop_event.is_set():
+                batch = self._do_poll(self.q)
+                if isinstance(batch, _Sentinel):
                     raise StopIteration
                 elif isinstance(batch, _ExceptionWrapper):
                     batch.reraise()
@@ -81,64 +125,120 @@ class BackgroundIterator(Iterator[Ex]):
         self.stop()
 
     def stop(self, wait: bool = True):
-        self._stop_event.set()
-        # I'm getting an error that the thread is threading.current_thread(), which seems impossible
-        if self.thread is not None and wait and self.thread != threading.current_thread():
+        try:
+            self._stop_event.set()
+        except AttributeError:
+            # on mac we get a nonsensical error sometimes?
+            pass
+        # For threads, join if necessary
+        if hasattr(self, "thread") and self.thread is not None and wait and self.thread != threading.current_thread():
             self.thread.join()
+        # For processes, join if necessary
+        try:
+            if hasattr(self, "process") and self.process is not None and wait and self.process.is_alive():
+                self.process.join()
+        except AttributeError:
+            # on mac we get this weird non-sensical error
+            # Traceback (most recent call last):
+            #   File "/opt/homebrew/Caskroom/miniforge/base/envs/levanter/lib/python3.10/multiprocessing/pool.py", line 271, in __del__
+            #   File "/opt/homebrew/Caskroom/miniforge/base/envs/levanter/lib/python3.10/multiprocessing/queues.py", line 371, in put
+            # AttributeError: 'NoneType' object has no attribute 'dumps'
+            # Exception ignored in: <function BackgroundIterator.__del__ at 0x11c12eef0>
+            pass
 
     def _fill_queue_with_batches(self):
         try:
             iterator = self._producer_fn()
             if isinstance(iterator, Iterator):
-                self._produce_batches_sync(iterator)
+                BackgroundIterator._produce_batches_sync(iterator, self.q, self._stop_event, False)
             else:
-                asyncio.run(self._produce_batches_async(iterator))
+                asyncio.run(BackgroundIterator._produce_batches_async(iterator, self.q, self._stop_event, False))
         except Exception:
             self.q.put(_ExceptionWrapper(sys.exc_info()))
 
-    def _produce_batches_sync(self, iterator):
+    @staticmethod
+    def _forkserver_worker(encoded_producer_fn, queue, stop_event):
+        """
+        This is the worker function that runs in a separate process.
+        It sets up dill-based serialization and consumes the iterator.
+        """
+
+        try:
+            producer_fn = dill.loads(encoded_producer_fn)
+            iterator = producer_fn()
+            if isinstance(iterator, Iterator):
+                BackgroundIterator._produce_batches_sync(iterator, queue, stop_event, True)
+            else:
+                asyncio.run(BackgroundIterator._produce_batches_async(iterator, queue, stop_event, True))
+        except Exception:
+            queue.put(_ExceptionWrapper(sys.exc_info()))
+
+    @staticmethod
+    def _produce_batches_sync(iterator, queue, stop_event, use_multiprocessing):
         try:
             for batch in iterator:
-                while not self._stop_event.is_set():
+                while not stop_event.is_set():
                     try:
-                        self.q.put(batch, block=True, timeout=1)
+                        BackgroundIterator._do_put(queue, batch, use_multiprocessing)
                         break
-                    except queue.Full:
+                    except QueueFull:
                         pass
 
-                if self._stop_event.is_set():
+                if stop_event.is_set():
                     break
 
-            while not self._stop_event.is_set():
+            while not stop_event.is_set():
                 try:
-                    self.q.put(_SENTINEL, block=True, timeout=1)
+                    queue.put(_SENTINEL, block=True, timeout=1)
                     break
-                except queue.Full:
+                except QueueFull:
                     pass
         except Exception:
-            self.q.put(_ExceptionWrapper(sys.exc_info()))
+            queue.put(_ExceptionWrapper(sys.exc_info()))
 
-    async def _produce_batches_async(self, iterator):
+    @staticmethod
+    async def _produce_batches_async(iterator, queue, stop_event, use_multiprocessing):
         try:
             async for batch in iterator:
-                while not self._stop_event.is_set():
+                while not stop_event.is_set():
                     try:
-                        self.q.put(batch, block=True, timeout=1)
+                        BackgroundIterator._do_put(queue, batch, use_multiprocessing)
                         break
-                    except queue.Full:
+                    except QueueFull:
                         pass
 
-                if self._stop_event.is_set():
+                if stop_event.is_set():
                     break
 
-            while not self._stop_event.is_set():
+            while not stop_event.is_set():
                 try:
-                    self.q.put(_SENTINEL, block=True, timeout=1)
+                    queue.put(_SENTINEL, block=True, timeout=1)
                     break
-                except queue.Full:
+                except QueueFull:
                     pass
         except Exception:
-            self.q.put(_ExceptionWrapper(sys.exc_info()))
+            queue.put(_ExceptionWrapper(sys.exc_info()))
+
+    @staticmethod
+    def _do_put(queue, msg, use_multiprocessing):
+        if use_multiprocessing:
+            # queue.put(dill.dumps(msg), block=True, timeout=1)
+            queue.put(msg, block=True, timeout=1)
+        else:
+            queue.put(msg, block=True, timeout=1)
+
+    def _do_poll(self, queue):
+        if self.method:
+            out = queue.get(block=True)
+            if isinstance(out, _Sentinel):
+                return _SENTINEL
+            elif isinstance(out, _ExceptionWrapper):
+                return out
+            else:
+                # return dill.loads(out)
+                return out
+        else:
+            return queue.get(block=True)
 
 
 class _Sentinel:
@@ -160,3 +260,40 @@ class _ExceptionWrapper:
 
     def reraise(self):
         raise self.exc.with_traceback(self.tb.as_traceback())
+
+
+_background_process_pool = None
+
+
+def _get_background_process_pool(ctx):
+    global _background_process_pool
+    if _background_process_pool is None:
+        _background_process_pool = ctx.Pool()
+    return _background_process_pool
+
+
+if __name__ == "__main__":
+
+    async def async_producer():
+        for i in range(1, 101):
+            yield i
+
+    background_iterable = BackgroundIterable(async_producer, max_capacity=None, method="forkserver")
+
+    iter1 = iter(background_iterable)
+    iter2 = iter(background_iterable)
+
+    data1 = [item for item in iter1]
+    data2 = [item for item in iter2]
+
+    assert data1 == data2
+    assert data1 == list(range(1, 101))
+    print(data1)
+    print(data2)
+    print("done")
+    iter1.stop()
+    iter2.stop()
+    print("stopped")
+    iter3 = iter(background_iterable)
+    data3 = [item for item in iter3]
+    print(data3)

--- a/tests/test_background_iterable.py
+++ b/tests/test_background_iterable.py
@@ -4,11 +4,35 @@ import pytest
 
 from levanter.utils.background_iterable import BackgroundIterable
 
+from .test_utils import is_in_pycharm_test
 
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-def test_reentrancy(max_capacity):
+
+# forkserver hangs in pycharm tests somehow
+mp_method = "forkserver" if not is_in_pycharm_test() else "spawn"
+
+
+def test_basic():
     test_data = list(range(1, 101))
-    background_iterable = BackgroundIterable(lambda: iter(test_data), max_capacity=max_capacity)
+
+    background_iterable = BackgroundIterable(lambda: iter(test_data), max_capacity=None, method=mp_method)
+
+    iter1 = iter(background_iterable)
+
+    data1 = list(iter1)
+
+    assert data1 == test_data
+
+    # try again
+    iter2 = iter(background_iterable)
+    data2 = list(iter2)
+    assert data2 == test_data
+
+
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+def test_reentrancy(max_capacity, method):
+    test_data = list(range(1, 101))
+    background_iterable = BackgroundIterable(lambda: iter(test_data), max_capacity=max_capacity, method=method)
 
     iter1 = iter(background_iterable)
     iter2 = iter(background_iterable)
@@ -20,10 +44,11 @@ def test_reentrancy(max_capacity):
     assert data1 == test_data
 
 
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-def test_empty_iteration(max_capacity):
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+def test_empty_iteration(max_capacity, method):
     # Create a BackgroundIterable instance with an empty producer function
-    background_iterable = BackgroundIterable(lambda: iter([]), max_capacity=max_capacity)
+    background_iterable = BackgroundIterable(lambda: iter([]), max_capacity=max_capacity, method=method)
 
     # Convert the iterator to a list for comparison
     data = list(background_iterable)
@@ -32,14 +57,15 @@ def test_empty_iteration(max_capacity):
     assert data == []
 
 
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-def test_exception_handling(max_capacity):
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+def test_exception_handling(max_capacity, method):
     # Create a producer function that raises an exception
     def producer_with_exception():
         raise ValueError("Something went wrong!")
 
     # Create a BackgroundIterable instance with the producer function that raises an exception
-    background_iterable = BackgroundIterable(producer_with_exception, max_capacity=max_capacity)
+    background_iterable = BackgroundIterable(producer_with_exception, max_capacity=max_capacity, method=method)
 
     # Iterate over the BackgroundIterable and handle the raised exception
     with pytest.raises(ValueError):
@@ -47,14 +73,15 @@ def test_exception_handling(max_capacity):
             pass
 
 
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-def test_stop_event(max_capacity):
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+def test_stop_event(max_capacity, method):
     def ongoing_process():
         while True:
             for item in range(1, 101):
                 yield item
 
-    background_iterable = BackgroundIterable(ongoing_process, max_capacity=max_capacity)
+    background_iterable = BackgroundIterable(ongoing_process, max_capacity=max_capacity, method=method)
 
     iter1 = iter(background_iterable)
 
@@ -71,15 +98,16 @@ def test_stop_event(max_capacity):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-async def test_async_reentrancy(max_capacity):
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+async def test_async_reentrancy(max_capacity, method):
     async def async_producer():
         for i in range(1, 101):
             yield i
             if i % 10 == 0:
                 await asyncio.sleep(0.001)
 
-    background_iterable = BackgroundIterable(async_producer, max_capacity=max_capacity)
+    background_iterable = BackgroundIterable(async_producer, max_capacity=max_capacity, method=method)
 
     iter1 = iter(background_iterable)
     iter2 = iter(background_iterable)
@@ -92,13 +120,14 @@ async def test_async_reentrancy(max_capacity):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-async def test_async_empty_iteration(max_capacity):
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+async def test_async_empty_iteration(max_capacity, method):
     async def async_producer():
         if False:
             yield
 
-    background_iterable = BackgroundIterable(async_producer, max_capacity=max_capacity)
+    background_iterable = BackgroundIterable(async_producer, max_capacity=max_capacity, method=method)
 
     data = list(background_iterable)
 
@@ -106,13 +135,14 @@ async def test_async_empty_iteration(max_capacity):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-async def test_async_exception_handling(max_capacity):
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+async def test_async_exception_handling(max_capacity, method):
     async def async_producer_with_exception():
         raise ValueError("Something went wrong!")
         yield 0  # have to make sure it's an async coroutine
 
-    background_iterable = BackgroundIterable(async_producer_with_exception, max_capacity=max_capacity)
+    background_iterable = BackgroundIterable(async_producer_with_exception, max_capacity=max_capacity, method=method)
 
     with pytest.raises(ValueError):
         for _ in background_iterable:
@@ -120,24 +150,23 @@ async def test_async_exception_handling(max_capacity):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("max_capacity", [-1, None, 10])
-async def test_async_stop_event(max_capacity):
+@pytest.mark.parametrize("max_capacity", [None, 10])
+@pytest.mark.parametrize("method", ["thread", mp_method, None])
+async def test_async_stop_event(max_capacity, method):
     async def ongoing_async_process():
         while True:
             for item in range(1, 101):
                 yield item
 
-    background_iterable = BackgroundIterable(ongoing_async_process, max_capacity=max_capacity)
+    background_iterable = BackgroundIterable(ongoing_async_process, max_capacity=max_capacity, method=method)
 
     iter1 = iter(background_iterable)
 
     for _ in range(5):
-        q = next(iter1)
-        print(q)
+        next(iter1)
 
     iter1.stop()
 
-    # this doesn't work b/c pytest is stupid
     with pytest.raises(StopIteration):
         next(iter1)
         next(iter1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,11 @@ def skip_if_not_enough_devices(count: int):
     return pytest.mark.skipif(len(jax.devices()) < count, reason=f"Not enough devices ({len(jax.devices())})")
 
 
+def is_in_pycharm_test():
+    # This gets set by pycharm when running tests
+    return os.getenv("_JB_PPRINT_PRIMITIVES") == "1"
+
+
 class MLP(eqx.Module):
     """slightly less annoying MLP, used for testing purposes"""
 


### PR DESCRIPTION
Both @Helw150 and I have observed a crash when resuming from a checkpoint. I'm pretty sure it's a race or similar in tensorstore b/c checkpointing and dataloader use TS.

Also, Python is so dumb.