### PR TITLE
compute pos_ids during allocation

### DIFF
--- a/src/levanter/main/sample_lm.py
+++ b/src/levanter/main/sample_lm.py
@@ -92,12 +92,9 @@ def _load_model(config: SampleLmConfig, Vocab: Axis, *, key) -> LmHeadModel:
 @haliax.named_jit(donate_args=(False, True, True, False, False, True))
 def do_prefill(model, cache, page_table: PageTable, tokens, seq_ids, sampler, temps, key):
     """Prefill ``tokens`` and sample the next token."""
-    pos_ids = page_table.pos_ids_from_seq_ids(seq_ids)
     page_table, binfo = page_table.allocate_for_seq(token_seq_ids=seq_ids)
 
-    jax.debug.print("this pos_ids={} computed={}", pos_ids, hax.arange(tokens.axes[0], dtype=jnp.int32))
-
-    logits, cache = model.decode(tokens, cache, binfo, pos_ids)
+    logits, cache = model.decode(tokens, cache, binfo, binfo.pos_ids)
     next_tok, _ = sampler(logits["position", -1], temps, key=key)
     return next_tok, page_table, cache
 


### PR DESCRIPTION
## Summary
- add pos_ids to `PageBatchInfo` and compute it inside `allocate_for_seq`
- fix `pos_ids_from_seq_ids` indexing bug
- update sample script and tests to use `binfo.pos_ids`

## Testing
- `pre-commit run --files src/levanter/layers/page_table.py src/levanter/main/sample_lm.py tests/test_llama_decode.py tests/test_attention.py`
- `pytest tests/test_page_table.py tests/test_llama_decode.py tests/test_attention.py -m "not entry and not slow and not ray"` *(fails: ModuleNotFoundError: No module named 'haliax')*

------
https://chatgpt.com/codex/tasks/task_e_6876d2e524e48331ad08c06969770cc3