### PR TITLE
Support Parquet files in ShardedDataSource

### DIFF
--- a/src/levanter/data/sharded_datasource.py
+++ b/src/levanter/data/sharded_datasource.py
@@ -21,7 +21,6 @@ import datasets
 import fsspec
 import numpy as np
 import pyarrow.parquet as pq
-import pandas as pd
 
 from levanter.utils import fsspec_utils
 
@@ -248,7 +247,7 @@ class TextUrlDataSource(ShardedDataSource[str]):
                     table = pq.read_table(f)
                     sliced_table = table.slice(row)
                     for record in sliced_table.to_pylist():
-                        yield record[self.text_key] # assumes text_key is in record
+                        yield record[self.text_key]  # assumes text_key is in record
                 case _:
                     raise ValueError(f"Unknown format {format}")
 
@@ -441,7 +440,7 @@ class ParquetDataSource(ShardedDataSource[dict]):
         url = self._shard_name_to_url_mapping[shard_name]
         with fsspec.open(url, "r", compression="infer") as f:
             table = pq.read_table(f)
-            sliced_table = table.slice(row) # zero-copy slicing
+            sliced_table = table.slice(row)  # zero-copy slicing
             for record in sliced_table.to_pylist():
                 yield record
 

--- a/src/levanter/data/sharded_datasource.py
+++ b/src/levanter/data/sharded_datasource.py
@@ -438,7 +438,7 @@ class ParquetDataSource(ShardedDataSource[dict]):
 
     def open_shard_at_row(self, shard_name: str, row: int) -> Iterator[dict]:
         url = self._shard_name_to_url_mapping[shard_name]
-        with fsspec.open(url, "r", compression="infer") as f:
+        with fsspec.open(url, "rb", compression="infer") as f:
             table = pq.read_table(f)
             sliced_table = table.slice(row)  # zero-copy slicing
             for record in sliced_table.to_pylist():

--- a/tests/test_sharded_dataset.py
+++ b/tests/test_sharded_dataset.py
@@ -1,6 +1,6 @@
 import tempfile
 
-from levanter.data.sharded_datasource import AudioTextUrlDataSource, _sniff_format_for_dataset
+from levanter.data.sharded_datasource import AudioTextUrlDataSource, _sniff_format_for_dataset, ParquetDataSource
 from test_utils import skip_if_no_soundlibs
 
 
@@ -24,6 +24,47 @@ def test_sniff_format_for_json():
         assert _sniff_format_for_dataset(f.name) == ".json"
 
 
+def test_sniff_format_for_parquet():
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+        table = pa.table({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']})
+        pq.write_table(table, f.name)
+        f.flush()
+
+        assert _sniff_format_for_dataset(f.name) == ".parquet"
+    
+
 @skip_if_no_soundlibs
 def test_resolve_audio_pointer():
     AudioTextUrlDataSource.resolve_audio_pointer("https://ccrma.stanford.edu/~jos/mp3/trumpet.mp3", 16_000)
+
+
+def test_basic_parquet_datasource_read_row():
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+        # Create a simple dataset
+        data = {
+            "column1": ["value1", "value2", "value3"],
+            "column2": [10, 20, 30]
+        }
+        table = pa.Table.from_pydict(data)
+        pq.write_table(table, f.name)
+
+        # Instantiate the ParquetDataSource
+        datasource = ParquetDataSource([f.name])
+
+        # sanity check: Read data starting from row 1
+        row_data = list(datasource.open_shard_at_row(shard_name=f.name.replace(".", "_"), row=1))
+
+        # Verify the output
+        assert len(row_data) == 2  # We expect 2 rows starting from index 1
+        assert row_data[0]["column1"] == "value2"
+        assert row_data[0]["column2"] == 20
+        assert row_data[1]["column1"] == "value3"
+        assert row_data[1]["column2"] == 30

--- a/tests/test_sharded_dataset.py
+++ b/tests/test_sharded_dataset.py
@@ -35,7 +35,7 @@ def test_sniff_format_for_parquet():
         f.flush()
 
         assert _sniff_format_for_dataset(f.name) == ".parquet"
-    
+
 
 @skip_if_no_soundlibs
 def test_resolve_audio_pointer():
@@ -56,11 +56,13 @@ def test_basic_parquet_datasource_read_row():
         table = pa.Table.from_pydict(data)
         pq.write_table(table, f.name)
 
-        # Instantiate the ParquetDataSource
         datasource = ParquetDataSource([f.name])
 
+        assert len(datasource.shard_names) == 1, "Expected only one shard"
+        shard_name = datasource.shard_names[0]
+
         # sanity check: Read data starting from row 1
-        row_data = list(datasource.open_shard_at_row(shard_name=f.name.replace(".", "_"), row=1))
+        row_data = list(datasource.open_shard_at_row(shard_name=shard_name, row=1))
 
         # Verify the output
         assert len(row_data) == 2  # We expect 2 rows starting from index 1

--- a/tests/test_sharded_dataset.py
+++ b/tests/test_sharded_dataset.py
@@ -48,13 +48,11 @@ def test_basic_parquet_datasource_read_row():
     import pyarrow as pa
     import pyarrow.parquet as pq
 
-    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=True) as f:
         # Create a simple dataset
         data = {"column1": ["value1", "value2", "value3"], "column2": [10, 20, 30]}
         table = pa.Table.from_pydict(data)
         pq.write_table(table, f.name)
-
-    try:
 
         datasource = ParquetDataSource([os.path.abspath(f.name)])
 
@@ -70,6 +68,3 @@ def test_basic_parquet_datasource_read_row():
         assert row_data[0]["column2"] == 20
         assert row_data[1]["column1"] == "value3"
         assert row_data[1]["column2"] == 30
-
-    finally:
-        os.unlink(f.name)

--- a/tests/test_sharded_dataset.py
+++ b/tests/test_sharded_dataset.py
@@ -61,10 +61,6 @@ def test_basic_parquet_datasource_read_row():
         assert len(datasource.shard_names) == 1, "Expected only one shard"
         shard_name = datasource.shard_names[0]
 
-        print(f"Shard name: {shard_name}")
-        print("File name: ", f.name)
-        print("File path: ", os.path.abspath(f.name))
-
         # sanity check: Read data starting from row 1
         row_data = list(datasource.open_shard_at_row(shard_name=shard_name, row=1))
 


### PR DESCRIPTION
This PR creates a `ParquetDataSource` class to support loading `.parquet` files.
Closes #763 