### PR TITLE
Fix dataset union for evaluation configs

### DIFF
--- a/src/levanter/main/eval_lm.py
+++ b/src/levanter/main/eval_lm.py
@@ -15,7 +15,11 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
-from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
+from levanter.data.text import (
+    LMMixtureDatasetConfig,
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.eval import TaggedEvaluator, eval_model
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, compute_next_token_loss
@@ -33,7 +37,7 @@ class EvalLmConfig:
     checkpoint_path: Optional[str] = None
     hf_checkpoint: Optional[RepoRef] = None
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig | LMMixtureDatasetConfig = field(default_factory=UrlSingleDatasetLMConfig)
     model: LmConfig = field(default_factory=Gpt2Config)
 
     eval_on_train: bool = False

--- a/src/levanter/main/eval_sliding_lm.py
+++ b/src/levanter/main/eval_sliding_lm.py
@@ -18,11 +18,16 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
-from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
+from levanter.data.text import (
+    LMMixtureDatasetConfig,
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +37,7 @@ class EvalSlidingLmConfig:
     checkpoint_path: Optional[str] = None
     hf_checkpoint: Optional[RepoRef] = None
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig | LMMixtureDatasetConfig = field(default_factory=UrlSingleDatasetLMConfig)
     model: LmConfig = field(default_factory=Gpt2Config)
 
     split: str = "validation"
@@ -95,7 +100,7 @@ def main(config: EvalSlidingLmConfig):
                 lp = log_softmax(logits, axis=model.Vocab)
                 targets = hax.roll(batch.tokens, -1, Pos)
                 lp = hax.take(lp, model.Vocab, targets)
-                mask = (1 - hax.nn.one_hot(-1, Pos, dtype=lp.dtype))
+                mask = 1 - hax.nn.one_hot(-1, Pos, dtype=lp.dtype)
                 if batch.loss_mask is not None:
                     mask = mask * batch.loss_mask
                 return lp * mask
@@ -113,7 +118,9 @@ def main(config: EvalSlidingLmConfig):
                 raise ValueError("Model config does not have an HF checkpoint converter.")
             converter: HFCheckpointConverter = model_config.hf_checkpoint_converter()
             converter = converter.replaced(reference_checkpoint=config.hf_checkpoint, tokenizer=tokenizer)
-            model = converter.load_pretrained(model_config.model_type, ref=config.hf_checkpoint, dtype=mp.compute_dtype)
+            model = converter.load_pretrained(
+                model_config.model_type, ref=config.hf_checkpoint, dtype=mp.compute_dtype
+            )
         else:
             raise ValueError("Must specify checkpoint_path or hf_checkpoint")
 

--- a/src/levanter/main/lora_lm.py
+++ b/src/levanter/main/lora_lm.py
@@ -10,7 +10,10 @@ import haliax.random
 import levanter
 from levanter import callbacks
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
-from levanter.data.text import SingleDatasetLMConfigBase
+from levanter.data.text import (
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.lora import (
     LoraConfig,
     lora_trainable_params_filter,
@@ -31,7 +34,7 @@ logger = logging.getLogger(__name__)
 class LoraLmConfig:
     initialize_from_hf: str
     lora: LoraConfig = field(default_factory=LoraConfig)
-    data: SingleDatasetLMConfigBase = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig = field(default_factory=UrlSingleDatasetLMConfig)
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
 

--- a/src/levanter/main/viz_logprobs.py
+++ b/src/levanter/main/viz_logprobs.py
@@ -15,7 +15,11 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
-from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
+from levanter.data.text import (
+    LMMixtureDatasetConfig,
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.models.loss import next_token_loss
@@ -33,7 +37,7 @@ class VizLmConfig:
     checkpoint_path: str
     path: str = "logprobs.html"
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig | LMMixtureDatasetConfig = field(default_factory=UrlSingleDatasetLMConfig)
     model: LmConfig = field(default_factory=Gpt2Config)
 
     num_docs: int = 32


### PR DESCRIPTION
## Summary
- allow specifying HF dataset IDs in evaluation scripts by using `SingleDatasetLMConfig`
- update `eval_lm.py`, `eval_sliding_lm.py`, `viz_logprobs.py`, and `lora_lm.py`

## Testing
- `black` formatting
- `isort` import ordering
- `pytest -k "eval_lm or viz_lm" -q` *(fails: ModuleNotFoundError: tensorboardX)*

------
https://chatgpt.com/codex/tasks/task_e_6858da279ef88327a9f11a4d206dab07