### PR TITLE
Adds Ability to Sub-Sample Data for Data Constrained Scaling Law Experiments

### DIFF
--- a/src/levanter/data/dataset.py
+++ b/src/levanter/data/dataset.py
@@ -122,6 +122,11 @@ class AsyncDataset(DatasetBase[T_co]):
     def map_batches(self, fn: MapFunction[Sequence[U]], *extra_args, **extra_kwargs) -> "BatchMappedAsyncDataset[U]":
         return BatchMappedAsyncDataset(self, fn, *extra_args, **extra_kwargs)
 
+    def slice_dataset(
+        self, start_index: Optional[int] = None, end_index: Optional[int] = None
+    ) -> "SlicedAsyncDataset[U]":
+        return SlicedAsyncDataset(self, start_index, end_index)
+
     def shuffle(self, key: PRNGKey):
         import levanter.data.permutation as permutation
 
@@ -373,6 +378,53 @@ class MappedAsyncDataset(AsyncDataset[U], Generic[T, U]):
         else:
             kwargs = self._extra_kwargs
         return self.fn(item, *self._extra_args, **kwargs)
+
+
+class SlicedAsyncDataset(AsyncDataset[U]):
+    def __init__(
+        self,
+        dataset: AsyncDataset[T],
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
+    ):
+        if start_index is None:
+            start_index = 0
+        if end_index is not None and start_index > end_index:
+            raise ValueError("End index must come after start index.")
+        self.start_index = start_index
+        self.end_index = end_index
+        self.dataset = dataset
+        self._min_known_len = dataset._min_known_len if start_index is not None else (end_index - start_index)
+
+    async def get_batch(self, indices: Sequence[int]) -> Sequence[T_co]:
+        shifted_indices = [(index + self.start_index) for index in indices]
+        max_index = max(shifted_indices)
+
+        if self.end_index is not None and max_index > self.end_index:
+            raise ValueError("Requested indices beyond the end of the dataset")
+
+        return await self.dataset.get_batch(indices)
+
+    async def async_len(self) -> int:
+        underlying_length = await self.dataset.async_len()
+        if self.end_index is None:
+            return underlying_length - self.start_index
+        else:
+            return self.end_index - self.start_index
+
+    async def final_length_is_known(self) -> bool:
+        underlying_is_known = await self.dataset.final_length_is_known()
+        return underlying_is_known and self.end_index is not None
+
+    def is_finite(self) -> bool:
+        return self.dataset.is_finite() and self.end_index is not None
+
+    async def current_len(self) -> Optional[int]:
+        underlying_length = await self.dataset.current_len()
+        if self.end_index is None:
+            return underlying_length - self.start_index
+        else:
+            return self.end_index - self.start_index
 
 
 class BatchMappedAsyncDataset(AsyncDataset[U]):

--- a/src/levanter/data/mixture.py
+++ b/src/levanter/data/mixture.py
@@ -52,6 +52,7 @@ class MixtureDataset(AsyncDataset[T]):
         randomize_blocks: bool = True,
         key: PRNGKeyArray | int,
         stop_strategy: str = StopStrategy.RESTART_STRATEGY,
+        simulated_data_ratio: float = 1,
     ):
         super().__init__()
         if isinstance(weights, dict):
@@ -99,6 +100,9 @@ class MixtureDataset(AsyncDataset[T]):
             raise NotImplementedError("Only restart strategy is supported for now.")
 
         self.stop_strategy = stop_strategy
+        if simulated_data_ratio > 1:
+            raise ValueError(f"Simulated data ratio must be at most  1, got {simulated_data_ratio}")
+        self.simulated_data_ratio = simulated_data_ratio
 
         # Initialize stage-related counts and IDs
         (
@@ -275,7 +279,13 @@ class MixtureDataset(AsyncDataset[T]):
         if self.stop_strategy == StopStrategy.RESTART_STRATEGY:
             if ds.is_finite():
                 max_elem = max(indices_into_ds)
-                length_of_dataset = await ds.wait_until_len_at_least(max_elem + 1)
+                # Remap Indices Earlier when simulating epoching for a larger budget
+                if self.simulated_data_ratio < 1:
+                    # Note(Will): This blocks on datasets being fully processed even for small simulated runs making simulating data size slightly latency inducing but I think that's ok
+                    true_length_of_dataset = await ds.async_len()
+                    length_of_dataset = int(true_length_of_dataset * self.simulated_data_ratio)
+                else:
+                    length_of_dataset = await ds.wait_until_len_at_least(max_elem + 1)
                 indices_into_ds = [idx % length_of_dataset for idx in indices_into_ds]
 
             return indices_into_ds

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1240,11 +1240,13 @@ class LMMixtureDatasetConfig(LMTaskConfig):
             )
         if self.experiment_budget is not None and self.target_budget is not None:
             simulated_data_ratio = self.experiment_budget / self.target_budget
+            sliced_token_datasets: Dict[str, TokenSeqDataset] = {}
             for name, ds in token_datasets.items():
                 # Note(Will): This blocks on datasets being fully processed even for small simulated runs making simulating data size slightly latency inducing but I think that's ok
                 true_length_of_dataset = len(ds.as_sync_dataset())
                 simulated_length_of_dataset = int(true_length_of_dataset * simulated_data_ratio)
-                token_datasets[name] = ds.slice_dataset(end_index=simulated_length_of_dataset)
+                sliced_token_datasets[name] = ds.slice_dataset(end_index=simulated_length_of_dataset)
+            token_datasets = sliced_token_datasets
 
         mixture = MixtureDataset(
             datasets=token_datasets,

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1169,6 +1169,11 @@ class LMMixtureDatasetConfig(LMTaskConfig):
     """ Dataset mixing weights. Either a constant dict[name->weight] or list of (step, weights) tuples """
 
     stop_strategy: str = field(default=StopStrategy.RESTART_STRATEGY)
+
+    # Configuration for Simulated Epoching
+    target_budget: Optional[int] = None
+    experiment_budget: Optional[int] = None
+
     mixture_block_size: int = 2048
     """ Block size for deterministic mixing """
 
@@ -1226,12 +1231,18 @@ class LMMixtureDatasetConfig(LMTaskConfig):
                 out_token_datasets[name] = shuffle_ds(ds, next(key_iter))
             token_datasets = out_token_datasets
 
+        if self.experiment_budget is not None and self.target_budget is not None:
+            simulated_data_ratio = self.experiment_budget / self.target_budget
+        else:
+            simulated_data_ratio = 1
+
         mixture = MixtureDataset(
             datasets=token_datasets,
             weights=self.train_weights,
             stop_strategy=self.stop_strategy,
             key=mix_key,
             block_size=self.mixture_block_size,
+            simulated_data_ratio=simulated_data_ratio,
         )
 
         return mixture

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1231,10 +1231,20 @@ class LMMixtureDatasetConfig(LMTaskConfig):
                 out_token_datasets[name] = shuffle_ds(ds, next(key_iter))
             token_datasets = out_token_datasets
 
+        if (
+            self.experiment_budget is not None and self.target_budget is not None
+        ) and self.experiment_budget > self.target_budget:
+            raise ValueError(
+                f"Experiment budget should be smaller than target budget, got {self.experiment_budget} >"
+                f" {self.target_budget}"
+            )
         if self.experiment_budget is not None and self.target_budget is not None:
             simulated_data_ratio = self.experiment_budget / self.target_budget
-        else:
-            simulated_data_ratio = 1
+            for name, ds in token_datasets.items():
+                # Note(Will): This blocks on datasets being fully processed even for small simulated runs making simulating data size slightly latency inducing but I think that's ok
+                true_length_of_dataset = len(ds.as_sync_dataset())
+                simulated_length_of_dataset = int(true_length_of_dataset * simulated_data_ratio)
+                token_datasets[name] = ds.slice_dataset(end_index=simulated_length_of_dataset)
 
         mixture = MixtureDataset(
             datasets=token_datasets,
@@ -1242,7 +1252,6 @@ class LMMixtureDatasetConfig(LMTaskConfig):
             stop_strategy=self.stop_strategy,
             key=mix_key,
             block_size=self.mixture_block_size,
-            simulated_data_ratio=simulated_data_ratio,
         )
 
         return mixture

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -74,6 +74,24 @@ async def test_mixture_dataset_stop_strategy_restart():
 
 
 @pytest.mark.asyncio
+async def test_mixture_dataset_simulated_data_size():
+    weights = {"ds1": 1 / 3, "ds2": 1 / 3, "ds3": 1 / 3}
+    mixture_ds = MixtureDataset(
+        datasets(),
+        weights,
+        block_size=10,
+        key=key(),
+        randomize_blocks=False,
+        stop_strategy=StopStrategy.RESTART_STRATEGY,
+        simulated_data_ratio=0.2,
+    )
+    for _ in range(10):
+        batch = await mixture_ds.get_batch([0, 1, 2])
+        assert len(batch) == 3
+        assert all(item in [1, 10, 100] for item in batch)
+
+
+@pytest.mark.asyncio
 async def test_mixture_dataset_normalized_weights():
     weights = {"ds1": 0, "ds2": 0.5, "ds3": 0.5}
     mixture_ds = MixtureDataset(datasets(), weights, block_size=10, key=key(), randomize_blocks=False)

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -90,6 +90,20 @@ async def test_mixture_dataset_simulated_data_size():
         assert len(batch) == 3
         assert all(item in [1, 10, 100] for item in batch)
 
+    mixture_ds = MixtureDataset(
+        datasets(),
+        weights,
+        block_size=10,
+        key=key(),
+        randomize_blocks=False,
+        stop_strategy=StopStrategy.RESTART_STRATEGY,
+        simulated_data_ratio=0.4,
+    )
+    for _ in range(10):
+        batch = await mixture_ds.get_batch([0, 1, 2])
+        assert len(batch) == 3
+        assert all(item in [1, 2, 10, 20, 100, 200] for item in batch)
+
 
 @pytest.mark.asyncio
 async def test_mixture_dataset_normalized_weights():

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -77,13 +77,12 @@ async def test_mixture_dataset_stop_strategy_restart():
 async def test_mixture_dataset_simulated_data_size():
     weights = {"ds1": 1 / 3, "ds2": 1 / 3, "ds3": 1 / 3}
     mixture_ds = MixtureDataset(
-        datasets(),
+        {name: dataset.slice_dataset(end_index=1) for name, dataset in datasets().items()},
         weights,
         block_size=10,
         key=key(),
         randomize_blocks=False,
         stop_strategy=StopStrategy.RESTART_STRATEGY,
-        simulated_data_ratio=0.2,
     )
     for _ in range(10):
         batch = await mixture_ds.get_batch([0, 1, 2])
@@ -91,13 +90,12 @@ async def test_mixture_dataset_simulated_data_size():
         assert all(item in [1, 10, 100] for item in batch)
 
     mixture_ds = MixtureDataset(
-        datasets(),
+        {name: dataset.slice_dataset(end_index=2) for name, dataset in datasets().items()},
         weights,
         block_size=10,
         key=key(),
         randomize_blocks=False,
         stop_strategy=StopStrategy.RESTART_STRATEGY,
-        simulated_data_ratio=0.4,
     )
     for _ in range(10):
         batch = await mixture_ds.get_batch([0, 1, 2])


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc381e88-79b4-4810-bb66-351ddf7c3b04)


Allows mixture datasets to specify a target budget and a experiment budget. This then computes what percentage of the data to sample overall in order to enable data constrained experiments like the above figure. 