### PR TITLE
feat: Allow specifying save dtype for HF checkpoints

### DIFF
--- a/src/levanter/compat/hf_checkpoints.py
+++ b/src/levanter/compat/hf_checkpoints.py
@@ -658,6 +658,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
         save_reference_code: Optional[bool],
         max_shard_size: int,
         save_feature_extractor: bool = False,
+        dtype: Optional[jnp.dtype] = None,
     ):
         """
         Saves a HF-compatible checkpoint to a local path.
@@ -743,6 +744,15 @@ class HFCheckpointConverter(Generic[LevConfig]):
 
         # Model
         state_dict = to_torch_compatible_state_dict(model)
+
+        if dtype is not None:
+            logger.info(f"Converting floating-point arrays in state_dict to {dtype}")
+            for k, v in state_dict.items():
+                if jnp.issubdtype(v.dtype, jnp.floating):
+                    state_dict[k] = v.astype(dtype)
+                else:
+                    logger.debug(f"Skipping dtype conversion for non-floating point array {k} with dtype {v.dtype}")
+
         shards, index = _shard_hf_checkpoint(state_dict, max_shard_size, SAFE_TENSORS_MODEL)
         if index is None:
             save_state_dict(state_dict, os.path.join(path, SAFE_TENSORS_MODEL))
@@ -765,6 +775,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
         save_tokenizer: bool = True,
         max_shard_size: int = DEFAULT_MAX_SHARD_SIZE,
         save_feature_extractor: bool = False,
+                dtype: Optional[jnp.dtype] = None,
         **hf_upload_kwargs,
     ):
         """
@@ -796,6 +807,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
                 save_tokenizer=save_tokenizer,
                 save_feature_extractor=save_feature_extractor,
                 max_shard_size=max_shard_size,
+                dtype=dtype,
             )
 
             if upload_to_hf is True:
@@ -886,6 +898,7 @@ def save_hf_checkpoint_callback(
     base_path,
     converter: HFCheckpointConverter,
     upload_to_hf: Union[bool, str, RepoRef] = False,
+    save_dtype: Optional[jnp.dtype] = None,
     **hf_upload_kwargs,
 ):
     """
@@ -912,6 +925,7 @@ def save_hf_checkpoint_callback(
             cast(ModelWithHfSerializationMixin, step.eval_model),
             os.path.join(base_path, f"step-{step.step}"),
             upload_to_hf=upload_to_hf,
+            dtype=save_dtype,
             **my_upload_kwargs,
         )
 


### PR DESCRIPTION
This change introduces the ability to specify a `jax.numpy.dtype` when saving Hugging Face compatible checkpoints using `HFCheckpointConverter.save_pretrained`.

The primary modifications include:
- Adding an optional `dtype` parameter to `HFCheckpointConverter.save_pretrained` and `HFCheckpointConverter._save_pretrained_local`. If provided, the model's state dictionary is converted to this dtype before saving.
- Introducing an `hf_save_dtype` option (string) in `TrainLmConfig` to allow you to specify the desired save dtype via configuration.
- Updating the training loop in `train_lm.py` to parse `hf_save_dtype` and pass it to the checkpoint saving mechanism.
- Modifying `save_hf_checkpoint_callback` to accept and propagate the save dtype.

Unit tests have been added to `tests/test_hf_checkpoints.py` to verify that:
- Models are saved with the specified custom dtype (e.g., bfloat16).
- Models are saved with the default dtype when no override is given.
- Saved models can be correctly loaded.
- Utilize a test model wrapper (`TestModelWrapper`) that includes parameters of float, integer, and boolean dtypes.
- Verify that only floating-point parameters are converted to the specified save dtype, while integer and boolean parameters are preserved.