### PR TITLE
Add additional Llama paged decode tests

### DIFF
--- a/tests/test_llama_decode.py
+++ b/tests/test_llama_decode.py
@@ -1,7 +1,9 @@
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 from chex import assert_trees_all_close
+import pytest
 
 import haliax as hax
 from haliax import Axis
@@ -90,3 +92,208 @@ def test_llama_paged_decode_matches_full_ar():
     # Concatenate along the position axis and compare -------------------------------------
     decoded_arr = jnp.concatenate(out_chunks, axis=0)
     assert_trees_all_close(full_out.array, decoded_arr, atol=1e-4, rtol=1e-4)
+
+
+def test_llama_paged_decode_matches_full_prefill():
+    """Ensure llama paged decode matches full forward when prefilling entire sequences."""
+    Pos = Axis("position", 16)
+    Embed = Axis("embed", 8)
+    Vocab = Axis("vocab", 64)
+
+    cfg = LlamaConfig(
+        seq_len=Pos.size,
+        hidden_dim=Embed.size,
+        intermediate_dim=16,
+        num_layers=2,
+        num_heads=2,
+        num_kv_heads=2,
+        rope=None,
+        gradient_checkpointing=False,
+        scan_layers=True,
+        attn_backend=AttentionBackend.VANILLA,
+    )
+
+    model_key, input_key = jrandom.split(jrandom.PRNGKey(0))
+    model = LlamaLMHeadModel.init(Vocab=Vocab, config=cfg, key=model_key)
+
+    input_ids = hax.random.randint(input_key, Pos, 0, Vocab.size)
+
+    pt = PageTable.init(max_pages=4, max_seqs=2, page_size=4, max_pages_per_seq=4)
+    pt, seq1 = pt.assign_seq_id_to_seq()
+    pt, seq2 = pt.assign_seq_id_to_seq()
+
+    seq_ids = hax.named([seq1, seq2, -1, -1, -1, -1, -1, -1], "seq")
+    new_token_counts = hax.named([4, 3, 0, 0, 0, 0, 0, 0], "seq")
+    seg_ids = hax.named([0] * 4 + [1] * 3 + [-1] * 9, "position")
+    pt, binfo = pt.allocate_for_seqs(updated_seqs=seq_ids, new_counts=new_token_counts, tokens=seg_ids)
+
+    mask = AttentionMask.causal().with_segment_ids(seg_ids)
+    full_out = model.activations(input_ids, attn_mask=mask, key=jrandom.PRNGKey(1))
+
+    layer_caches = model.transformer.initial_cache(pt, dtype=jnp.float32)
+    page_state = KvPageState.from_batch(binfo, layer_caches)
+    pos_ids = hax.arange(Pos, dtype=jnp.int32)
+    x = model.embeddings.embed(input_ids)
+    decode_out, _ = _jit_paged_decode(model.transformer, x, pos_ids, page_state)
+
+    full_out = full_out["position", hax.dslice(0, 7)]
+    decode_out = decode_out["position", hax.dslice(0, 7)]
+    assert_trees_all_close(full_out.array, decode_out.array, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("prefix_size", [1, 2, 3])
+@pytest.mark.parametrize("chunk_size", [1, 2, 3])
+def test_llama_paged_decode_prefill_in_chunks(prefix_size, chunk_size):
+    Pos = Axis("position", prefix_size + 4 * chunk_size)
+    Embed = Axis("embed", 8)
+    Vocab = Axis("vocab", 64)
+
+    cfg = LlamaConfig(
+        seq_len=Pos.size,
+        hidden_dim=Embed.size,
+        intermediate_dim=16,
+        num_layers=2,
+        num_heads=2,
+        num_kv_heads=2,
+        rope=None,
+        gradient_checkpointing=False,
+        scan_layers=True,
+        attn_backend=AttentionBackend.VANILLA,
+    )
+
+    model_key, input_key = jrandom.split(jrandom.PRNGKey(0))
+    model = LlamaLMHeadModel.init(Vocab=Vocab, config=cfg, key=model_key)
+
+    B = Axis("batch", 2)
+    input_ids = hax.random.randint(input_key, (B, Pos), 0, Vocab.size)
+    full_out = model.activations(input_ids, attn_mask=AttentionMask.causal(), key=jrandom.PRNGKey(1))
+
+    seq_axis = Axis("seq", 2)
+    pt = PageTable.init(max_pages=8, max_seqs=2, page_size=4, max_pages_per_seq=4)
+    pt, seq1 = pt.assign_seq_id_to_seq()
+    pt, seq2 = pt.assign_seq_id_to_seq()
+    layer_caches = model.transformer.initial_cache(pt, dtype=jnp.float32)
+
+    x = model.embeddings.embed(input_ids)
+    x0 = x[B, 0]
+    x1 = x[B, 1]
+
+    outputs0 = []
+    outputs1 = []
+
+    updated = hax.named([seq1, seq2], seq_axis)
+    new_counts = hax.named([prefix_size, prefix_size], seq_axis)
+    tok_axis = Axis("position", 2 * prefix_size)
+    tokens = hax.named([seq1] * prefix_size + [seq2] * prefix_size, tok_axis)
+    pt, binfo = pt.allocate_for_seqs(updated, new_counts, tokens)
+    state = KvPageState.from_batch(binfo, layer_caches)
+    x_prefill = hax.concatenate("position", [x0[Pos, 0:prefix_size], x1[Pos, 0:prefix_size]])
+    pos_ids_prefill = hax.named(list(range(prefix_size)) + list(range(prefix_size)), tok_axis)
+    out, state = _jit_paged_decode(model.transformer, x_prefill, pos_ids_prefill, state)
+    layer_caches = state.cache
+    outputs0.append(out["position", hax.dslice(0, prefix_size)])
+    outputs1.append(out["position", hax.dslice(prefix_size, prefix_size)])
+
+    for i in range(prefix_size, Pos.size, chunk_size):
+        updated = hax.named([seq1, seq2], seq_axis)
+        new_counts = hax.named([chunk_size, chunk_size], seq_axis)
+        tok_axis = Axis("position", 2 * chunk_size)
+        tokens = hax.named([seq1] * chunk_size + [seq2] * chunk_size, tok_axis)
+        pt, binfo = pt.allocate_for_seqs(updated, new_counts, tokens)
+        state = KvPageState.from_batch(binfo, layer_caches)
+
+        x_chunk = hax.concatenate(
+            "position",
+            [x0[Pos, hax.dslice(i, chunk_size)], x1[Pos, hax.dslice(i, chunk_size)]],
+        )
+        pos_ids_chunk = hax.named(list(range(i, i + chunk_size)) + list(range(i, i + chunk_size)), tok_axis)
+        out_chunk, state = _jit_paged_decode(model.transformer, x_chunk, pos_ids_chunk, state)
+        layer_caches = state.cache
+        outputs0.append(out_chunk["position", hax.dslice(0, chunk_size)])
+        outputs1.append(out_chunk["position", hax.dslice(chunk_size, chunk_size)])
+
+    outputs0_cat = hax.concatenate("position", outputs0)
+    outputs1_cat = hax.concatenate("position", outputs1)
+    decoded_arr = hax.stack("batch", [outputs0_cat, outputs1_cat])
+    assert_trees_all_close(full_out.array, decoded_arr.array, atol=1e-4, rtol=1e-4)
+
+
+def test_llama_paged_decode_ragged_fill_in_chunks():
+    B = Axis("batch", 2)
+    Pos = Axis("position", 8)
+    Embed = Axis("embed", 8)
+    Vocab = Axis("vocab", 64)
+
+    cfg = LlamaConfig(
+        seq_len=Pos.size,
+        hidden_dim=Embed.size,
+        intermediate_dim=16,
+        num_layers=2,
+        num_heads=2,
+        num_kv_heads=2,
+        rope=None,
+        gradient_checkpointing=False,
+        scan_layers=True,
+        attn_backend=AttentionBackend.VANILLA,
+    )
+
+    model_key, input_key = jrandom.split(jrandom.PRNGKey(0))
+    model = LlamaLMHeadModel.init(Vocab=Vocab, config=cfg, key=model_key)
+
+    input_ids = hax.random.randint(input_key, (B, Pos), 0, Vocab.size)
+    full_out = model.activations(input_ids, attn_mask=AttentionMask.causal(), key=jrandom.PRNGKey(1))
+
+    pt = PageTable.init(max_pages=8, max_seqs=2, page_size=4, max_pages_per_seq=4)
+    pt, seq1 = pt.assign_seq_id_to_seq()
+    pt, seq2 = pt.assign_seq_id_to_seq()
+    layer_caches = model.transformer.initial_cache(pt, dtype=jnp.float32)
+
+    x = model.embeddings.embed(input_ids)
+    x0 = x[B, 0]
+    x1 = x[B, 1]
+
+    chunk_sizes = [[4, 2], [0, 1], [0, 1], [2, 1], [1, 2], [1, 1]]
+    off0 = off1 = 0
+    outputs0 = []
+    outputs1 = []
+
+    seq_axis = Axis("seq", 2)
+    for step0, step1 in chunk_sizes:
+        tok_axis = Axis("position", step0 + step1)
+        updated = hax.named([seq1, seq2], seq_axis)
+        new_counts = hax.named([step0, step1], seq_axis)
+        tokens = hax.named([seq1] * step0 + [seq2] * step1, tok_axis)
+        pt, binfo = pt.allocate_for_seqs(updated, new_counts, tokens)
+        state = KvPageState.from_batch(binfo, layer_caches)
+
+        x_chunk = hax.concatenate(
+            "position",
+            [x0[Pos, hax.dslice(off0, step0)], x1[Pos, hax.dslice(off1, step1)]],
+        )
+        pos_ids = hax.named(list(range(off0, off0 + step0)) + list(range(off1, off1 + step1)), tok_axis)
+        with jax.disable_jit():
+            output, state = _jit_paged_decode(model.transformer, x_chunk, pos_ids, state)
+        layer_caches = state.cache
+        outputs0.append(output["position", hax.dslice(0, step0)])
+        outputs1.append(output["position", hax.dslice(step0, step1)])
+
+        assert_trees_all_close(
+            full_out[B, 0, "position", hax.dslice(off0, step0)].array,
+            outputs0[-1].array,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+        assert_trees_all_close(
+            full_out[B, 1, "position", hax.dslice(off1, step1)].array,
+            outputs1[-1].array,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+        off0 += step0
+        off1 += step1
+
+    outputs0_cat = hax.concatenate("position", outputs0)
+    outputs1_cat = hax.concatenate("position", outputs1)
+    decoded_arr = hax.stack("batch", [outputs0_cat, outputs1_cat])
+    assert_trees_all_close(full_out.array, decoded_arr.array, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
## Summary
- expand llama paged decode tests with prefill, chunking, and ragged scenarios

## Testing
- `pre-commit run --files tests/test_llama_decode.py`
- `pytest tests/test_llama_decode.py -m "not entry and not slow and not ray"` *(failed: ImportError: cannot import name 'BuiltInKeyEntry' from 'jax._src.tree_util')*

------
https://chatgpt.com/codex/tasks/task_e_686f6a420d3883318f11efd8d52c6a90