### PR TITLE
Support Tied Weights in Llama Models

### DIFF
--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -551,24 +551,22 @@ class LlamaLMHeadModel(eqx.Module, LmHeadModel[LlamaConfig], StateDictSerializat
         k_t, k_head = maybe_rng_split(key, 2)
         x = self.embeddings.embed(input_ids)
         x = self.transformer(x, attn_mask=attn_mask, key=k_t)
-        if tie_word_embeddings:
-            lm_logits = self.embeddings.unembed(x)
-        else:
+        if self.lm_head:
             lm_logits = self.lm_head(x, key=k_head)
+        else:
+            lm_logits = self.embeddings.unembed(x)
         return lm_logits
 
     def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[LlamaConfig]":
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
-        new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-        new_lm_head = (
-            dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
-            if not config.tie_word_embeddings
-            else None
-        )
-
-        return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
+        if self.lm_head is not None:
+            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
+            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
+        else:
+            return dataclasses.replace(self, embeddings=new_embeddings)
 
     def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
         return {"transformer": "model", "embeddings": None}
@@ -576,7 +574,7 @@ class LlamaLMHeadModel(eqx.Module, LmHeadModel[LlamaConfig], StateDictSerializat
     def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None):
         # unflatten the linear layers of HF state_dict to match the shape of LlamaMlp
         d = state_dict.copy()
-        if not config.tie_word_embeddings:
+        if self.lm_head is not None:
             d.update(
                 unflatten_linear_layers(
                     apply_prefix(prefix, "lm_head"), state_dict, self.lm_head, out_dims_first_in_dict=True
@@ -588,7 +586,7 @@ class LlamaLMHeadModel(eqx.Module, LmHeadModel[LlamaConfig], StateDictSerializat
         my_dict: StateDict = {}
         super().update_state_dict(my_dict, prefix=prefix)
 
-        if not config.tie_word_embeddings:
+        if self.lm_head is not None:
             my_dict.update(
                 flatten_linear_layers(apply_prefix(prefix, "lm_head"), self.lm_head, out_dims_first_in_dict=True)
             )


### PR DESCRIPTION
The new smaller Llama 3.2 1B and 3.2 3B models have tied weights - so Levanter throws an error currently if we try to import these models.

https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct/blob/main/config.json
![Screenshot 2024-10-24 8 17 03 PM](https://github.com/user-attachments/assets/08e79ed7-cab5-43f0-9ca6-f90e2fe73249)

This adds HF support for that argument and just switches to using embedding.unembed when Embeddings are tied!