### PR TITLE
Avoid network downloads in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from transformers import AutoTokenizer
+
+pytest_plugins = ["tests.test_utils"]
+
+
+@pytest.fixture(scope="session")
+def local_gpt2_tokenizer(tmp_path_factory):
+    """Load a GPT2 tokenizer from a local JSON file to avoid network downloads."""
+
+    config_src = Path(__file__).parent / "gpt2_tokenizer_config.json"
+    tmpdir = tmp_path_factory.mktemp("gpt2_tok")
+    shutil.copy(config_src, tmpdir / "tokenizer.json")
+    shutil.copy(config_src, tmpdir / "tokenizer_config.json")
+    (tmpdir / "config.json").write_text(json.dumps({"model_type": "gpt2", "vocab_size": 5027}))
+    return AutoTokenizer.from_pretrained(str(tmpdir))

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -2,7 +2,6 @@ import equinox
 import jax
 import jax.numpy as jnp
 import pytest
-from transformers import AutoTokenizer
 
 import haliax as hax
 
@@ -16,13 +15,13 @@ class TestModel(equinox.Module):
     lm_head: hax.nn.Linear
 
 
-def test_reinitialize_some_tokens():
+def test_reinitialize_some_tokens(local_gpt2_tokenizer):
     # Setup test data
     embed_dim = 32
     tokens_to_reinit = ["<|test_token|>", "<|another_token|>"]
 
     # Create a simple tokenizer with our test tokens
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer = local_gpt2_tokenizer
     tokenizer.add_special_tokens({"additional_special_tokens": tokens_to_reinit})
     vocab_size = len(tokenizer)
 
@@ -73,17 +72,17 @@ def test_reinitialize_some_tokens():
             ), f"Embedding for token {i} was changed when it shouldn't have been"
 
 
-def test_reinitialize_some_tokens_invalid_tokens():
+def test_reinitialize_some_tokens_invalid_tokens(local_gpt2_tokenizer):
     # Test with tokens not in vocabulary
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer = local_gpt2_tokenizer
     model = None
 
     with pytest.raises(ValueError, match="One or more tokens are not in the tokenizer vocabulary"):
         reinitialize_some_tokens(model, tokenizer, ["<mklamnfljkaf>"], jax.random.PRNGKey(0))
 
 
-def test_reinitialize_some_tokens_empty_list():
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+def test_reinitialize_some_tokens_empty_list(local_gpt2_tokenizer):
+    tokenizer = local_gpt2_tokenizer
     model = None
 
     with pytest.raises(ValueError, match="No tokens to reinitialize"):

--- a/tests/test_supervised.py
+++ b/tests/test_supervised.py
@@ -1,20 +1,20 @@
 import numpy as np
-from transformers import AutoTokenizer
 
 import haliax
 from haliax import Axis
 
 from levanter.data.text import SupervisedProcessor, _prepare_supervised_examples
+from transformers import PreTrainedTokenizerBase
 
 
-def test_supervised_eval():
+def test_supervised_eval(local_gpt2_tokenizer: PreTrainedTokenizerBase):
     examples = [
         {
             "input": "Find all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer:",
             "output": "B",
         }
     ]
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer = local_gpt2_tokenizer
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -2,6 +2,8 @@ import json
 import tempfile
 from pathlib import Path
 
+from transformers import AutoTokenizer
+
 import jax.numpy as jnp
 import numpy as np
 import pytest

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -6,7 +6,6 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from transformers import AutoTokenizer
 
 import haliax as hax
 
@@ -31,6 +30,8 @@ def test_dont_blow_up_without_validation_set():
             train_urls=["kaa"],
             validation_urls=[],
             cache_dir=tmpdir,
+            tokenizer="passthrough",
+            vocab_size=64,
         )
 
         Pos = hax.Axis("position", 10)
@@ -65,8 +66,8 @@ def test_lm_example_handles_ignore_id():
     assert no_ignore_loss.item() >= ignored_loss.item() + 100 / Pos.size
 
 
-def test_merge_split_encodings():
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+def test_merge_split_encodings(local_gpt2_tokenizer):
+    tokenizer = local_gpt2_tokenizer
     # make this very short for testing
 
     lorem = """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."""


### PR DESCRIPTION
## Summary
- add `local_gpt2_tokenizer` fixture to load GPT2 tokenizer from local files
- switch GPT2-using tests to rely on this fixture
- use passthrough tokenizer for validation-set test

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_supervised.py tests/test_sft.py tests/test_text.py -m "not entry and not slow and not ray"`

------
https://chatgpt.com/codex/tasks/task_e_68719c180a4883319e292ffc9037e739