### PR TITLE
Remove redundant test requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ repository. Follow these notes when implementing new features or fixing bugs.
 * **Playbooks.** Sometimes, there are repeatable tasks (e.g. porting models) for which we follow a standard set of steps.
   Please reference `.playbooks/` to see what playbooks are available, or see the list below. If you want to add a playbook
   write a markdown doc named e.g. `.playbooks/port-models.md` and add a pointer to it in the list below.
+* **Dependency management**: Use `uv` and the extras specified in `pyproject.toml` (e.g. `[test]`) instead of separate
+  `requirements.txt` files.
 
 ## Playbooks
 

--- a/infra/helpers/setup-tpu-vm-tests.sh
+++ b/infra/helpers/setup-tpu-vm-tests.sh
@@ -122,5 +122,3 @@ git checkout $BRANCH
 # install levanter
 
 pip install -e ".[test]"
-
-pip install -r tests/requirements.txt


### PR DESCRIPTION
## Summary
- update guidelines to mention using `uv` extras for dependencies
- drop the unused `tests/requirements.txt`
- clean up TPU setup script to install `[test]` extras only

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: blocked access to huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_687ad69ed2788331a7fd03c181778bb0