### PR TITLE
Refine cached_token_count util

### DIFF
--- a/src/levanter/data/text.py
+++ b/src/levanter/data/text.py
@@ -1768,6 +1768,25 @@ class SingleTurnChatProcessor(BatchProcessor[dict, ProcessedSupervisedDict]):
         }
 
 
+def cached_token_count(cache_path: str, field: str = "input_ids") -> int:
+    """Return the total number of tokens stored in a finished :class:`TreeCache`.
+
+    This simply loads the cache and reads the ``data_size`` for ``field``.  It
+    assumes the cache contains the given field of token ids and that the cache
+    is already finished.
+
+    Args:
+        cache_path: Path to the on-disk cache directory.
+        field: Name of the field containing token ids. Defaults to ``"input_ids"``.
+
+    Returns:
+        The total number of tokens in the cache.
+    """
+
+    cache = TreeCache.load(cache_path, {field: np.zeros((0,), dtype=np.int32)})
+    return cache.store.tree[field].data_size
+
+
 def count_corpus_sizes(config: LMMixtureDatasetConfig | SingleDatasetLMConfig, prefix: str = "data/stats/") -> dict:
     """
     Counts the number of tokens in each dataset in the config.


### PR DESCRIPTION
## Summary
- remove unused TensorStore import
- simplify `cached_token_count` by loading the TreeCache directly

## Testing
- `black src/levanter/data/text.py`
- `isort src/levanter/data/text.py`
- `flake8 src/levanter/data/text.py`
- `mypy --config-file pyproject.toml src/levanter/data/text.py` *(fails: many type errors)*
- `pre-commit run --files src/levanter/data/text.py` *(fails: RPC error 403)*

------
https://chatgpt.com/codex/tasks/task_e_686307e5d0ac83319d051ba3c7d828f7