### PR TITLE
make eval_harness part of levanter namespace

### DIFF
--- a/src/levanter/__init__.py
+++ b/src/levanter/__init__.py
@@ -3,6 +3,7 @@ import levanter.config as config
 import levanter.data as data
 import levanter.distributed as distributed
 import levanter.eval as eval
+import levanter.eval_harness as eval_harness
 import levanter.models as models
 import levanter.optim as optim
 import levanter.tracker as tracker


### PR DESCRIPTION
For being able to import as `from levanter.eval_harness import __`