### PR TITLE
Update JittedScheduler to avoid deprecated outfeed

### DIFF
--- a/src/levanter/inference/__init__.py
+++ b/src/levanter/inference/__init__.py
@@ -1,0 +1,5 @@
+from .llm_engine import LLM, LLMEngine
+from .sampling_params import SamplingParams
+from .scheduler import JittedScheduler, Scheduler, run
+
+__all__ = ["LLM", "LLMEngine", "SamplingParams", "Scheduler", "JittedScheduler", "run"]

--- a/src/levanter/inference/llm_engine.py
+++ b/src/levanter/inference/llm_engine.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import List, cast
+
+import jax.numpy as jnp
+import jax.random as jrandom
+from transformers import AutoTokenizer
+
+import haliax as hax
+from haliax import Axis
+from haliax.partitioning import round_axis_for_partitioning
+
+from levanter.compat.hf_checkpoints import RepoRef
+from levanter.layers.page_table import PageTable
+from levanter.layers.sampler import Sampler
+from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
+from levanter.trainer import TrainerConfig
+
+from .sampling_params import SamplingParams
+from .sequence import Sequence, SequenceStatus
+from .scheduler import Scheduler
+from levanter.main.sample_lm import do_prefill, do_generate
+
+
+PREFERRED_SIZES = (1, 4, 16, 32, 64, 256, 1024, 4096, 165336)
+MAX_SEQS = 32
+
+
+def _round_preferred(n: int) -> int:
+    for s in PREFERRED_SIZES:
+        if n <= s:
+            return s
+    return PREFERRED_SIZES[-1]
+
+
+class LLMEngine:
+    """Simplified engine for autoregressive generation."""
+
+    def __init__(self, model_path: str):
+        self.model_path = model_path
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True)
+        self.trainer_cfg = TrainerConfig()
+        self.Vocab = round_axis_for_partitioning(
+            Axis("vocab", len(self.tokenizer)), self.trainer_cfg.compute_axis_mapping
+        )
+        converter = LlamaConfig().hf_checkpoint_converter()
+        converter = converter.replaced(reference_checkpoint=RepoRef(model_path), tokenizer=self.tokenizer)
+        self.model = cast(
+            LlamaLMHeadModel,
+            converter.load_pretrained(
+                LlamaLMHeadModel,
+                ref=RepoRef(model_path),
+                dtype=self.trainer_cfg.mp.compute_dtype,
+            ),
+        )
+        self.sampler = Sampler(self.Vocab)
+        self.eos = self.tokenizer.eos_token_id or -1
+
+    # ------------------------------------------------------------------
+    def add_request(self, prompt: str | List[int], sampling_params: SamplingParams, scheduler: Scheduler) -> None:
+        prompt_ids = (
+            self.tokenizer.encode(prompt, add_special_tokens=False)
+            if isinstance(prompt, str)
+            else prompt
+        )
+        seq = Sequence(list(prompt_ids), sampling_params)
+        scheduler.add(seq)
+
+    def _prefill(self, seq: Sequence, cache, page_table):
+        real_len = len(seq.prompt_token_ids)
+        padded_len = _round_preferred(real_len)
+        pos_axis = Axis("position", padded_len)
+        padded_tokens = list(seq.prompt_token_ids) + [self.eos] * (padded_len - real_len)
+        tokens = hax.NamedArray(jnp.array(padded_tokens, dtype=jnp.int32), axes=(pos_axis,))
+        seq_named = hax.named([seq.seq_id], "seq")
+        temps = hax.full((), seq.sampling_params.temperature, dtype=jnp.float32)
+        key = jrandom.PRNGKey(0)
+        tok, page_table, cache = do_prefill(self.model, cache, page_table, tokens, self.sampler, seq_named, temps, key)
+        return int(tok.array), cache, page_table
+
+    def _decode(self, seq: Sequence, cache, page_table, step: int):
+        prev_token = jnp.array([seq.last_token], dtype=jnp.int32)
+        seq_named = hax.named([seq.seq_id], "seq")
+        temps = hax.full((), seq.sampling_params.temperature, dtype=jnp.float32)
+        key = jrandom.PRNGKey(step)
+        start = jnp.array(step, dtype=jnp.int32)
+        tok, page_table, cache = do_generate(
+            self.model, cache, page_table, prev_token, self.sampler, seq_named, start, temps, key
+        )
+        return int(tok.array), cache, page_table
+
+    def generate(
+        self, prompts: List[str] | List[List[int]], sampling_params: SamplingParams | List[SamplingParams]
+    ) -> List[dict]:
+        if not isinstance(sampling_params, list):
+            sampling_params = [sampling_params] * len(prompts)
+
+        prompt_ids_list: List[List[int]] = [
+            self.tokenizer.encode(p, add_special_tokens=False) if isinstance(p, str) else list(p)
+            for p in prompts
+        ]
+
+        if len(prompt_ids_list) > MAX_SEQS:
+            raise ValueError(f"Too many prompts: got {len(prompt_ids_list)}, max {MAX_SEQS}")
+
+        max_prompt = max(len(p) for p in prompt_ids_list)
+        max_tokens = max(sp.max_tokens for sp in sampling_params)
+        page_size = _round_preferred(max_prompt + max_tokens)
+        page_table = PageTable.init(
+            max_pages=MAX_SEQS,
+            max_seqs=MAX_SEQS,
+            page_size=page_size,
+            max_pages_per_seq=1,
+        )
+        seq_ids = []
+        for _ in prompt_ids_list:
+            page_table, seq_id = page_table.assign_seq_id_to_seq()
+            seq_ids.append(seq_id)
+        cache = self.model.initial_cache(page_table, dtype=self.trainer_cfg.mp.compute_dtype)
+
+        scheduler = Scheduler(self.eos)
+        seq_objs = []
+        for p, sp, seq_id in zip(prompt_ids_list, sampling_params, seq_ids):
+            seq = Sequence(p, sp, seq_id=seq_id)
+            seq_objs.append(seq)
+            scheduler.add(seq)
+
+        outputs = {}
+        while not scheduler.is_finished():
+            seqs, is_prefill = scheduler.schedule()
+            token_ids = []
+            for seq in seqs:
+                if is_prefill and seq.status is SequenceStatus.WAITING:
+                    tok, cache, page_table = self._prefill(seq, cache, page_table)
+                    seq.status = SequenceStatus.RUNNING
+                else:
+                    tok, cache, page_table = self._decode(seq, cache, page_table, len(seq))
+                token_ids.append(tok)
+            scheduler.postprocess(seqs, token_ids)
+            for seq in seqs:
+                if seq.is_finished:
+                    outputs[seq.seq_id] = seq.token_ids
+        return [
+            {"text": self.tokenizer.decode(out, skip_special_tokens=True), "token_ids": out}
+            for _, out in sorted(outputs.items())
+        ]
+
+
+class LLM(LLMEngine):
+    pass

--- a/src/levanter/inference/sampling_params.py
+++ b/src/levanter/inference/sampling_params.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SamplingParams:
+    """Parameters controlling text generation sampling."""
+
+    temperature: float = 1.0
+    max_tokens: int = 64
+    ignore_eos: bool = False

--- a/src/levanter/inference/scheduler.py
+++ b/src/levanter/inference/scheduler.py
@@ -1,0 +1,141 @@
+from collections import deque
+from typing import Deque, List
+
+from .sequence import Sequence, SequenceStatus
+
+
+class Scheduler:
+    """Very small scheduler managing sequence state."""
+
+    def __init__(self, eos: int):
+        self.eos = eos
+        self.waiting: Deque[Sequence] = deque()
+        self.running: Deque[Sequence] = deque()
+
+    def add(self, seq: Sequence) -> None:
+        self.waiting.append(seq)
+
+    def is_finished(self) -> bool:
+        return not self.waiting and all(s.is_finished for s in self.running)
+
+    def schedule(self) -> tuple[List[Sequence], bool]:
+        if self.waiting:
+            seq = self.waiting.popleft()
+            self.running.append(seq)
+            return [seq], True
+        seqs = [s for s in self.running if not s.is_finished]
+        return seqs, False
+
+    def postprocess(self, seqs: List[Sequence], token_ids: List[int]) -> None:
+        for seq, token_id in zip(seqs, token_ids):
+            seq.append_token(int(token_id))
+            if (
+                (not seq.sampling_params.ignore_eos and token_id == self.eos)
+                or seq.num_completion_tokens >= seq.sampling_params.max_tokens
+            ):
+                seq.status = SequenceStatus.FINISHED
+
+
+class JittedScheduler:
+    """Ring buffer scheduler designed for jitted execution.
+
+    This scheduler stores sequence state in JAX arrays so it can run entirely
+    inside a ``lax`` loop.  Previously this relied on ``lax.infeed``/``outfeed``
+    to stream sequences to and from the device, but those APIs are now
+    deprecated.  Instead we execute for a fixed number of steps and return the
+    resulting state to the host once the loop completes.
+    """
+
+    def __init__(self, max_seqs: int, max_len: int, eos: int):
+        self.max_seqs = max_seqs
+        self.max_len = max_len
+        self.eos = eos
+
+    # ------------------------------------------------------------------
+    def init_state(self):
+        import jax.numpy as jnp
+        from dataclasses import dataclass
+
+        @dataclass
+        class State:
+            token_ids: jnp.ndarray  # (max_seqs, max_len)
+            lengths: jnp.ndarray  # (max_seqs,)
+            active: jnp.ndarray  # (max_seqs,)
+            head: jnp.ndarray  # ()
+            tail: jnp.ndarray  # ()
+
+        return State(
+            token_ids=jnp.full((self.max_seqs, self.max_len), self.eos, dtype=jnp.int32),
+            lengths=jnp.zeros((self.max_seqs,), dtype=jnp.int32),
+            active=jnp.zeros((self.max_seqs,), dtype=jnp.bool_),
+            head=jnp.array(0, dtype=jnp.int32),
+            tail=jnp.array(0, dtype=jnp.int32),
+        )
+
+    # ------------------------------------------------------------------
+    def add_sequence(self, state, tokens, length):
+        """Add a new sequence to ``state``. Evicts the oldest if full."""
+        import jax.numpy as jnp
+        from jax import lax
+
+        def _evict(state):
+            idx = state.tail
+            state.active = state.active.at[idx].set(False)
+            state.tail = (state.tail + 1) % self.max_seqs
+            return state
+
+        def _add(state):
+            idx = state.head
+            state.token_ids = state.token_ids.at[idx, :length].set(tokens[:length])
+            state.lengths = state.lengths.at[idx].set(length)
+            state.active = state.active.at[idx].set(True)
+            state.head = (state.head + 1) % self.max_seqs
+            return state
+
+        need_evict = jnp.logical_and(state.active[state.head], True)
+        state = lax.cond(need_evict, _evict, lambda s: s, state)
+        state = _add(state)
+        return state
+
+    # ------------------------------------------------------------------
+    def decode_step(self, state, decode_fn):
+        """Decode one token for the sequence at ``state.tail``."""
+        import jax.numpy as jnp
+        from jax import lax
+
+        idx = state.tail
+        tokens = state.token_ids[idx]
+        length = state.lengths[idx]
+        prev = tokens[length - 1]
+        new_tok = decode_fn(prev)
+        state.token_ids = state.token_ids.at[idx, length].set(new_tok)
+        state.lengths = state.lengths.at[idx].set(length + 1)
+
+        finished = jnp.logical_or(new_tok == self.eos, length + 1 >= self.max_len)
+
+        def _finish(st):
+            st.active = st.active.at[idx].set(False)
+            st.tail = (st.tail + 1) % self.max_seqs
+            return st
+
+        state = lax.cond(finished, _finish, lambda s: s, state)
+        return state
+
+    # ------------------------------------------------------------------
+    def collect(self, state):
+        """Return the decoded sequences as Python lists."""
+        return [
+            [int(t) for t in state.token_ids[i, : int(state.lengths[i])].tolist()]
+            for i in range(self.max_seqs)
+            if int(state.lengths[i]) > 0
+        ]
+
+
+def run(state, scheduler: JittedScheduler, decode_fn, max_steps: int):
+    """Execute ``scheduler.decode_step`` ``max_steps`` times inside a JAX loop."""
+    from jax import lax
+
+    def body(_, st):
+        return scheduler.decode_step(st, decode_fn)
+
+    return lax.fori_loop(0, max_steps, body, state)

--- a/src/levanter/inference/sequence.py
+++ b/src/levanter/inference/sequence.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from itertools import count
+from typing import List
+
+from .sampling_params import SamplingParams
+
+
+class SequenceStatus(Enum):
+    """Lifecycle state of a sequence."""
+
+    WAITING = auto()
+    RUNNING = auto()
+    FINISHED = auto()
+
+
+@dataclass
+class Sequence:
+    """Tracks the state of a single generation request."""
+
+    prompt_token_ids: List[int]
+    sampling_params: SamplingParams = field(default_factory=SamplingParams)
+    seq_id: int = -1
+    status: SequenceStatus = SequenceStatus.WAITING
+    token_ids: List[int] = field(init=False)
+
+    _counter = count()
+
+    def __post_init__(self):
+        if self.seq_id < 0:
+            self.seq_id = next(self._counter)
+        self.token_ids = list(self.prompt_token_ids)
+
+    def __len__(self) -> int:
+        return len(self.token_ids)
+
+    @property
+    def num_prompt_tokens(self) -> int:
+        return len(self.prompt_token_ids)
+
+    @property
+    def num_completion_tokens(self) -> int:
+        return len(self.token_ids) - self.num_prompt_tokens
+
+    @property
+    def last_token(self) -> int:
+        return self.token_ids[-1]
+
+    @property
+    def is_finished(self) -> bool:
+        return self.status is SequenceStatus.FINISHED
+
+    def append_token(self, token_id: int) -> None:
+        self.token_ids.append(token_id)

--- a/src/levanter/main/nano_inference.py
+++ b/src/levanter/main/nano_inference.py
@@ -1,0 +1,27 @@
+import argparse
+from pathlib import Path
+
+from levanter.inference import LLM, SamplingParams
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run simple LLM inference")
+    parser.add_argument("model", help="Path to HF checkpoint")
+    parser.add_argument("prompts", help="Text file with one prompt per line")
+    parser.add_argument("--temperature", type=float, default=0.6)
+    parser.add_argument("--max_tokens", type=int, default=256)
+    args = parser.parse_args()
+
+    with open(Path(args.prompts), "r", encoding="utf-8") as f:
+        prompts = [line.strip() for line in f if line.strip()]
+
+    llm = LLM(args.model)
+    sp = SamplingParams(temperature=args.temperature, max_tokens=args.max_tokens)
+    outputs = llm.generate(prompts, sp)
+
+    for prompt, out in zip(prompts, outputs):
+        print(f"Prompt: {prompt}\nCompletion: {out['text']}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- revise JittedScheduler so it no longer relies on infeed/outfeed
- add a `run` function to execute decode steps for a fixed number of iterations
- provide a helper to collect decoded sequences after the loop

## Testing
- `pre-commit run --files src/levanter/inference/__init__.py src/levanter/inference/scheduler.py`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: 63 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6873f9b13fb08331aeba8b8dbae1c77e