### PR TITLE
Fix HF evaluation options

### DIFF
--- a/config/eval_llama3_sliding.yaml
+++ b/config/eval_llama3_sliding.yaml
@@ -5,11 +5,13 @@ checkpoint_path: "gs://path/to/checkpoint"  # set to your checkpoint
 
 # Dataset processed with SingleTurnChatProcessor
 data:
-  id: allenai/tulu-3-sft-mixture
+  validation_urls:
+    - "gs://marin-us-central2/documents/books_windowed/great_gatsby-4b0031/matches_row_0/shard_00000.jsonl.gz"
   format:
     type: "chat"
+    single_turn: true
   tokenizer: stanford-crfm/marin-tokenizer
-  cache_dir: "gs://marin-us-central2/tokenized/marin-tokenizer/tulu-3-sft-mixture"
+  cache_dir: "gs://marin-us-central2/tokenized/marin-tokenizer/great_gatsby_windowed"
   shuffle: false
 
 model:  # 8B llama3 model

--- a/docs/Training-On-Your-Data.md
+++ b/docs/Training-On-Your-Data.md
@@ -426,6 +426,15 @@ The script masks the prompt portion of each example and plots a heat map of the
 completion probabilities. You can use `config/eval_llama3_sliding.yaml` as a
 starting point for a configuration.
 
+To evaluate a model checkpoint from Hugging Face directly, pass `initialize_from_hf`:
+
+```bash
+python -m levanter.main.eval_sliding_lm \
+    --config_path gs://path/to/config.yaml \
+    --initialize_from_hf meta-llama/Llama-2-7b-hf
+```
+If the model configuration should be derived from the checkpoint, set `use_hf_model_config: true` in your YAML config.
+
 
 ## Huggingface Export
 

--- a/src/levanter/main/eval_lm.py
+++ b/src/levanter/main/eval_lm.py
@@ -15,7 +15,11 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
-from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
+from levanter.data.text import (
+    LMMixtureDatasetConfig,
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.eval import TaggedEvaluator, eval_model
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, compute_next_token_loss
@@ -32,8 +36,11 @@ class EvalLmConfig:
 
     checkpoint_path: Optional[str] = None
     hf_checkpoint: Optional[RepoRef] = None
+    initialize_from_hf: Optional[RepoRef] = None
+    """If set, load the model weights from this HF checkpoint."""
+    use_hf_model_config: bool = False
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig | LMMixtureDatasetConfig = field(default_factory=UrlSingleDatasetLMConfig)
     model: LmConfig = field(default_factory=Gpt2Config)
 
     eval_on_train: bool = False
@@ -69,9 +76,11 @@ def main(config: EvalLmConfig):
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
 
-    if config.checkpoint_path is None and config.hf_checkpoint is None:
+    hf_ref = config.hf_checkpoint or config.initialize_from_hf
+
+    if config.checkpoint_path is None and hf_ref is None:
         raise ValueError("Must specify either checkpoint_path or hf_checkpoint")
-    if config.checkpoint_path is not None and config.hf_checkpoint is not None:
+    if config.checkpoint_path is not None and hf_ref is not None:
         raise ValueError("Must specify either checkpoint_path or hf_checkpoint, not both")
 
     with config.trainer.device_mesh, hax.axis_mapping(parameter_axis_mapping):
@@ -113,16 +122,17 @@ def main(config: EvalLmConfig):
                 model = load_checkpoint(model, config.checkpoint_path, subpath="model")
 
             model = hax.shard_with_axis_mapping(model, parameter_axis_mapping)
-        elif config.hf_checkpoint is not None:
+        elif hf_ref is not None:
             # load the huggingface model
             model_config = config.model
             if not hasattr(model_config, "hf_checkpoint_converter"):
                 raise ValueError("Model config does not have an HF checkpoint converter. Can't load HF checkpoint.")
             converter: HFCheckpointConverter = model_config.hf_checkpoint_converter()
-            converter = converter.replaced(reference_checkpoint=config.hf_checkpoint, tokenizer=tokenizer)
-            model = converter.load_pretrained(
-                model_config.model_type, ref=config.hf_checkpoint, dtype=mp.compute_dtype
-            )
+            converter = converter.replaced(reference_checkpoint=hf_ref, tokenizer=tokenizer)
+            if config.use_hf_model_config:
+                config.model = converter.config_from_hf_config(converter.default_hf_config)
+                model_config = config.model
+            model = converter.load_pretrained(model_config.model_type, ref=hf_ref, dtype=mp.compute_dtype)
         else:
             assert False, "Should not get here"
 

--- a/src/levanter/main/eval_sliding_lm.py
+++ b/src/levanter/main/eval_sliding_lm.py
@@ -18,11 +18,16 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
-from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
+from levanter.data.text import (
+    LMMixtureDatasetConfig,
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
+
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +36,11 @@ logger = logging.getLogger(__name__)
 class EvalSlidingLmConfig:
     checkpoint_path: Optional[str] = None
     hf_checkpoint: Optional[RepoRef] = None
+    initialize_from_hf: Optional[RepoRef] = None
+    """HF checkpoint to load for evaluation."""
+    use_hf_model_config: bool = False
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig | LMMixtureDatasetConfig = field(default_factory=UrlSingleDatasetLMConfig)
     model: LmConfig = field(default_factory=Gpt2Config)
 
     split: str = "validation"
@@ -78,6 +86,13 @@ def main(config: EvalSlidingLmConfig):
     compute_axis_mapping = config.trainer.compute_axis_mapping
     parameter_axis_mapping = config.trainer.parameter_axis_mapping
 
+    hf_ref = config.hf_checkpoint or config.initialize_from_hf
+
+    if config.checkpoint_path is None and hf_ref is None:
+        raise ValueError("Must specify either checkpoint_path or hf_checkpoint")
+    if config.checkpoint_path is not None and hf_ref is not None:
+        raise ValueError("Must specify either checkpoint_path or hf_checkpoint, not both")
+
     with config.trainer.device_mesh, hax.axis_mapping(parameter_axis_mapping):
         key = jax.random.PRNGKey(0)
 
@@ -95,7 +110,7 @@ def main(config: EvalSlidingLmConfig):
                 lp = log_softmax(logits, axis=model.Vocab)
                 targets = hax.roll(batch.tokens, -1, Pos)
                 lp = hax.take(lp, model.Vocab, targets)
-                mask = (1 - hax.nn.one_hot(-1, Pos, dtype=lp.dtype))
+                mask = 1 - hax.nn.one_hot(-1, Pos, dtype=lp.dtype)
                 if batch.loss_mask is not None:
                     mask = mask * batch.loss_mask
                 return lp * mask
@@ -107,13 +122,16 @@ def main(config: EvalSlidingLmConfig):
                 model = eqx.filter_eval_shape(config.model.build, Vocab, key=key)
                 model = load_checkpoint(model, config.checkpoint_path, subpath="model")
             model = hax.shard_with_axis_mapping(model, parameter_axis_mapping)
-        elif config.hf_checkpoint is not None:
+        elif hf_ref is not None:
             model_config = config.model
             if not hasattr(model_config, "hf_checkpoint_converter"):
                 raise ValueError("Model config does not have an HF checkpoint converter.")
             converter: HFCheckpointConverter = model_config.hf_checkpoint_converter()
-            converter = converter.replaced(reference_checkpoint=config.hf_checkpoint, tokenizer=tokenizer)
-            model = converter.load_pretrained(model_config.model_type, ref=config.hf_checkpoint, dtype=mp.compute_dtype)
+            converter = converter.replaced(reference_checkpoint=hf_ref, tokenizer=tokenizer)
+            if config.use_hf_model_config:
+                config.model = converter.config_from_hf_config(converter.default_hf_config)
+                model_config = config.model
+            model = converter.load_pretrained(model_config.model_type, ref=hf_ref, dtype=mp.compute_dtype)
         else:
             raise ValueError("Must specify checkpoint_path or hf_checkpoint")
 

--- a/src/levanter/main/lora_lm.py
+++ b/src/levanter/main/lora_lm.py
@@ -10,7 +10,10 @@ import haliax.random
 import levanter
 from levanter import callbacks
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
-from levanter.data.text import SingleDatasetLMConfigBase
+from levanter.data.text import (
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.lora import (
     LoraConfig,
     lora_trainable_params_filter,
@@ -31,7 +34,7 @@ logger = logging.getLogger(__name__)
 class LoraLmConfig:
     initialize_from_hf: str
     lora: LoraConfig = field(default_factory=LoraConfig)
-    data: SingleDatasetLMConfigBase = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig = field(default_factory=UrlSingleDatasetLMConfig)
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
 

--- a/src/levanter/main/viz_logprobs.py
+++ b/src/levanter/main/viz_logprobs.py
@@ -15,7 +15,11 @@ import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
-from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
+from levanter.data.text import (
+    LMMixtureDatasetConfig,
+    SingleDatasetLMConfig,
+    UrlSingleDatasetLMConfig,
+)
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.models.loss import next_token_loss
@@ -33,7 +37,7 @@ class VizLmConfig:
     checkpoint_path: str
     path: str = "logprobs.html"
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
+    data: SingleDatasetLMConfig | LMMixtureDatasetConfig = field(default_factory=UrlSingleDatasetLMConfig)
     model: LmConfig = field(default_factory=Gpt2Config)
 
     num_docs: int = 32


### PR DESCRIPTION
## Summary
- support `initialize_from_hf` and `use_hf_model_config` in evaluation scripts
- document using `eval_sliding_lm.py` with HF checkpoints
- update sliding evaluation config to load dataset from GCS

## Testing
- `black src/levanter/main/eval_lm.py src/levanter/main/eval_sliding_lm.py`
- `isort src/levanter/main/eval_lm.py src/levanter/main/eval_sliding_lm.py`
- `pytest -k "eval_lm or viz_lm" -q` *(fails: ModuleNotFoundError: tensorboardX)*

------
https://chatgpt.com/codex/tasks/task_e_6858da279ef88327a9f11a4d206dab07