### PR TITLE
Fix Transformers seq length override 

### DIFF
--- a/src/levanter/main/sft.py
+++ b/src/levanter/main/sft.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import os
 from dataclasses import dataclass, field
@@ -99,6 +100,7 @@ def train(config: SFTConfig):
             converter = converter.replaced(tokenizer=tokenizer)
 
         model_config = converter.default_config
+        model_config = dataclasses.replace(converter.default_config, seq_len=config.max_seq_len)
     elif config.trainer.initialize_from is None:
         raise ValueError("Must specify either --initialize_from_hf or --initialize_from")
     else:

--- a/src/levanter/models/loss.py
+++ b/src/levanter/models/loss.py
@@ -43,7 +43,7 @@ def maybe_fused_next_token_loss(
         NamedArray: Computed loss.
     """
     # Resolve axes
-    Pos = pred_embeddings.resolve_axis(Pos)
+    Pos = pred_embeddings.resolve_axis(Pos.name)
     Vocab = pred_lm_head.resolve_axis(Vocab)
 
     if block_size is None:


### PR DESCRIPTION
Right now we are unable to override the base config loaded from transformers models when training. This normally isn't an issue but causes OOM when doing SFT fine-tuning and using Llama 3 8B base since the model config has a very large context length of 131K tokens.


This might not be the most elegant solution but has fixed the problem AFAIK.