### PR TITLE
Selecting number of batches from training and validation to use from original training set

### DIFF
--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1171,7 +1171,9 @@ class LMMixtureDatasetConfig(LMTaskConfig):
 
         initial_batch_size = batch_schedule.batch_size_at_step(0)
 
-        causal_datasets = self.train_sets(Pos, monitors, key=shuffle_key, epochs=epochs, initial_batch_size=initial_batch_size)
+        causal_datasets = self.train_sets(
+            Pos, monitors, key=shuffle_key, epochs=epochs, initial_batch_size=initial_batch_size
+        )
 
         mixture = MixtureDataset(
             datasets=causal_datasets,
@@ -1252,28 +1254,34 @@ class LMMixtureDatasetConfig(LMTaskConfig):
         self.validation_token_datasets = {}
 
         if self.num_validation_batches_dict is not None:
-            assert initial_batch_size is not None, "initial_batch_size must be provided if num_validation_batches_dict is provided"
+            assert (
+                initial_batch_size is not None
+            ), "initial_batch_size must be provided if num_validation_batches_dict is provided"
 
             for name, ds in datasets.items():
                 if name in self.num_validation_batches_dict:
                     num_sequences = self.num_validation_batches_dict[name] * initial_batch_size
                     len_dataset = len(ds.as_sync_dataset())
                     # Take the last N sequences for validation and use the rest for training
-                    self.validation_token_datasets[name] = ds.slice_dataset(start_index=len_dataset - num_sequences, end_index=len_dataset)
+                    self.validation_token_datasets[name] = ds.slice_dataset(
+                        start_index=len_dataset - num_sequences, end_index=len_dataset
+                    )
                     datasets[name] = ds.slice_dataset(start_index=0, end_index=len_dataset - num_sequences)
 
         if self.max_batches_dict is not None:
-            assert initial_batch_size is not None, "initial_batch_size must be provided if max_batches_dict is provided"
+            assert (
+                initial_batch_size is not None
+            ), "initial_batch_size must be provided if max_batches_dict is provided"
 
             for name, ds in datasets.items():
                 if name in self.max_batches_dict:
                     num_sequences = self.max_batches_dict[name] * initial_batch_size
                     len_dataset = len(ds.as_sync_dataset())
-                    assert num_sequences <= len_dataset, f"Max sequences for {name} ({num_sequences}) is greater than the dataset size ({len_dataset})"
+                    assert (
+                        num_sequences <= len_dataset
+                    ), f"Max sequences for {name} ({num_sequences}) is greater than the dataset size ({len_dataset})"
                     logger.info(f"Slicing {name} to {num_sequences} sequences")
                     datasets[name] = ds.slice_dataset(end_index=num_sequences)
-        
-        
 
         return datasets
 

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1128,8 +1128,9 @@ class LMMixtureDatasetConfig(LMTaskConfig):
     max_batches_dict: Optional[Dict[str, int]] = None
     """ Maximum number of batches to use from each dataset for training (using the initial batch size)"""
 
+    validation_batch_size: Optional[int] = 1024
     num_validation_batches_dict: Optional[Dict[str, int]] = None
-    """ Number of validation batches to sample from the training set for each dataset (using validation_batch_size)"""
+    """ Number of validation batches to sample from the training set for each dataset"""
 
     def __post_init__(self):
         if len(self.configs) == 0:
@@ -1279,22 +1280,11 @@ class LMMixtureDatasetConfig(LMTaskConfig):
                     datasets[name] = ds.slice_dataset(end_index=num_sequences)
 
         return datasets
-    
-    def tagged_eval_sets(
-        self, Pos: Axis, batch_schedule: BatchSchedule, monitors: Union[bool, List[MetricsMonitor]] = True
-    ) -> list[Tuple[AsyncDataset[LmExample], List[str]]]:
-        tags = {name: (config.tags or []) + [name] for name, config in self.sources.items()}
-        initial_batch_size = batch_schedule.batch_size_at_step(0)
-        eval_sets = self.validation_sets(Pos, monitors, initial_batch_size=initial_batch_size)
-
-        return [(eval_sets[name], tags[name]) for name in eval_sets]
 
     def validation_sets(
         self,
         Pos: Axis,
         monitors: Union[bool, List[MetricsMonitor]] = True,
-        *,
-        initial_batch_size: Optional[int] = None,
     ) -> Mapping[str, AsyncDataset[LmExample]]:
         doc_caches = self.build_caches("validation", monitors=monitors)
         token_datasets = {
@@ -1311,14 +1301,17 @@ class LMMixtureDatasetConfig(LMTaskConfig):
         if self.num_validation_batches_dict is not None:
             for name, ds in token_datasets.items():
                 if name in self.num_validation_batches_dict:
-                    num_sequences = self.num_validation_batches_dict[name] * initial_batch_size
+                    num_sequences = self.num_validation_batches_dict[name] * self.validation_batch_size
                     len_dataset = len(ds.as_sync_dataset())
-                    assert (
-                        num_sequences <= len_dataset
-                    ), f"Num validation sequences for {name} ({num_sequences}) is greater than the dataset size ({len_dataset})"
+                    assert num_sequences <= len_dataset, (
+                        f"Num validation sequences for {name} ({num_sequences}) is greater than the dataset size"
+                        f" ({len_dataset})"
+                    )
                     logger.info(f"Selecting {num_sequences} validation sequences for {name}")
                     # Take the last N sequences for validation
-                    token_datasets[name] = ds.slice_dataset(start_index=len_dataset - num_sequences, end_index=len_dataset)
+                    token_datasets[name] = ds.slice_dataset(
+                        start_index=len_dataset - num_sequences, end_index=len_dataset
+                    )
 
         return token_datasets
 

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1267,10 +1267,6 @@ class LMMixtureDatasetConfig(LMTaskConfig):
             for name, ds in datasets.items():
                 if name in self.max_batches_dict:
                     num_sequences = self.max_batches_dict[name] * self.validation_batch_size
-                    len_dataset = len(ds.as_sync_dataset())
-                    assert (
-                        num_sequences <= len_dataset
-                    ), f"Max sequences for {name} ({num_sequences}) is greater than the dataset size ({len_dataset})"
                     logger.info(f"Slicing {name} to {num_sequences} sequences")
                     datasets[name] = ds.slice_dataset(end_index=num_sequences)
 

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1256,9 +1256,8 @@ class LMMixtureDatasetConfig(LMTaskConfig):
             for name, ds in datasets.items():
                 if name in self.num_validation_batches_dict:
                     num_sequences = self.num_validation_batches_dict[name] * self.validation_batch_size
-                    len_dataset = len(ds.as_sync_dataset())
-                    # Reserve the last N sequences for validation
-                    datasets[name] = ds.slice_dataset(start_index=0, end_index=len_dataset - num_sequences)
+                    # Reserve the first N sequences for validation
+                    datasets[name] = ds.slice_dataset(start_index=num_sequences)
 
         if self.max_batches_dict is not None:
             assert (
@@ -1298,16 +1297,9 @@ class LMMixtureDatasetConfig(LMTaskConfig):
             for name, ds in token_datasets.items():
                 if name in self.num_validation_batches_dict:
                     num_sequences = self.num_validation_batches_dict[name] * self.validation_batch_size
-                    len_dataset = len(ds.as_sync_dataset())
-                    assert num_sequences <= len_dataset, (
-                        f"Num validation sequences for {name} ({num_sequences}) is greater than the dataset size"
-                        f" ({len_dataset})"
-                    )
                     logger.info(f"Selecting {num_sequences} validation sequences for {name}")
-                    # Take the last N sequences for validation
-                    token_datasets[name] = ds.slice_dataset(
-                        start_index=len_dataset - num_sequences, end_index=len_dataset
-                    )
+                    # Take the first N sequences for validation
+                    token_datasets[name] = ds.slice_dataset(end_index=num_sequences)
 
         return token_datasets
 

--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1128,7 +1128,7 @@ class LMMixtureDatasetConfig(LMTaskConfig):
     max_batches_dict: Optional[Dict[str, int]] = None
     """ Maximum number of batches to use from each dataset for training (using the initial batch size)"""
 
-    validation_batch_size: Optional[int] = 1024
+    validation_batch_size: int = 1024
     num_validation_batches_dict: Optional[Dict[str, int]] = None
     """ Number of validation batches to sample from the training set for each dataset"""
 
@@ -1253,10 +1253,6 @@ class LMMixtureDatasetConfig(LMTaskConfig):
             datasets = sliced_datasets
 
         if self.num_validation_batches_dict is not None:
-            assert (
-                initial_batch_size is not None
-            ), "initial_batch_size must be provided if num_validation_batches_dict is provided"
-
             for name, ds in datasets.items():
                 if name in self.num_validation_batches_dict:
                     num_sequences = self.num_validation_batches_dict[name] * self.validation_batch_size
@@ -1271,7 +1267,7 @@ class LMMixtureDatasetConfig(LMTaskConfig):
 
             for name, ds in datasets.items():
                 if name in self.max_batches_dict:
-                    num_sequences = self.max_batches_dict[name] * initial_batch_size
+                    num_sequences = self.max_batches_dict[name] * self.validation_batch_size
                     len_dataset = len(ds.as_sync_dataset())
                     assert (
                         num_sequences <= len_dataset

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -140,8 +140,10 @@ def main(config: TrainLmConfig):
         )
 
         # Get the tagged evaluation datasets
-        # Evaluation datasets need to be constructed after the training dataset is constructed since they may take validation sequences from the training set
-        tagged_eval_datasets = config.data.tagged_eval_sets(Pos)
+        tagged_eval_datasets = config.data.tagged_eval_sets(
+            Pos,
+            config.trainer.batch_schedule,
+        )
 
         state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))
 

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -140,6 +140,7 @@ def main(config: TrainLmConfig):
         )
 
         # Get the tagged evaluation datasets
+        # Evaluation datasets need to be constructed after the training dataset is constructed since they may take validation sequences from the training set
         tagged_eval_datasets = config.data.tagged_eval_sets(Pos)
 
         state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))


### PR DESCRIPTION
Adding the ability to specify
- a number of batches to cut off the train dataset to add as an iid val dataset (`max_batches_dict`)
- a maximum number of batches to take from the train dataset (useful when u want to do epoching experiments as a function of token count rather than dataset size) (`num_validation_batches_dict`)

Resolves https://github.com/stanford-crfm/marin/issues/708