### PR TITLE
Pass tokens to page table allocation

### DIFF
--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -548,6 +548,7 @@ def test_attention_paged_decode_matches_full_ar():
         pt, binfo = pt.allocate_for_seqs(
             updated_seqs=hax.named([seq_id], "seq"),
             new_counts=hax.named([1], "seq"),
+            tokens=hax.named([seq_id], "position"),
         )
 
         kv_state = KvPageState.from_batch(binfo, kv_cache)


### PR DESCRIPTION
## Summary
- allow `PageTable.allocate_for_seqs` to take token-level sequence ids
- compute destination slots from the passed tokens
- update attention tests to include token ids
- expand page table tests to verify new token destinations

## Testing
- `flake8 src/levanter/layers/attention.py tests/test_page_table.py tests/test_attention.py`
- `pytest tests/test_page_table.py::test_allocate_for_seqs_with_padding tests/test_page_table.py::test_allocate_for_seqs_updates_only_valid_ids`

------
https://chatgpt.com/codex/tasks/task_e_686590bc7954833185b5aa1fa233a29f