### PR TITLE
Fix ragged_paged_attention default soft_cap

### DIFF
--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -1734,7 +1734,7 @@ def ragged_paged_attention(
     cu_q_lens: NamedArray,  # i32[Seq + 1] <-- cumulative lengths for the sequences, including new tokens
     num_seqs: jnp.ndarray,
     sm_scale: float = 1.0,
-    soft_cap: float | None = 100.0,
+    soft_cap: float | None = None,
 ) -> NamedArray:
     """Ragged attention for paged KV caches.
 


### PR DESCRIPTION
## Summary
- align ragged_paged_attention default soft_cap with reference implementation
- this prevents small numerical mismatches in tests

## Testing
- `pre-commit run --files src/levanter/layers/attention.py tests/test_paged_attention.py`
- `pytest tests/test_paged_attention.py::test_ragged_paged_attention_multi_seq -vv -s`
- `pytest tests -m "not entry and not slow and not ray" -vv` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68734fbcb8388331a3f19fe7c786f393