### PR TITLE
Allow for tokenizers/preprocessors to change batch size

### DIFF
--- a/src/levanter/store/cache.py
+++ b/src/levanter/store/cache.py
@@ -1375,9 +1375,9 @@ def _tokenize_one_shard_group(
             tokenized = _canonicalize_batch(tokenized)  # type: ignore
             this_prepared = writer._tree_store.batch_preparer(tokenized)
 
-            this_batch_size += len(batch)
-            rows_this_shard += len(batch)
-            total_rows += len(batch)
+            this_batch_size += len(tokenized)
+            rows_this_shard += len(tokenized)
+            total_rows += len(tokenized)
 
             if prepared_batch is None:
                 prepared_batch = this_prepared


### PR DESCRIPTION
Small  change that keeps changes how the counting for the number of batches is done. Instead of assuming $n$ examples from shard iterator means $n$ examples after tokenizing/processing, it gets the length from the output of the tokenizer. I had a use case that involved combining multiple samples together during the processing stage, and ran into a bug where the number of batches stored in the offsets was incorrect.