### PR TITLE
Make rotary config fields static

### DIFF
--- a/src/levanter/layers/rotary.py
+++ b/src/levanter/layers/rotary.py
@@ -26,7 +26,7 @@ class RotaryEmbeddings(eqx.Module):
 
 class DefaultRotaryEmbeddings(RotaryEmbeddings):
     HeadDim: Axis = eqx.field(static=True)
-    config: "DefaultRotaryEmbeddingsConfig"
+    config: "DefaultRotaryEmbeddingsConfig" = eqx.field(static=True)
 
     def __call__(self, q: NamedArray, position_ids: NamedArray) -> NamedArray:
         with jax.ensure_compile_time_eval():
@@ -93,7 +93,7 @@ RotaryEmbeddingsConfig.register_subclass("linear", DefaultRotaryEmbeddingsConfig
 
 class Llama3RotaryEmbeddings(RotaryEmbeddings):
     HeadDim: Axis = eqx.field(static=True)
-    config: "Llama3RotaryEmbeddingsConfig"
+    config: "Llama3RotaryEmbeddingsConfig" = eqx.field(static=True)
 
     def __call__(self, q: NamedArray, position_ids: NamedArray) -> NamedArray:
         inv_freq_llama = self._compute_inv_freq_llama()
@@ -182,7 +182,7 @@ RotaryEmbeddingsConfig.register_subclass("llama3", Llama3RotaryEmbeddingsConfig)
 
 class YarnRotaryEmbeddings(RotaryEmbeddings):
     HeadDim: Axis = eqx.field(static=True)
-    config: "YarnRotaryEmbeddingsConfig"
+    config: "YarnRotaryEmbeddingsConfig" = eqx.field(static=True)
 
     def __call__(self, q: NamedArray, position_ids: NamedArray) -> NamedArray:
         import math


### PR DESCRIPTION
## Summary
- make `config` static fields for equinox modules in rotary embeddings

## Testing
- `pre-commit run --files src/levanter/layers/rotary.py`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: cannot import name `BuiltInKeyEntry` from `jax`)*

------
https://chatgpt.com/codex/tasks/task_e_687a7927940c8331b379aa3a26750f5b