### PR TITLE
Supporting varied mixtures over training

### DIFF
--- a/src/levanter/data/mixture.py
+++ b/src/levanter/data/mixture.py
@@ -183,7 +183,7 @@ class MixtureDataset(AsyncDataset[T]):
         stage_starts = np.array([start for start, _ in self.weight_stages])
         return max(0, np.searchsorted(stage_starts, block_start, side="right") - 1)
 
-    @alru_cache
+    @alru_cache(maxsize=32)
     async def _get_block(self, index: int) -> Optional[np.ndarray]:
         stage = self._get_stage_for_block(index)
         if not self.randomize_blocks:

--- a/src/levanter/data/mixture.py
+++ b/src/levanter/data/mixture.py
@@ -1,6 +1,6 @@
 import asyncio
 import warnings
-from typing import Mapping, Optional, Sequence, TypeVar
+from typing import List, Mapping, Optional, Sequence, Tuple, TypeVar
 
 import jax
 import numpy as np
@@ -30,12 +30,12 @@ class MixtureDataset(AsyncDataset[T]):
     according to the weights.
 
     Creating a random-access MixtureDataset is challenging because we need to keep track of the current index of each
-    dataset. So solve this, we instead use "block-deterministic" mixtures, where the number of samples from each dataset
-    in each block is always identical (and we shuffle the order of the dataset ids in each block).
+    dataset. To solve this, we instead use "block-deterministic" mixtures, where the number of samples from each dataset
+    in each block is always identical (and we shuffle the order of the dataset ids in each block). To handle the case where the dataset mixture changes over time, we use a list of stages and precompute statistics to accurately compute the index of each dataset in each block.
 
     Args:
         datasets: A dict of datasets, where the key is the name of the dataset and the value is the dataset itself
-        weights: weights for each dataset
+        weights: Weights for each dataset. This can be provided in a list of stages, where each stage is a tuple of (start_index, weights).
         stop_strategy: strategy for stopping the iteration, by default RESTART_STRATEGY. (Currently only RESTART_STRATEGY is supported)
             - FIRST_STOP_STRATEGY: stop when one dataset has been exhausted
             - ALL_STOP_STRATEGY: stop when all datasets have been exhausted
@@ -46,7 +46,7 @@ class MixtureDataset(AsyncDataset[T]):
     def __init__(
         self,
         datasets: Mapping[str, AsyncDataset[T]],
-        weights: dict[str, float],
+        weights: dict[str, float] | List[Tuple[int, dict[str, float]]],
         block_size: int,
         *,
         randomize_blocks: bool = True,
@@ -54,8 +54,29 @@ class MixtureDataset(AsyncDataset[T]):
         stop_strategy: str = StopStrategy.RESTART_STRATEGY,
     ):
         super().__init__()
-        self.weights = MixtureDataset._normalize_weights(weights)
-        self.datasets = {name: dataset for name, dataset in datasets.items() if self.weights.get(name, 0) > 0}
+        if isinstance(weights, dict):
+            weight_stages = [(0, weights)]
+        else:
+            weight_stages = weights
+
+        # assert that steps are in sorted order and that the start index of each stage is a multiple of block_size
+        for i, (start_index, _) in enumerate(weight_stages):
+            if i == 0:
+                assert start_index == 0
+            else:
+                assert (
+                    start_index % block_size == 0
+                ), f"start_index for a stage must be a multiple of block_size, got {start_index=} and {block_size=}"
+                assert start_index > weight_stages[i - 1][0], f"Weights list must be sorted, got {weight_stages}"
+
+        self.weight_stages = [
+            (start_index, self._normalize_weights(weights)) for start_index, weights in weight_stages
+        ]
+        self.datasets = {
+            name: dataset
+            for name, dataset in datasets.items()
+            if any(weights.get(name, 0) > 0 for _, weights in self.weight_stages)
+        }
         self.dataset_index = Index(self.datasets.keys())
         self.block_size = block_size
         # we pack index and ds id into a single 32 bit, so block size must be at most 2^16
@@ -78,15 +99,29 @@ class MixtureDataset(AsyncDataset[T]):
 
         self.stop_strategy = stop_strategy
 
-        self._counts_per_block = self._compute_expected_counts_per_block(block_size)
-        # precompute a list of ids for each block
-        # the ids contain both the dataset index and the index within the dataset
-        self._unpermuted_ids = self._compute_unpermuted_ids(self._counts_per_block)
+        # Compute counts and unpermuted_ids for each stage
+        self._counts_per_block_per_stage = []
+        self._counts_after_stage = []
+        self._unpermuted_ids_per_stage = []
 
-    def _compute_expected_counts_per_block(self, block_size):
+        cumulative_counts = np.zeros(len(self.datasets), dtype=np.int32)
+
+        for stage_idx, (start_index, stage_weights) in enumerate(self.weight_stages):
+            counts_this_stage = self._compute_expected_counts_per_block(stage_weights, block_size)
+            self._counts_per_block_per_stage.append(counts_this_stage)
+            self._unpermuted_ids_per_stage.append(self._compute_unpermuted_ids(counts_this_stage))
+
+            if stage_idx < len(self.weight_stages) - 1:
+                next_start = self.weight_stages[stage_idx + 1][0]
+                num_blocks_in_stage = (next_start - start_index) // block_size
+                stage_total_counts = counts_this_stage * num_blocks_in_stage
+                cumulative_counts += stage_total_counts
+                self._counts_after_stage.append(cumulative_counts.copy())
+
+    def _compute_expected_counts_per_block(self, weights: dict[str, float], block_size: int):
         _expected_values_per_block = np.zeros(len(self.datasets), dtype=np.int32)
         for i, dsname in enumerate(self.dataset_index):
-            _expected_values_per_block[i] = self.weights[dsname] * block_size
+            _expected_values_per_block[i] = weights.get(dsname, 0) * block_size
 
         # handle remainder by adding to the largest dataset
         largest_dataset = np.argmax(_expected_values_per_block)
@@ -94,9 +129,9 @@ class MixtureDataset(AsyncDataset[T]):
 
         # check if any dataset has 0 samples (and nonzero weight)
         for i, dsname in enumerate(self.dataset_index):
-            if _expected_values_per_block[i] == 0 and self.weights[dsname] > 0:
+            if _expected_values_per_block[i] == 0 and weights.get(dsname, 0) > 0:
                 warnings.warn(
-                    f"Dataset {dsname} has 0 samples in the block, but weight of {self.weights[dsname]}."
+                    f"Dataset {dsname} has 0 samples in the block, but weight of {weights[dsname]}."
                     " Recommend increasing block size."
                 )
 
@@ -143,20 +178,35 @@ class MixtureDataset(AsyncDataset[T]):
 
         raise NotImplementedError("Length is not known for other strategies")
 
+    def _get_stage_for_block(self, block_id: int) -> int:
+        block_start = block_id * self.block_size
+        stage_starts = np.array([start for start, _ in self.weight_stages])
+        return max(0, np.searchsorted(stage_starts, block_start, side="right") - 1)
+
     @alru_cache
     async def _get_block(self, index: int) -> Optional[np.ndarray]:
+        stage = self._get_stage_for_block(index)
         if not self.randomize_blocks:
-            return self._unpermuted_ids
+            return self._unpermuted_ids_per_stage[stage]
 
-        return np.array(_compute_block_assignment(self._unpermuted_ids, index, self.key))
+        return np.array(_compute_block_assignment(self._unpermuted_ids_per_stage[stage], index, self.key))
 
-    def _index_into_dataset_for_id(self, id: int, block_id) -> tuple[int, int]:
+    def _index_into_dataset_for_id(self, id: int, block_id: int) -> tuple[int, int]:
+        stage = self._get_stage_for_block(block_id)
         dataset_id = id >> 16
         dataset_index = id & 0xFFFF
-        return dataset_id, dataset_index + block_id * self._counts_per_block[dataset_id]
+
+        # Get the base offset from previous stages
+        base_offset = self._counts_after_stage[stage - 1][dataset_id] if stage > 0 else 0
+        # Add offset within current stage
+        offset_in_stage = (block_id * self.block_size - self.weight_stages[stage][0]) // self.block_size
+        current_stage_offset = offset_in_stage * self._counts_per_block_per_stage[stage][dataset_id]
+
+        return dataset_id, dataset_index + base_offset + current_stage_offset
 
     async def get_batch(self, indices: Sequence[int]) -> Sequence[T]:
         block_ids = np.array([idx // self.block_size for idx in indices])
+
         blocks = [self._get_block(block_id) for block_id in block_ids]
         blocks = await asyncio.gather(*blocks)
 
@@ -167,8 +217,8 @@ class MixtureDataset(AsyncDataset[T]):
         assert len(indices) == len(blocks) == len(block_ids)
 
         for batch_index, (idx, block, block_id) in enumerate(zip(indices, blocks, block_ids)):
-            index_within_block = idx % self.block_size  # which element of the block to get
-            id = block[index_within_block]  # for this block, which dataset+base dataset offset
+            index_within_block = idx % self.block_size
+            id = block[index_within_block]
             dataset_id, dataset_index = self._index_into_dataset_for_id(id, block_id)
             batches_per_dataset[dataset_id].append(dataset_index)
             indices_in_final_batch[dataset_id].append(batch_index)
@@ -209,9 +259,6 @@ class MixtureDataset(AsyncDataset[T]):
         return await dataset.getitem_async(dataset_index)
 
     async def _remap_indices(self, ds, indices_into_ds):
-        """
-        Handles wrap around for datasets that have finite length
-        """
         if self.stop_strategy == StopStrategy.RESTART_STRATEGY:
             if ds.is_finite():
                 max_elem = max(indices_into_ds)

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -87,7 +87,9 @@ async def test_mixture_dataset_normalized_weights():
 async def test_mixture_dataset_unpermuted_ids():
     mixture_ds = MixtureDataset(datasets(), weights(), block_size=10, key=key())
 
-    unpermuted_ids = mixture_ds._compute_unpermuted_ids(mixture_ds._counts_per_block)
+    unpermuted_ids = mixture_ds._compute_unpermuted_ids(
+        mixture_ds._compute_expected_counts_per_block(weights(), block_size())
+    )
     assert len(unpermuted_ids) == 10
     assert unpermuted_ids[0] >> 32 in range(3)  # Ensure the dataset ID is valid
 

--- a/tests/test_varying_mixture.py
+++ b/tests/test_varying_mixture.py
@@ -1,0 +1,142 @@
+import jax
+import pytest
+
+from levanter.data import ListAsyncDataset, MixtureDataset
+
+
+def create_datasets():
+    ds1 = ListAsyncDataset([1, 2, 3, 4, 5])
+    ds2 = ListAsyncDataset([10, 20, 30, 40, 50])
+    ds3 = ListAsyncDataset([100, 200, 300, 400, 500])
+    ds1.finalize()
+    ds2.finalize()
+    ds3.finalize()
+    return {"ds1": ds1, "ds2": ds2, "ds3": ds3}
+
+
+@pytest.mark.asyncio
+async def test_mixture_dataset_stage_transitions():
+    datasets = create_datasets()
+    # Define three stages with different weights
+    stages = [
+        (0, {"ds1": 1.0, "ds2": 0.0, "ds3": 0.0}),  # Stage 1: only ds1
+        (20, {"ds1": 0.0, "ds2": 1.0, "ds3": 0.0}),  # Stage 2: only ds2
+        (40, {"ds1": 0.0, "ds2": 0.0, "ds3": 1.0}),  # Stage 3: only ds3
+    ]
+
+    mixture_ds = MixtureDataset(datasets, stages, block_size=10, key=jax.random.PRNGKey(42), randomize_blocks=False)
+
+    # Test first stage (should only get values from ds1)
+    batch1 = await mixture_ds.get_batch(list(range(10)))
+    assert all(x in [1, 2, 3, 4, 5] for x in batch1), f"Unexpected values in first stage: {batch1}"
+
+    # Test second stage (should only get values from ds2)
+    batch2 = await mixture_ds.get_batch(list(range(20, 30)))
+    assert all(x in [10, 20, 30, 40, 50] for x in batch2), f"Unexpected values in second stage: {batch2}"
+
+    # Test third stage (should only get values from ds3)
+    batch3 = await mixture_ds.get_batch(list(range(40, 50)))
+    assert all(x in [100, 200, 300, 400, 500] for x in batch3), f"Unexpected values in third stage: {batch3}"
+
+
+@pytest.mark.asyncio
+async def test_mixture_dataset_gradual_transition():
+    datasets = create_datasets()
+    # Define stages with gradual transitions
+    stages = [
+        (0, {"ds1": 0.8, "ds2": 0.2, "ds3": 0.0}),  # Mostly ds1
+        (20, {"ds1": 0.2, "ds2": 0.6, "ds3": 0.2}),  # Mostly ds2
+        (40, {"ds1": 0.0, "ds2": 0.2, "ds3": 0.8}),  # Mostly ds3
+    ]
+
+    mixture_ds = MixtureDataset(datasets, stages, block_size=10, key=jax.random.PRNGKey(42))
+
+    # Sample a large batch from each stage and verify proportions
+    def count_sources(batch):
+        counts = {"ds1": 0, "ds2": 0, "ds3": 0}
+        for x in batch:
+            if x < 10:
+                counts["ds1"] += 1
+            elif x < 100:
+                counts["ds2"] += 1
+            else:
+                counts["ds3"] += 1
+        return counts
+
+    # Test first stage
+    batch1 = await mixture_ds.get_batch(list(range(20)))
+    counts1 = count_sources(batch1)
+    assert counts1["ds1"] > counts1["ds2"] > counts1["ds3"], f"Unexpected distribution in first stage: {counts1}"
+
+    # Test second stage
+    batch2 = await mixture_ds.get_batch(list(range(20, 40)))
+    counts2 = count_sources(batch2)
+    assert (
+        counts2["ds2"] > counts2["ds1"] and counts2["ds2"] > counts2["ds3"]
+    ), f"Unexpected distribution in second stage: {counts2}"
+
+    # Test third stage
+    batch3 = await mixture_ds.get_batch(list(range(40, 60)))
+    counts3 = count_sources(batch3)
+    assert counts3["ds3"] > counts3["ds2"] > counts3["ds1"], f"Unexpected distribution in third stage: {counts3}"
+
+
+@pytest.mark.asyncio
+async def test_mixture_dataset_invalid_stage_configurations():
+    datasets = create_datasets()
+
+    # Test stages that don't start at 0
+    with pytest.raises(AssertionError):
+        MixtureDataset(datasets, [(10, {"ds1": 1.0})], block_size=10, key=jax.random.PRNGKey(42))
+
+    # Test stages with start indices not multiple of block_size
+    with pytest.raises(AssertionError):
+        MixtureDataset(datasets, [(0, {"ds1": 1.0}), (15, {"ds2": 1.0})], block_size=10, key=jax.random.PRNGKey(42))
+
+    # Test stages in wrong order
+    with pytest.raises(AssertionError):
+        MixtureDataset(
+            datasets,
+            [(0, {"ds1": 1.0}), (20, {"ds2": 1.0}), (10, {"ds3": 1.0})],
+            block_size=10,
+            key=jax.random.PRNGKey(42),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mixture_dataset_zero_weight_handling():
+    datasets = create_datasets()
+    # Define stages where some datasets have zero weight
+    stages = [
+        (0, {"ds1": 1.0, "ds2": 0.0, "ds3": 0.0}),
+        (20, {"ds1": 0.0, "ds2": 1.0, "ds3": 0.0}),
+    ]
+
+    mixture_ds = MixtureDataset(datasets, stages, block_size=10, key=jax.random.PRNGKey(42), randomize_blocks=False)
+
+    # Verify that zero-weight datasets are not sampled
+    batch1 = await mixture_ds.get_batch(list(range(10)))
+    assert all(x < 10 for x in batch1), f"Found samples from zero-weight datasets in first stage: {batch1}"
+
+    batch2 = await mixture_ds.get_batch(list(range(20, 30)))
+    assert all(10 <= x < 100 for x in batch2), f"Found samples from zero-weight datasets in second stage: {batch2}"
+
+
+@pytest.mark.asyncio
+async def test_mixture_dataset_block_boundaries():
+    datasets = create_datasets()
+    # Define stages with transition at block boundary
+    stages = [
+        (0, {"ds1": 1.0, "ds2": 0.0, "ds3": 0.0}),
+        (10, {"ds1": 0.0, "ds2": 1.0, "ds3": 0.0}),
+    ]
+
+    mixture_ds = MixtureDataset(datasets, stages, block_size=10, key=jax.random.PRNGKey(42), randomize_blocks=False)
+
+    # Test the boundary between stages
+    batch = await mixture_ds.get_batch(list(range(5, 15)))  # Should span both stages
+    first_half = batch[:5]
+    second_half = batch[5:]
+
+    assert all(x < 10 for x in first_half), f"Unexpected values at end of first stage: {first_half}"
+    assert all(10 <= x < 100 for x in second_half), f"Unexpected values at start of second stage: {second_half}"


### PR DESCRIPTION
## Description
Currently, LM mixture dataset can only handle a static mixture over the course of training. This PR enables varying this mixture over datasets over the course of training. The user can now specify a list of stages and the sequence index at which each should start. 

Internally, we identify a training block to its stage, which defines its mixing weights. To efficiently translate a data point's index within a block to a respective source dataset, we precompute prefix sums that track how many data points are seen by previous stages.

## Fixes Issues
https://github.com/stanford-crfm/marin/issues/81

## Unit test coverage
There are new unit tests in `test_varying_mixture.py` to ensure that the varying mixture behaves as expected.

## Known breaking changes/behaviors
The design enables traditional usage of the MixtureDataset class. However, some of the private quantities are different (i.e. the expected counts per block now depends on the block and is not a member variable). To my knowledge, these variables are not accessed outside of tests.

## Additional context
I have some changes I want to make Marin to enable usage of this new functionality, though these updates are modular and can be seperate PR's. I have spot-checked that training proceeds as expected with this test. This is my first PR so feedback is appreciated :))