### PR TITLE
Optimize page table slicing

### DIFF
--- a/src/levanter/layers/page_table.py
+++ b/src/levanter/layers/page_table.py
@@ -92,6 +92,8 @@ class PageTable(eqx.Module):
         token_seq_ids = hax.where(token_seq_ids < 0, self.max_seqs, token_seq_ids)
         updated_seqs, new_counts = hax.unique_counts(token_seq_ids, self.max_Seq, fill_value=self.max_seqs)
 
+        num_active = int(hax.sum(updated_seqs < self.max_seqs).scalar())
+
         new_counts = hax.where(updated_seqs >= self.max_seqs, 0, new_counts)
 
         current_lens = hax.where(seq_lens < 0, 0, seq_lens)
@@ -131,7 +133,7 @@ class PageTable(eqx.Module):
             return page_indices, page_owners
 
         page_indices, page_owners = jax.lax.fori_loop(
-            0, updated_seqs.axis_size("seq"), outer, (page_indices, page_owners)
+            0, num_active, outer, (page_indices, page_owners)
         )
 
         new_table = dataclasses.replace(
@@ -141,11 +143,32 @@ class PageTable(eqx.Module):
             seq_lens=new_lens,
         )
 
-        batch_info = self._slice_batch_info(updated_seqs, self.seq_lens, new_table, new_counts, token_seq_ids)
+        batch_info = self._slice_batch_info(
+            updated_seqs,
+            self.seq_lens,
+            new_table,
+            new_counts,
+            token_seq_ids,
+            num_active,
+        )
 
         return new_table, batch_info
 
-    def _slice_batch_info(self, updated_seqs, old_seq_lens, new_table, new_token_counts, tokens):
+    def _slice_batch_info(self, updated_seqs, old_seq_lens, new_table, new_token_counts, tokens, num_active):
+        updated_seqs = hax.slice(
+            updated_seqs,
+            axis="seq",
+            start=0,
+            length=num_active,
+            new_axis=hax.Axis("seq", num_active),
+        )
+        new_token_counts = hax.slice(
+            new_token_counts,
+            axis="seq",
+            start=0,
+            length=num_active,
+            new_axis=hax.Axis("seq", num_active),
+        )
         mask = hax.logical_and(updated_seqs >= 0, updated_seqs < self.max_seqs)
         safe_updated = hax.where(mask, updated_seqs, 0)
 

--- a/tests/test_page_table.py
+++ b/tests/test_page_table.py
@@ -42,6 +42,7 @@ def test_page_batch_info_shapes():
         cu_q_lens=hax.named(jnp.array([0, 1, 2], dtype=jnp.int32), hax.Axis("seq_plus_one", 3)),
         num_seqs=jnp.array(2, dtype=jnp.int32),
         new_token_dests=hax.full((hax.Axis("position", 2),), -1, dtype=jnp.int32),
+        pos_ids=hax.zeros({"position": 2}, dtype=jnp.int32),
         page_size=2,
     )
 


### PR DESCRIPTION
## Summary
- optimize loops in page_table
- slice updated sequences and token counts by num_active
- update tests for new PageBatchInfo signature

## Testing
- `pre-commit run --files src/levanter/layers/page_table.py`
- `pytest tests/test_page_table.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ec7ca3dc83318ce01950914aa611