### PR TITLE
feat: Add script for automated WandB workspace setup

### DIFF
--- a/docs/Getting-Started-Training.md
+++ b/docs/Getting-Started-Training.md
@@ -125,6 +125,39 @@ This will overwrite the default WandB configuration from the `TrainerConfig` in 
 We pass all these arguments to the `wandb.init()` function at the same verbatim.
 For more information on the WandB configuration, please refer to the [WandB documentation](https://docs.wandb.ai/ref/python/init).
 
+#### Automated Wandb Workspace Setup
+Levanter logs many metrics, and the default WandB workspace layout can sometimes be unhelpful for navigating them. We provide a script to automatically configure a WandB workspace with a preferred layout, including specific plots and grouping settings.
+
+To run the script:
+- Script location: `scripts/setup_wandb_workspace.py`
+- Command-line arguments:
+    - `--entity` (optional): Your WandB entity (username or team name). If not provided, it defaults to the current logged-in WandB user's default entity.
+    - `--project` (optional): The WandB project name for your Levanter runs. Defaults to `"levanter"` if not provided.
+    - `--workspace` (optional): The desired name for the workspace. Defaults to `"levanter-default"` if not provided.
+    - `--base_url` (optional): If you are using a self-hosted WandB instance, specify its base URL here.
+- Example commands:
+  ```bash
+  # Example: Setup a workspace with default project ("levanter") and workspace name ("levanter-default")
+  # using your default WandB entity.
+  python scripts/setup_wandb_workspace.py
+
+  # Example: Setup a specific workspace in a specific project, using your default entity.
+  python scripts/setup_wandb_workspace.py --project my-levanter-experiments --workspace my-custom-view
+
+  # Example: Full specification (e.g., for a different entity or self-hosted instance).
+  python scripts/setup_wandb_workspace.py --entity <your-wandb-entity> --project <your-wandb-project> --workspace <your-desired-workspace-name> --base_url <your-wandb-instance-url>
+  ```
+
+The script applies the following configuration:
+- Sets run grouping to `group_by_prefix="first"`.
+- Creates a "main" section with the following plots:
+    - `log(train/loss)` vs `log(tokens)`
+    - `log(train/loss)` vs `log(steps)`
+    - `log(eval/bpb)` vs `log(tokens)`
+    - A bar chart for `max(throughput/mfu)` (titled "Max MFU").
+
+The script will update the workspace if it already exists or create it if it doesn't.
+
 ### Resume Training Runs
 When you resume a training run, you may like to restart from a previously saved checking and resume the corresponding WandB run, as well.
 To do so, you can use the following command. The `trainer.wandb.resume true` is optional, but will make WandB error out if the run ID does not exist.

--- a/scripts/setup_wandb_workspace.py
+++ b/scripts/setup_wandb_workspace.py
@@ -1,14 +1,28 @@
 import argparse
 import os
-import wandb # For wandb.Api()
+
+import wandb  # For wandb.Api()
+import wandb_workspaces.reports.v2 as wr
 import wandb_workspaces.workspaces as ws
-import wandb_workspaces.reports as wr
+
 
 def main():
     parser = argparse.ArgumentParser(description="Create or update a WandB workspace.")
-    parser.add_argument("--entity", type=str, default=None, help="WandB entity (user or team name). Optional, defaults to the logged-in user's default entity.")
-    parser.add_argument("--project", type=str, default="levanter", help="WandB project name. Optional, defaults to 'levanter'.")
-    parser.add_argument("--workspace", type=str, default="levanter-default", help="Name of the workspace to create or update. Optional, defaults to 'levanter-default'.")
+    parser.add_argument(
+        "--entity",
+        type=str,
+        default=None,
+        help="WandB entity (user or team name). Optional, defaults to the logged-in user's default entity.",
+    )
+    parser.add_argument(
+        "--project", type=str, default="levanter", help="WandB project name. Optional, defaults to 'levanter'."
+    )
+    parser.add_argument(
+        "--workspace",
+        type=str,
+        default="levanter-default",
+        help="Name of the workspace to create or update. Optional, defaults to 'levanter-default'.",
+    )
     parser.add_argument("--base_url", type=str, help="Base URL for WandB (for self-hosted instances)")
 
     args = parser.parse_args()
@@ -21,28 +35,27 @@ def main():
         name="main",
         panels=[
             wr.LinePlot(
-                x=["tokens"],
+                x="throughput/total_tokens",
                 y=["train/loss"],
                 title="log(train/loss) vs log(tokens)",
-                plot_config={'layout': {'xaxis': {'type': 'log'}, 'yaxis': {'type': 'log'}}}
+                log_x=True,
+                log_y=True,
             ),
             wr.LinePlot(
-                x=["step"],
                 y=["train/loss"],
                 title="log(train/loss) vs log(steps)",
-                plot_config={'layout': {'xaxis': {'type': 'log'}, 'yaxis': {'type': 'log'}}}
+                log_x=True,
+                log_y=True,
             ),
             wr.LinePlot(
-                x=["tokens"],
+                x="throughput/total_tokens",
                 y=["eval/bpb"],
                 title="log(eval/bpb) vs log(tokens)",
-                plot_config={'layout': {'xaxis': {'type': 'log'}, 'yaxis': {'type': 'log'}}}
+                log_x=True,
+                log_y=True,
             ),
-            wr.BarPlot(
-                metrics=["throughput/mfu"],  # Assuming this shows max or latest value
-                title="Max MFU"
-            )
-        ]
+            wr.BarPlot(metrics=["throughput/mfu"], title="Max MFU"),  # Assuming this shows max or latest value
+        ],
     )
 
     workspace_settings = ws.WorkspaceSettings(group_by_prefix="first")
@@ -50,7 +63,7 @@ def main():
     # Try to load existing workspace or create a new one
     workspace = None
     resolved_entity = args.entity
-    
+
     try:
         # Initialize wandb.Api to determine default entity if args.entity is None
         # This also helps verify API key setup early.
@@ -59,7 +72,10 @@ def main():
             if not resolved_entity:
                 resolved_entity = api.default_entity
                 if not resolved_entity:
-                    print("Warning: WandB entity not specified and could not determine default entity (user might not be logged in).")
+                    print(
+                        "Warning: WandB entity not specified and could not determine default entity (user might not be"
+                        " logged in)."
+                    )
                     # Proceeding with entity=None, creation might still work if project is unique enough or API handles it.
                     # Loading by URL will likely fail if entity is required in the path and is None.
                 else:
@@ -67,66 +83,77 @@ def main():
             else:
                 print(f"Using specified WandB entity: {resolved_entity}")
 
-        except wandb.errors.Error as e: # Catch wandb specific errors for API initialization
+        except wandb.errors.Error as e:  # Catch wandb specific errors for API initialization
             print(f"Error initializing WandB API (ensure you are logged in and API key is set): {e}")
             # Fallback to trying with entity=None if args.entity was None, or the specified one.
             # This path might be problematic for from_url if entity is truly needed.
-            resolved_entity = args.entity # Stick to original if API init fails
+            resolved_entity = args.entity  # Stick to original if API init fails
             if not resolved_entity:
-                 print("Proceeding without a resolved WandB entity. Workspace creation/loading might fail or use an unexpected default.")
-
+                resolved_entity = wandb.Api().default_entity
+                print(f"Falling back to default entity: {resolved_entity}")
 
         # Construct the workspace URL for from_url attempt
         # Only attempt from_url if we have a resolved_entity, as it's part of the URL path
         if resolved_entity:
-            web_url_base = args.base_url or 'https://wandb.ai'
+            web_url_base = args.base_url or "https://wandb.ai"
             workspace_url_path = f"{resolved_entity}/{args.project}/workspaces/{args.workspace}"
             web_url = f"{web_url_base}/{workspace_url_path}"
 
             try:
                 print(f"Attempting to load workspace from URL: {web_url}")
                 workspace = ws.Workspace.from_url(web_url)
-                print(f"Found existing workspace: '{args.workspace}' (Entity: {resolved_entity}, Project: {args.project})")
+                print(
+                    f"Found existing workspace: '{args.workspace}' (Entity: {resolved_entity}, Project:"
+                    f" {args.project})"
+                )
                 workspace.sections = [main_section]
                 workspace.settings = workspace_settings
                 print(f"Updating existing workspace: '{args.workspace}'")
             except Exception as e:
-                print(f"Workspace '{args.workspace}' not found via URL (or error: {e}). Will attempt to create a new one.")
+                print(
+                    f"Workspace '{args.workspace}' not found via URL (or error: {e}). Will attempt to create a new"
+                    " one."
+                )
                 # Fall through to creation block
-                workspace = None # Ensure workspace is None to trigger creation
+                workspace = None  # Ensure workspace is None to trigger creation
         else:
             print("Skipping attempt to load workspace by URL as entity is not resolved. Will proceed to creation.")
 
-
-        if workspace is None: # If not loaded, create new
-            print(f"Creating new workspace: '{args.workspace}' (Entity: {args.entity or 'default'}, Project: {args.project})")
+        if workspace is None:  # If not loaded, create new
+            print(
+                f"Creating new workspace: '{args.workspace}' (Entity: {args.entity or 'default'}, Project:"
+                f" {args.project})"
+            )
             # Pass args.entity (which can be None) to Workspace constructor.
             # The wandb_workspaces library or underlying wandb client should handle None as default entity.
+
             workspace = ws.Workspace(
-                entity=args.entity, # This can be None
+                entity=resolved_entity,
                 project=args.project,
                 name=args.workspace,
                 sections=[main_section],
-                settings=workspace_settings
+                settings=workspace_settings,
             )
-            # For a new workspace, entity in the workspace object might get resolved by the backend upon save.
-            # If args.entity was None, workspace.entity might be populated after save.
 
         workspace.save()
-        
-        final_entity = workspace.entity # Get entity from workspace object after save
+
+        final_entity = workspace.entity  # Get entity from workspace object after save
         final_project = workspace.project
         final_name = workspace.name
 
         print(f"Workspace '{final_name}' (Entity: {final_entity}, Project: {final_project}) saved successfully.")
         print(f"View it at: {workspace.url}")
 
-    except wandb.errors.Error as e: # Catch Wandb specific errors
+    except wandb.errors.Error as e:  # Catch Wandb specific errors
         print(f"A WandB specific error occurred: {e}")
         print("Please ensure your WandB API key is configured (e.g., via 'wandb login' or WANDB_API_KEY).")
-        print(f"Also verify that the project '{args.project}' exists under entity '{resolved_entity or 'your default entity'}' and that you have necessary permissions.")
+        print(
+            f"Also verify that the project '{args.project}' exists under entity"
+            f" '{resolved_entity or 'your default entity'}' and that you have necessary permissions."
+        )
     except Exception as e:
         print(f"An unexpected error occurred during workspace setup: {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/setup_wandb_workspace.py
+++ b/scripts/setup_wandb_workspace.py
@@ -1,0 +1,132 @@
+import argparse
+import os
+import wandb # For wandb.Api()
+import wandb_workspaces.workspaces as ws
+import wandb_workspaces.reports as wr
+
+def main():
+    parser = argparse.ArgumentParser(description="Create or update a WandB workspace.")
+    parser.add_argument("--entity", type=str, default=None, help="WandB entity (user or team name). Optional, defaults to the logged-in user's default entity.")
+    parser.add_argument("--project", type=str, default="levanter", help="WandB project name. Optional, defaults to 'levanter'.")
+    parser.add_argument("--workspace", type=str, default="levanter-default", help="Name of the workspace to create or update. Optional, defaults to 'levanter-default'.")
+    parser.add_argument("--base_url", type=str, help="Base URL for WandB (for self-hosted instances)")
+
+    args = parser.parse_args()
+
+    if args.base_url:
+        os.environ["WANDB_BASE_URL"] = args.base_url
+
+    # Define workspace sections and panels
+    main_section = ws.Section(
+        name="main",
+        panels=[
+            wr.LinePlot(
+                x=["tokens"],
+                y=["train/loss"],
+                title="log(train/loss) vs log(tokens)",
+                plot_config={'layout': {'xaxis': {'type': 'log'}, 'yaxis': {'type': 'log'}}}
+            ),
+            wr.LinePlot(
+                x=["step"],
+                y=["train/loss"],
+                title="log(train/loss) vs log(steps)",
+                plot_config={'layout': {'xaxis': {'type': 'log'}, 'yaxis': {'type': 'log'}}}
+            ),
+            wr.LinePlot(
+                x=["tokens"],
+                y=["eval/bpb"],
+                title="log(eval/bpb) vs log(tokens)",
+                plot_config={'layout': {'xaxis': {'type': 'log'}, 'yaxis': {'type': 'log'}}}
+            ),
+            wr.BarPlot(
+                metrics=["throughput/mfu"],  # Assuming this shows max or latest value
+                title="Max MFU"
+            )
+        ]
+    )
+
+    workspace_settings = ws.WorkspaceSettings(group_by_prefix="first")
+
+    # Try to load existing workspace or create a new one
+    workspace = None
+    resolved_entity = args.entity
+    
+    try:
+        # Initialize wandb.Api to determine default entity if args.entity is None
+        # This also helps verify API key setup early.
+        try:
+            api = wandb.Api(overrides={"base_url": args.base_url} if args.base_url else {})
+            if not resolved_entity:
+                resolved_entity = api.default_entity
+                if not resolved_entity:
+                    print("Warning: WandB entity not specified and could not determine default entity (user might not be logged in).")
+                    # Proceeding with entity=None, creation might still work if project is unique enough or API handles it.
+                    # Loading by URL will likely fail if entity is required in the path and is None.
+                else:
+                    print(f"Using default WandB entity: {resolved_entity}")
+            else:
+                print(f"Using specified WandB entity: {resolved_entity}")
+
+        except wandb.errors.Error as e: # Catch wandb specific errors for API initialization
+            print(f"Error initializing WandB API (ensure you are logged in and API key is set): {e}")
+            # Fallback to trying with entity=None if args.entity was None, or the specified one.
+            # This path might be problematic for from_url if entity is truly needed.
+            resolved_entity = args.entity # Stick to original if API init fails
+            if not resolved_entity:
+                 print("Proceeding without a resolved WandB entity. Workspace creation/loading might fail or use an unexpected default.")
+
+
+        # Construct the workspace URL for from_url attempt
+        # Only attempt from_url if we have a resolved_entity, as it's part of the URL path
+        if resolved_entity:
+            web_url_base = args.base_url or 'https://wandb.ai'
+            workspace_url_path = f"{resolved_entity}/{args.project}/workspaces/{args.workspace}"
+            web_url = f"{web_url_base}/{workspace_url_path}"
+
+            try:
+                print(f"Attempting to load workspace from URL: {web_url}")
+                workspace = ws.Workspace.from_url(web_url)
+                print(f"Found existing workspace: '{args.workspace}' (Entity: {resolved_entity}, Project: {args.project})")
+                workspace.sections = [main_section]
+                workspace.settings = workspace_settings
+                print(f"Updating existing workspace: '{args.workspace}'")
+            except Exception as e:
+                print(f"Workspace '{args.workspace}' not found via URL (or error: {e}). Will attempt to create a new one.")
+                # Fall through to creation block
+                workspace = None # Ensure workspace is None to trigger creation
+        else:
+            print("Skipping attempt to load workspace by URL as entity is not resolved. Will proceed to creation.")
+
+
+        if workspace is None: # If not loaded, create new
+            print(f"Creating new workspace: '{args.workspace}' (Entity: {args.entity or 'default'}, Project: {args.project})")
+            # Pass args.entity (which can be None) to Workspace constructor.
+            # The wandb_workspaces library or underlying wandb client should handle None as default entity.
+            workspace = ws.Workspace(
+                entity=args.entity, # This can be None
+                project=args.project,
+                name=args.workspace,
+                sections=[main_section],
+                settings=workspace_settings
+            )
+            # For a new workspace, entity in the workspace object might get resolved by the backend upon save.
+            # If args.entity was None, workspace.entity might be populated after save.
+
+        workspace.save()
+        
+        final_entity = workspace.entity # Get entity from workspace object after save
+        final_project = workspace.project
+        final_name = workspace.name
+
+        print(f"Workspace '{final_name}' (Entity: {final_entity}, Project: {final_project}) saved successfully.")
+        print(f"View it at: {workspace.url}")
+
+    except wandb.errors.Error as e: # Catch Wandb specific errors
+        print(f"A WandB specific error occurred: {e}")
+        print("Please ensure your WandB API key is configured (e.g., via 'wandb login' or WANDB_API_KEY).")
+        print(f"Also verify that the project '{args.project}' exists under entity '{resolved_entity or 'your default entity'}' and that you have necessary permissions.")
+    except Exception as e:
+        print(f"An unexpected error occurred during workspace setup: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a new Python script `scripts/setup_wandb_workspace.py` that automates the configuration of Weights & Biases workspaces for your Levanter projects.

The script performs the following actions:
- Takes WandB entity, project, and workspace name as command-line arguments.
- Sets the workspace setting `group_by_prefix` to "first" for better organization of Levanter's numerous logged metrics.
- Creates (or updates an existing) workspace with a pinned section named "main".
- Populates the "main" section with key performance plots:
    - log(train/loss) vs log(tokens)
    - log(train/loss) vs log(steps)
    - log(eval/bpb) vs log(tokens)
    - A bar chart for max(throughput/mfu)

Documentation for this script, including usage instructions, has been added to `docs/Getting-Started-Training.md`.

The necessary `wandb` dependency was confirmed to be already present in `pyproject.toml`.

This utility aims to improve your experience when analyzing Levanter runs in WandB by providing a more structured and insightful default view.