### PR TITLE
Refactor attention mask structure

### DIFF
--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -676,7 +676,6 @@ class AttentionMask(eqx.Module):
         return ExplicitMask(mask)
 
 
-@dataclass(frozen=True)
 class CausalMask(AttentionMask):
     def materialize(
         self, QPos: Axis, KPos: Axis, q_slice: Optional[haliax.dslice] = None, k_slice: Optional[haliax.dslice] = None
@@ -693,7 +692,6 @@ class CausalMask(AttentionMask):
         return True
 
 
-@dataclass(frozen=True)
 class ExplicitMask(AttentionMask):
     mask: NamedArray
 
@@ -714,7 +712,6 @@ class ExplicitMask(AttentionMask):
         return self.mask
 
 
-@dataclass(frozen=True)
 class SegmentMask(AttentionMask):
     ids: NamedArray
 
@@ -728,7 +725,6 @@ class SegmentMask(AttentionMask):
         return self.ids
 
 
-@dataclass(frozen=True)
 class AndMask(AttentionMask):
     left: AttentionMask
     right: AttentionMask
@@ -757,7 +753,6 @@ class AndMask(AttentionMask):
         return left_ids if left_ids is not None else right_ids
 
 
-@dataclass(frozen=True)
 class OrMask(AttentionMask):
     left: AttentionMask
     right: AttentionMask


### PR DESCRIPTION
## Summary
- represent `AttentionMask` as an algebraic data type
- add `_mask_to_splash_mask` utility for Splash backend
- convert splash attention to use the new helper
- document `AttentionMask` with details on materialization

## Testing
- `pre-commit run --files src/levanter/layers/attention.py`
- `pytest -q` *(fails: 59 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68575901c3a48331a68ec073f33f1ddc