### PR TITLE
tracker.finish to deal with subprocess stuff

### DIFF
--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -268,6 +268,9 @@ def main(config: TrainLmConfig):
             checkpointer = trainer.config.checkpointer.create(trainer.run_id)
             checkpointer.wait_until_finished()
 
+    # This isn't necessary except when Levanter is run in a subprocess (as happens w/ ray)
+    trainer.tracker.finish()
+
 
 if __name__ == "__main__":
     levanter.config.main(main)()

--- a/src/levanter/tracker/tensorboard.py
+++ b/src/levanter/tracker/tensorboard.py
@@ -43,6 +43,9 @@ class TensorboardTracker(Tracker):
             pylogger.exception(f"Error logging artifact {artifact_path} to {log_path}")
             return
 
+    def finish(self):
+        self.writer.close()
+
 
 @TrackerConfig.register_subclass("tensorboard")
 @dataclass

--- a/src/levanter/tracker/wandb.py
+++ b/src/levanter/tracker/wandb.py
@@ -72,6 +72,10 @@ class WandbTracker(Tracker):
     def log_artifact(self, artifact_path, *, name: Optional[str] = None, type: Optional[str] = None):
         self.run.log_artifact(artifact_path, name=name, type=type)
 
+    def finish(self):
+        logger.info("Finishing wandb run...")
+        self.run.finish()
+
 
 def is_wandb_available():
     try:


### PR DESCRIPTION
we use subprocess in marin to invoke levanter, but subprocesses don't wait on other subprocesses somehow, and so wandb doesn't get a chance to finish. This solves this