### PR TITLE
pin tensorstore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "braceexpand>=0.1.7",
     "jmp>=0.0.3",
     "fsspec[http]>=2024.2,<2026",
-    "tensorstore>=0.1.65",
+    "tensorstore>=0.1.65,<0.1.70",
     "pytimeparse>=1.1.8",
     "humanfriendly==10.0",
     "safetensors[numpy]>=0.4.2,<0.6.0",


### PR DESCRIPTION
Tensorstore recently started aborting if it detects a fork, which means that wandb, pygit, and many other things that use subprocess no longer work. ahnmfdjklamnrfjkl