### PR TITLE
Update sharding helper to avoid deprecated JAX API

### DIFF
--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -6,7 +6,7 @@ import jax.random as jrandom
 import numpy as np
 import pytest
 from chex import assert_trees_all_close
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 import haliax as hax
 from haliax import Axis
@@ -257,18 +257,17 @@ def test_segment_ids_are_respected(impl):
     keys = hax.named(keys, (KPos, Head))
     values = hax.named(values, (KPos, Head))
 
+    dp_mesh = Mesh(jax.devices(), ("dp",))
     query, keys, values = jax.device_put(
-        [query, keys, values], jax.sharding.PositionalSharding(jax.devices()).reshape(-1, 1)
+        [query, keys, values], NamedSharding(dp_mesh, PartitionSpec("dp", None))
     )
 
     segment_ids = np.array([0, 0, 0] + [1] * (L - 3), dtype=np.int32)
-    segment_ids = jax.device_put(segment_ids, jax.sharding.PositionalSharding(jax.devices()))
+    segment_ids = jax.device_put(segment_ids, NamedSharding(dp_mesh, PartitionSpec("dp")))
     segment_ids = hax.named(segment_ids, (Pos,))
     mask = AttentionMask(is_causal=True, segment_ids=segment_ids)
 
-    devices = jax.devices()
-
-    with Mesh(devices, ("dp",)):
+    with dp_mesh:
         result = hax.named_jit(dot_product_attention)(
             Pos, KPos, Head, query, keys, values, attn_backend=AttentionBackend(impl), mask=mask, flash_block_size=128
         )

--- a/tests/test_grad_accum.py
+++ b/tests/test_grad_accum.py
@@ -2,7 +2,7 @@ import equinox as eqx
 import jax
 import pytest
 from chex import assert_trees_all_close
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 import haliax
 import haliax as hax
@@ -49,7 +49,8 @@ def test_accumulate_gradients_sharded(parallelism, accum_steps):
 
     x = hax.random.normal(jax.random.PRNGKey(0), (Batch, In))
 
-    x = jax.device_put(x, jax.sharding.PositionalSharding(jax.devices()).reshape((-1, 1)))
+    mesh_shard = Mesh(jax.devices(), ("data",))
+    x = jax.device_put(x, NamedSharding(mesh_shard, PartitionSpec("data", None)))
 
     axis_mapping = {"Batch": "data"}
 


### PR DESCRIPTION
## Summary
- switch `best_effort_sharding` to build a `NamedSharding`
- fix imports in tests and stop using `PositionalSharding`

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: ModuleNotFoundError: No module named 'ray')*

------
https://chatgpt.com/codex/tasks/task_e_6873e49b2dfc8331b895a8ccacd8aae0