### PR TITLE
fix internal_eval lengths

### DIFF
--- a/examples/sft/sft.py
+++ b/examples/sft/sft.py
@@ -80,6 +80,7 @@ def train(config: SFTConfig):
         raise ValueError("Must specify either --initialize_from_hf or --initialize_from")
     else:
         converter = None
+        model_config = config.model
 
     levanter.initialize(config)
 
@@ -106,10 +107,10 @@ def train(config: SFTConfig):
             input_role=config.input_role,
             output_role=config.output_role,
         )
-        train_dataset = mk_chat_sft_dataset(chat_config, tokenizer)
+        train_dataset = mk_chat_sft_dataset(chat_config, tokenizer, model_config.Pos)
     else:
         assert config.supervised_data is not None
-        train_dataset = mk_supervised_dataset(config.supervised_data, tokenizer)
+        train_dataset = mk_supervised_dataset(config.supervised_data, tokenizer, model_config.Pos)
     logger.info("Supervised dataset created")
     train_dataset = PermutationDataset(train_dataset, data_key)
 

--- a/src/levanter/data/audio.py
+++ b/src/levanter/data/audio.py
@@ -270,6 +270,7 @@ class ProcessedAudioCache(AsyncDataset[AudioTextDict]):
     """
 
     def __init__(self, cache: TreeCache[AudioTextDict]):
+        super().__init__()
         self.cache = cache
 
     async def async_len(self) -> int:

--- a/src/levanter/data/mixture.py
+++ b/src/levanter/data/mixture.py
@@ -53,6 +53,7 @@ class MixtureDataset(AsyncDataset[T]):
         key: PRNGKeyArray | int,
         stop_strategy: str = StopStrategy.RESTART_STRATEGY,
     ):
+        super().__init__()
         self.weights = MixtureDataset._normalize_weights(weights)
         self.datasets = {name: dataset for name, dataset in datasets.items() if self.weights.get(name, 0) > 0}
         self.dataset_index = Index(self.datasets.keys())

--- a/src/levanter/data/permutation.py
+++ b/src/levanter/data/permutation.py
@@ -14,6 +14,7 @@ class PermutationDataset(AsyncDataset[T_co]):
     # TODO: add epoch reshuffling
 
     def __init__(self, dataset: AsyncDataset[T_co], key: jax.random.PRNGKey):
+        super().__init__()
         self.dataset = dataset
         self.key = key
         self._permutation: Optional[Permutation] = None
@@ -72,6 +73,7 @@ class EraShufflingDataset(AsyncDataset[T_co]):
     """
 
     def __init__(self, dataset: AsyncDataset[T_co], era_length: int, *, key: jax.random.PRNGKey):
+        super().__init__()
         self.dataset = dataset
         self.era_length = era_length
         self.key = key

--- a/src/levanter/eval.py
+++ b/src/levanter/eval.py
@@ -60,6 +60,7 @@ class DomainTaggedDataset(AsyncDataset[tuple[T, hax.NamedArray]]):
     def __init__(
         self, datasets: Sequence[tuple[AsyncDataset[T], Sequence[str]]], max_examples_per_dataset: Optional[int] = None
     ):
+        super().__init__()
         self.datasets = []
         tag_index: dict[str, int] = {}
         for i, (dataset, tags) in enumerate(datasets):

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -209,7 +209,7 @@ def main(config: TrainLmConfig):
 
         if config.supervised_data is not None:
             logger.info("Using supervised data")
-            supervised_eval = [(levanter.data.text.mk_supervised_dataset(config.supervised_data, tokenizer), "")]
+            supervised_eval = [(levanter.data.text.mk_supervised_dataset(config.supervised_data, tokenizer, Pos), "")]
             # TODO Add tags
             cb = levanter.eval.cb_tagged_lm_evaluate(
                 EvalBatch,

--- a/src/levanter/store/cache.py
+++ b/src/levanter/store/cache.py
@@ -191,6 +191,7 @@ class TreeCache(AsyncDataset[T_co]):
         ledger: Optional["CacheLedger"],
         _broker,  # handle of _TreeStoreCacheBuilder
     ):
+        super().__init__()
         self.cache_dir = cache_dir
         self.ledger = ledger
         self._was_already_finished = ledger is not None and ledger.is_finished

--- a/tests/test_doremi.py
+++ b/tests/test_doremi.py
@@ -38,6 +38,7 @@ def platform_of_array(x):
 
 class LogitDataset(AsyncDataset[Example]):
     def __init__(self, W, noise, x_mask, x_bias, *, key):
+        super().__init__()
         self.W = W
         self.noise = noise
         self.x_mask = x_mask

--- a/tests/test_new_loader.py
+++ b/tests/test_new_loader.py
@@ -64,6 +64,7 @@ def test_local_batched_data_loading_model_axis_1():
 
 class StructuredDataset(AsyncDataset):
     def __init__(self, seq_len):
+        super().__init__()
         self.seq_len = seq_len
         self.begin = 0
         self.end = 256
@@ -138,6 +139,7 @@ def test_structured_batches_model_axis_2():
 
 class StructuredDatasetWithNames(AsyncDataset):
     def __init__(self, Height: Axis, Width: Axis, begin, end, stride):
+        super().__init__()
         self.Height = Height
         self.Width = Width
         self.begin = begin

--- a/tests/test_supervised.py
+++ b/tests/test_supervised.py
@@ -2,6 +2,7 @@ import numpy as np
 from transformers import AutoTokenizer
 
 import haliax
+from haliax import Axis
 
 from levanter.data.text import _prepare_supervised_example, preprocess_supervised_example
 
@@ -76,7 +77,7 @@ def test_supervised_eval():
         "sources_len": np.array(45, dtype=np.int32),
     }
 
-    lm_ex = _prepare_supervised_example(ex, tokenizer)
+    lm_ex = _prepare_supervised_example(ex, tokenizer, Axis("position", 128))
 
     assert lm_ex.loss_mask["position", 44]
     assert haliax.sum(lm_ex.loss_mask) == 1


### PR DESCRIPTION
previously we were padding to max tokenizer length, which is real bad with llama3