### PR TITLE
fix pre-commit warnings and errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: ".git"
 default_stages:
-    - commit
+    - pre-commit
 fail_fast: true
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/src/levanter/store/jagged_array.py
+++ b/src/levanter/store/jagged_array.py
@@ -291,7 +291,7 @@ class JaggedArrayStore:
         if shapes is None and self.item_rank != 1:
             raise ValueError("Shapes must be provided for non-vector data")
         elif shapes is not None and shapes.shape[1] != self.item_rank - 1:
-            raise ValueError(f"Shapes must have {self.item_rank-1} dimensions, but got {shapes.shape[1]}")
+            raise ValueError(f"Shapes must have {self.item_rank - 1} dimensions, but got {shapes.shape[1]}")
 
         num_rows = self.num_rows
         num_added = len(new_offsets)


### PR DESCRIPTION
top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.

repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.

src/levanter/store/jagged_array.py:294:64: E226 missing whitespace around arithmetic operator
