### PR TITLE
Handle scalar outputs in eval_sliding_lm

### DIFF
--- a/src/levanter/main/eval_sliding_lm.py
+++ b/src/levanter/main/eval_sliding_lm.py
@@ -137,8 +137,12 @@ def main(config: EvalSlidingLmConfig):
 
         log_probs = []
         for batch in loader:
-            lp = compute_log_probs(model, batch)
-            log_probs.append(np.array(lp))
+            lp = np.asarray(compute_log_probs(model, batch))
+            if lp.ndim == 0:
+                lp = lp[None]
+            elif lp.ndim == 1:
+                lp = lp[None, :]
+            log_probs.append(lp)
 
         if not log_probs:
             raise ValueError("No data processed")


### PR DESCRIPTION
## Summary
- handle scalar and 1-D arrays returned by `compute_log_probs`

## Testing
- `ruff check .` *(fails: `F401 levanter.analysis imported but unused` and other errors)*
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'tensorboardX'`)*

------
https://chatgpt.com/codex/tasks/task_e_68599c29706483278cffaffce8f442ef