### PR TITLE
Gemma Fixes

### DIFF
--- a/src/levanter/models/gemma.py
+++ b/src/levanter/models/gemma.py
@@ -355,6 +355,8 @@ class GemmaLMHeadModel(LmHeadModel[GemmaConfig], ModuleWithStateDictSerializatio
                 The attn_mask from training pipeline may be an AttentionMask object instead of NamedArray
         """
         x = self.embeddings.embed(input_ids)
+        normalizer = jnp.sqrt(self.config.hidden_dim).astype(x.dtype)
+        x = x * normalizer
         x = self.transformer(x, attn_mask=attn_mask, key=key)
         return x
 

--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -421,7 +421,7 @@ class LlamaEmbedding(ModuleWithStateDictSerialization, eqx.Module):
 
     def resize_embeddings(self, new_size: int, key: Optional[PRNGKeyArray] = None):
         new_weights = self.token_embeddings.resize_embeddings(new_size, key=key)
-        return dataclasses.replace(self, Vocab=self.Vocab.resize(new_size), token_embeddings=new_weights)
+        return dataclasses.replace(self, token_embeddings=new_weights)
 
 
 class LlamaLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[LlamaConfig]):


### PR DESCRIPTION
A Couple Discrepancies in our Gemma 1 Implementation. 

1) Gemma 1 now allows untied embeddings in HuggingFace, which isn't the case for OG Gemma but comes into play for models which use this option like https://huggingface.co/tomg-group-umd/Gemstone-256x23_cooldown

2) Gemma 1 has a normalization on the input embeddings based on the size of the input dim. This doesn't get caught by our round trip test because the hidden dim is too small in the test, but this resolves the discrepancy at more realistic scales.

3) Resize Embeddings is broken for Llama since Vocab is a property that inherits from token_embeddings directly.