### PR TITLE
docs: Add note on JAX_COMPILATION_CACHE_DIR env var

### DIFF
--- a/docs/reference/Configuration.md
+++ b/docs/reference/Configuration.md
@@ -176,6 +176,44 @@ checkpointer:
 This policy will save permanent checkpoints every 1,000 steps until 10,000 steps, then every 5,000 steps until 40,000 steps, then every 10,000 steps.
 The default step-based checkpoint policy is to save a checkpoint every 10,000 steps.
 
+### JAX Compilation Cache Configuration
+
+Levanter allows you to configure JAX's persistent compilation cache. This can significantly speed up startup times by caching compiled JAX functions.
+The primary way to specify the cache directory is via the `jax_compilation_cache_dir` field in the `TrainerConfig`.
+
+| Parameter                   | Description                                                                                               | Type            | Default                                                                   |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------|-----------------|---------------------------------------------------------------------------|
+| `jax_compilation_cache_dir` | Path to a directory to store the persistent compilation cache. Can be a local path or a GCS path.         | `Optional[str]` | `None` (JAX default, usually `~/.cache/jax` or platform specific)         |
+
+Other JAX compilation cache settings (like `jax_persistent_cache_min_compile_time_secs`, `jax_persistent_cache_min_entry_size_bytes`, `jax_persistent_cache_enable_xla_caches`, etc.)
+can be configured by including them in the `trainer.jax_config` dictionary. This dictionary allows you to pass arbitrary JAX configuration options.
+For more details on all available JAX compilation cache options and how JAX's compilation cache works, please refer to the [official JAX documentation](https://docs.jax.dev/en/latest/persistent_compilation_cache.html).
+
+Here's an example of how to configure these options in your YAML file:
+
+```yaml
+trainer:
+  # ... other trainer configs
+  jax_compilation_cache_dir: "/path/to/your/jax_cache"  # Or "gs://your-bucket/jax_cache"
+
+  # To set other JAX compilation cache options or any other JAX global flag:
+  jax_config:
+    jax_persistent_cache_min_compile_time_secs: 5.0
+    jax_persistent_cache_min_entry_size_bytes: 1024
+    jax_persistent_cache_enable_xla_caches: "all" # or "xla_gpu_kernel_cache_file", etc.
+    # ... other jax settings like jax_threefry_partitionable
+```
+
+Alternatively, JAX's compilation cache directory can be set using the `JAX_COMPILATION_CACHE_DIR` environment variable.
+This method is particularly useful for workflows involving `launch.py` on TPUs, as environment variables can be specified in the `.levanter.yaml` configuration file used by `launch.py`.
+For more details on using `launch.py`, see the [Using launch.py](../Getting-Started-TPU-VM.md#using-launchpy) section in the TPU VM guide.
+
+Example `.levanter.yaml` snippet:
+```yaml
+env:
+  JAX_COMPILATION_CACHE_DIR: "gs://your-compile-cache-bucket/path"
+  # ... other environment variables
+```
 
 
 ## Trackers and Logging

--- a/src/levanter/trainer.py
+++ b/src/levanter/trainer.py
@@ -716,6 +716,7 @@ class TrainerConfig:
     jax_config: Mapping[str, JsonAtom] = field(
         default_factory=lambda: copy.deepcopy(DEFAULT_JAX_CONFIG)
     )  # config to pass to jax.config.update
+    jax_compilation_cache_dir: Optional[str] = None
 
     distributed: DistributedConfig = DistributedConfig()
     ray: RayConfig = field(default_factory=RayConfig)
@@ -868,6 +869,9 @@ class TrainerConfig:
     def _initialize_jax_config(self):
         for key, value in self.jax_config.items():
             jax.config.update(key, value)
+
+        if self.jax_compilation_cache_dir is not None:
+            jax.config.update("jax_compilation_cache_dir", self.jax_compilation_cache_dir)
 
     def _maybe_set_id(self):
         # always do this so we don't get weird hangs if the id isn't set right

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,14 @@
 import dataclasses
-
+import jax # Added import
 import fsspec
+import copy # For deepcopying jax_config
 
 from haliax.partitioning import ResourceAxis
 
 import levanter.config
 from levanter.data.text import HfSingleDatasetLMConfig, LMMixtureDatasetConfig
-from levanter.trainer import TrainerConfig
+from levanter.trainer import TrainerConfig, DEFAULT_JAX_CONFIG # Added import
+from levanter.tracker.tracker import NoopConfig # Added import
 
 
 def test_main_wrapper_loads_from_fsspec():
@@ -100,6 +102,117 @@ def test_lm_mixture_dataset_config():
         # TODO: assert more things
 
     main()
+
+
+def test_jax_compilation_cache_config():
+    # Store original JAX config values
+    original_cache_dir = getattr(jax.config, "jax_compilation_cache_dir", None)
+    original_min_compile_time = getattr(jax.config, "jax_persistent_cache_min_compile_time_secs", None)
+    original_min_entry_size = getattr(jax.config, "jax_persistent_cache_min_entry_size_bytes", None)
+    original_enable_xla_caches = getattr(jax.config, "jax_persistent_cache_enable_xla_caches", None)
+
+    # JAX internal defaults (as of jax 0.4.23, these might change)
+    # These are used to check against if the original values were None (meaning JAX was using its internal defaults)
+    jax_default_min_compile_time = 1.0
+    jax_default_min_entry_size = 0
+
+
+    try:
+        # Test Case 1: Local path for jax_compilation_cache_dir
+        # Ensure other cache settings are NOT affected by TrainerConfig's direct fields (only by jax_config)
+        trainer_config_local = TrainerConfig(
+            jax_compilation_cache_dir="/tmp/test_jax_cache",
+            require_accelerator=False,
+            tracker=(NoopConfig(),),
+        )
+        trainer_config_local.initialize()
+
+        assert jax.config.jax_compilation_cache_dir == "/tmp/test_jax_cache"
+        # These should remain their original values or JAX's internal defaults if original was None
+        assert jax.config.jax_persistent_cache_min_compile_time_secs == (original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time)
+        assert jax.config.jax_persistent_cache_min_entry_size_bytes == (original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size)
+        assert jax.config.jax_persistent_cache_enable_xla_caches == original_enable_xla_caches
+
+
+        # Reset for next test case to ensure isolation
+        jax.config.update("jax_compilation_cache_dir", original_cache_dir)
+        jax.config.update("jax_persistent_cache_min_compile_time_secs", original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time)
+        jax.config.update("jax_persistent_cache_min_entry_size_bytes", original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size)
+        if original_enable_xla_caches is not None: # Only update if it was something, otherwise it might be unset
+            jax.config.update("jax_persistent_cache_enable_xla_caches", original_enable_xla_caches)
+        else: # If original was None, ensure it's None for the next test too, unless default jax_config sets it
+            if "jax_persistent_cache_enable_xla_caches" not in DEFAULT_JAX_CONFIG:
+                 jax.config.update("jax_persistent_cache_enable_xla_caches", None)
+
+
+        # Test Case 2: GCS path for jax_compilation_cache_dir
+        trainer_config_gcs = TrainerConfig(
+            jax_compilation_cache_dir="gs://my-bucket/test_jax_cache",
+            require_accelerator=False,
+            tracker=(NoopConfig(),),
+        )
+        trainer_config_gcs.initialize()
+        assert jax.config.jax_compilation_cache_dir == "gs://my-bucket/test_jax_cache"
+        # These should also remain their original values or JAX's internal defaults
+        assert jax.config.jax_persistent_cache_min_compile_time_secs == (original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time)
+        assert jax.config.jax_persistent_cache_min_entry_size_bytes == (original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size)
+        assert jax.config.jax_persistent_cache_enable_xla_caches == original_enable_xla_caches
+
+    finally:
+        # Restore original JAX config values
+        jax.config.update("jax_compilation_cache_dir", original_cache_dir)
+        jax.config.update("jax_persistent_cache_min_compile_time_secs", original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time)
+        jax.config.update("jax_persistent_cache_min_entry_size_bytes", original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size)
+        # Only update if it was something, otherwise it might be unset vs set to None by jax.config.update
+        if original_enable_xla_caches is not None:
+            jax.config.update("jax_persistent_cache_enable_xla_caches", original_enable_xla_caches)
+        else: # if original was None, ensure it's set back to None if it's not in default jax_config
+            current_default_jax_config = copy.deepcopy(DEFAULT_JAX_CONFIG)
+            if "jax_persistent_cache_enable_xla_caches" not in current_default_jax_config:
+                jax.config.update("jax_persistent_cache_enable_xla_caches", None)
+
+
+def test_advanced_jax_cache_settings_via_jax_config():
+    original_cache_dir = getattr(jax.config, "jax_compilation_cache_dir", None)
+    original_min_compile_time = getattr(jax.config, "jax_persistent_cache_min_compile_time_secs", None)
+    original_min_entry_size = getattr(jax.config, "jax_persistent_cache_min_entry_size_bytes", None)
+    original_enable_xla_caches = getattr(jax.config, "jax_persistent_cache_enable_xla_caches", None)
+
+    # JAX internal defaults
+    jax_default_min_compile_time = 1.0
+    jax_default_min_entry_size = 0
+
+    try:
+        custom_jax_config = copy.deepcopy(DEFAULT_JAX_CONFIG)
+        custom_jax_config["jax_persistent_cache_min_compile_time_secs"] = 10.0
+        custom_jax_config["jax_persistent_cache_min_entry_size_bytes"] = 2048
+        custom_jax_config["jax_persistent_cache_enable_xla_caches"] = "xla_gpu_kernel_cache_file"
+        # Optionally, set a custom cache dir via jax_config as well, or test it separately
+        custom_jax_config["jax_compilation_cache_dir"] = "/tmp/advanced_test_cache"
+
+        trainer_config = TrainerConfig(
+            jax_config=custom_jax_config,
+            require_accelerator=False,
+            tracker=(NoopConfig(),),
+        )
+        trainer_config.initialize()
+
+        assert jax.config.jax_compilation_cache_dir == "/tmp/advanced_test_cache"
+        assert jax.config.jax_persistent_cache_min_compile_time_secs == 10.0
+        assert jax.config.jax_persistent_cache_min_entry_size_bytes == 2048
+        assert jax.config.jax_persistent_cache_enable_xla_caches == "xla_gpu_kernel_cache_file"
+
+    finally:
+        # Restore original JAX config values
+        jax.config.update("jax_compilation_cache_dir", original_cache_dir)
+        jax.config.update("jax_persistent_cache_min_compile_time_secs", original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time)
+        jax.config.update("jax_persistent_cache_min_entry_size_bytes", original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size)
+        if original_enable_xla_caches is not None:
+            jax.config.update("jax_persistent_cache_enable_xla_caches", original_enable_xla_caches)
+        else:
+            current_default_jax_config = copy.deepcopy(DEFAULT_JAX_CONFIG)
+            if "jax_persistent_cache_enable_xla_caches" not in current_default_jax_config:
+                 jax.config.update("jax_persistent_cache_enable_xla_caches", None)
 
 
 def _write_yaml_to_memory(yaml: str, path: str = "memory://test.yaml"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,15 +1,12 @@
-import copy  # For deepcopying jax_config
 import dataclasses
 
 import fsspec
-import jax  # Added import
 
 from haliax.partitioning import ResourceAxis
 
 import levanter.config
 from levanter.data.text import HfSingleDatasetLMConfig, LMMixtureDatasetConfig
-from levanter.tracker.tracker import NoopConfig  # Added import
-from levanter.trainer import DEFAULT_JAX_CONFIG, TrainerConfig  # Added import
+from levanter.trainer import TrainerConfig
 
 
 def test_main_wrapper_loads_from_fsspec():
@@ -103,140 +100,6 @@ def test_lm_mixture_dataset_config():
         # TODO: assert more things
 
     main()
-
-
-def test_jax_compilation_cache_config():
-    # Store original JAX config values
-    original_cache_dir = getattr(jax.config, "jax_compilation_cache_dir", None)
-    original_min_compile_time = getattr(jax.config, "jax_persistent_cache_min_compile_time_secs", None)
-    original_min_entry_size = getattr(jax.config, "jax_persistent_cache_min_entry_size_bytes", None)
-    original_enable_xla_caches = getattr(jax.config, "jax_persistent_cache_enable_xla_caches", None)
-
-    # JAX internal defaults (as of jax 0.4.23, these might change)
-    # These are used to check against if the original values were None (meaning JAX was using its internal defaults)
-    jax_default_min_compile_time = 1.0
-    jax_default_min_entry_size = 0
-
-    try:
-        # Test Case 1: Local path for jax_compilation_cache_dir
-        # Ensure other cache settings are NOT affected by TrainerConfig's direct fields (only by jax_config)
-        trainer_config_local = TrainerConfig(
-            jax_compilation_cache_dir="/tmp/test_jax_cache",
-            require_accelerator=False,
-            tracker=(NoopConfig(),),
-        )
-        trainer_config_local.initialize()
-
-        assert jax.config.jax_compilation_cache_dir == "/tmp/test_jax_cache"
-        # These should remain their original values or JAX's internal defaults if original was None
-        assert jax.config.jax_persistent_cache_min_compile_time_secs == (
-            original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time
-        )
-        assert jax.config.jax_persistent_cache_min_entry_size_bytes == (
-            original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size
-        )
-        assert jax.config.jax_persistent_cache_enable_xla_caches == original_enable_xla_caches
-
-        # Reset for next test case to ensure isolation
-        jax.config.update("jax_compilation_cache_dir", original_cache_dir)
-        jax.config.update(
-            "jax_persistent_cache_min_compile_time_secs",
-            original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time,
-        )
-        jax.config.update(
-            "jax_persistent_cache_min_entry_size_bytes",
-            original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size,
-        )
-        if original_enable_xla_caches is not None:  # Only update if it was something, otherwise it might be unset
-            jax.config.update("jax_persistent_cache_enable_xla_caches", original_enable_xla_caches)
-        else:  # If original was None, ensure it's None for the next test too, unless default jax_config sets it
-            if "jax_persistent_cache_enable_xla_caches" not in DEFAULT_JAX_CONFIG:
-                jax.config.update("jax_persistent_cache_enable_xla_caches", None)
-
-        # Test Case 2: GCS path for jax_compilation_cache_dir
-        trainer_config_gcs = TrainerConfig(
-            jax_compilation_cache_dir="gs://my-bucket/test_jax_cache",
-            require_accelerator=False,
-            tracker=(NoopConfig(),),
-        )
-        trainer_config_gcs.initialize()
-        assert jax.config.jax_compilation_cache_dir == "gs://my-bucket/test_jax_cache"
-        # These should also remain their original values or JAX's internal defaults
-        assert jax.config.jax_persistent_cache_min_compile_time_secs == (
-            original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time
-        )
-        assert jax.config.jax_persistent_cache_min_entry_size_bytes == (
-            original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size
-        )
-        assert jax.config.jax_persistent_cache_enable_xla_caches == original_enable_xla_caches
-
-    finally:
-        # Restore original JAX config values
-        jax.config.update("jax_compilation_cache_dir", original_cache_dir)
-        jax.config.update(
-            "jax_persistent_cache_min_compile_time_secs",
-            original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time,
-        )
-        jax.config.update(
-            "jax_persistent_cache_min_entry_size_bytes",
-            original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size,
-        )
-        # Only update if it was something, otherwise it might be unset vs set to None by jax.config.update
-        if original_enable_xla_caches is not None:
-            jax.config.update("jax_persistent_cache_enable_xla_caches", original_enable_xla_caches)
-        else:  # if original was None, ensure it's set back to None if it's not in default jax_config
-            current_default_jax_config = copy.deepcopy(DEFAULT_JAX_CONFIG)
-            if "jax_persistent_cache_enable_xla_caches" not in current_default_jax_config:
-                jax.config.update("jax_persistent_cache_enable_xla_caches", None)
-
-
-def test_advanced_jax_cache_settings_via_jax_config():
-    original_cache_dir = getattr(jax.config, "jax_compilation_cache_dir", None)
-    original_min_compile_time = getattr(jax.config, "jax_persistent_cache_min_compile_time_secs", None)
-    original_min_entry_size = getattr(jax.config, "jax_persistent_cache_min_entry_size_bytes", None)
-    original_enable_xla_caches = getattr(jax.config, "jax_persistent_cache_enable_xla_caches", None)
-
-    # JAX internal defaults
-    jax_default_min_compile_time = 1.0
-    jax_default_min_entry_size = 0
-
-    try:
-        custom_jax_config = copy.deepcopy(DEFAULT_JAX_CONFIG)
-        custom_jax_config["jax_persistent_cache_min_compile_time_secs"] = 10.0
-        custom_jax_config["jax_persistent_cache_min_entry_size_bytes"] = 2048
-        custom_jax_config["jax_persistent_cache_enable_xla_caches"] = "xla_gpu_kernel_cache_file"
-        # Optionally, set a custom cache dir via jax_config as well, or test it separately
-        custom_jax_config["jax_compilation_cache_dir"] = "/tmp/advanced_test_cache"
-
-        trainer_config = TrainerConfig(
-            jax_config=custom_jax_config,
-            require_accelerator=False,
-            tracker=(NoopConfig(),),
-        )
-        trainer_config.initialize()
-
-        assert jax.config.jax_compilation_cache_dir == "/tmp/advanced_test_cache"
-        assert jax.config.jax_persistent_cache_min_compile_time_secs == 10.0
-        assert jax.config.jax_persistent_cache_min_entry_size_bytes == 2048
-        assert jax.config.jax_persistent_cache_enable_xla_caches == "xla_gpu_kernel_cache_file"
-
-    finally:
-        # Restore original JAX config values
-        jax.config.update("jax_compilation_cache_dir", original_cache_dir)
-        jax.config.update(
-            "jax_persistent_cache_min_compile_time_secs",
-            original_min_compile_time if original_min_compile_time is not None else jax_default_min_compile_time,
-        )
-        jax.config.update(
-            "jax_persistent_cache_min_entry_size_bytes",
-            original_min_entry_size if original_min_entry_size is not None else jax_default_min_entry_size,
-        )
-        if original_enable_xla_caches is not None:
-            jax.config.update("jax_persistent_cache_enable_xla_caches", original_enable_xla_caches)
-        else:
-            current_default_jax_config = copy.deepcopy(DEFAULT_JAX_CONFIG)
-            if "jax_persistent_cache_enable_xla_caches" not in current_default_jax_config:
-                jax.config.update("jax_persistent_cache_enable_xla_caches", None)
 
 
 def _write_yaml_to_memory(yaml: str, path: str = "memory://test.yaml"):


### PR DESCRIPTION
Adds documentation to `docs/reference/Configuration.md` explaining that `JAX_COMPILATION_CACHE_DIR` can be set as an environment variable.

This is particularly useful for you if you're using `launch.py` with TPUs, as it can be specified in the `.levanter.yaml` configuration file. Includes an example and a link to the relevant section in the TPU VM getting started guide.