### PR TITLE
[jules] Add GH Action for GPT-2 Small Fast integration test

### DIFF
--- a/.github/workflows/gpt2_small_itest.yaml
+++ b/.github/workflows/gpt2_small_itest.yaml
@@ -1,0 +1,53 @@
+name: GPT-2 Small Integration Test
+
+on:
+  push:
+    branches:
+      - main # Trigger on merges/pushes to main
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  integration_test:
+    runs-on: ubuntu-latest
+    env:
+      TPU_ZONE: "us-central2-b" # Matching the launch script
+      WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3 # Use a more recent version
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Configure Google Cloud
+        run: |
+          gcloud config set project ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Run GPT-2 Small Integration Test
+        run: |
+          # The launch script handles TPU creation and deletion
+          bash scripts/launch_gpt2_small_itest_tpu.sh
+        env:
+          USER: ci-runner-${{ github.run_id }} # Set a unique user for TPU naming in the script
+          # Ensure other necessary env vars for the script are set if any
+
+      # infra/launch.py with --foreground should handle cleanup.
+      # If not, a manual cleanup step would be needed here similar to tpu_unit_tests.yaml,
+      # but it would need to know the TPU_NAME used by launch.py.
+      # For now, relying on launch.py for cleanup.
+      # - name: Cleanup TPU
+      #   if: ${{ always() }}
+      #   run: |
+      #     # This would require launch.py to output the TPU name or use a predictable one
+      #     # For example, if TPU_NAME was consistently $(whoami)-levanter-itest-32 as in the script
+      #     TPU_NAME_IN_SCRIPT="ci-runner-${{ github.run_id }}-levanter-itest-32"
+      #     echo "Attempting to delete TPU: $TPU_NAME_IN_SCRIPT in zone ${TPU_ZONE}"
+      #     gcloud compute tpus tpu-vm delete $TPU_NAME_IN_SCRIPT --zone ${TPU_ZONE} --quiet || echo "TPU deletion failed or TPU did not exist."

--- a/config/gpt2_small_itest.yaml
+++ b/config/gpt2_small_itest.yaml
@@ -1,0 +1,28 @@
+data: !include data/openwebtext_source.yaml
+model:
+  type: gpt2
+  hidden_dim: 768
+  num_heads: 12
+  num_layers: 12
+  seq_len: 1024
+  gradient_checkpointing: true
+  scale_attn_by_inverse_layer_idx: true
+trainer:
+  tracker:
+    - type: wandb
+      project: "levanter-itest"
+      tags: [ "openwebtext", "gpt2", "itest"]
+
+  mp: p=f32,c=bfloat16
+  model_axis_size: 1
+  per_device_parallelism: -1
+
+  train_batch_size: 256
+  num_train_steps: 5000
+
+#  tensor_parallel_axes: ["position", "key_position"]
+#  tensor_parallel_axes: ["heads", "mlp"]
+optimizer:
+  learning_rate: 1E-3
+  weight_decay: 0.1
+  warmup: 0.01

--- a/scripts/launch_gpt2_small_itest_tpu.sh
+++ b/scripts/launch_gpt2_small_itest_tpu.sh
@@ -1,0 +1,6 @@
+# Launches the "gpt_small_fast" model on a TPU node
+
+python infra/launch.py --foreground --tpu_name $(whoami)-levanter-itest-32 --zone us-central2-b --tpu_type v4-32 --preemptible -- \
+    python -m levanter.main.train_lm \
+    --config_path config/gpt2_small_itest.yaml \
+    --trainer.checkpointer.base_path gs://levanter-checkpoints/gpt-itest/ --trainer.checkpointer.save_interval 30m $*


### PR DESCRIPTION
feat: 

This commit introduces a new GitHub Action to run an integration test for the GPT-2 Small Fast model.

The changes include:
- A new configuration file `config/gpt2_small_itest.yaml` with reduced training steps (5000) and a dedicated wandb project ("levanter-itest").
- A new launch script `scripts/launch_gpt2_small_itest_tpu.sh` that uses the new configuration and targets a v4-32 TPU.
- A new GitHub Actions workflow file `.github/workflows/gpt2_small_itest.yaml` that triggers on merges to main or manual dispatch, uses a v4-32 TPU, and executes the new launch script.