### PR TITLE
Fix setup script commit checkout

### DIFF
--- a/infra/helpers/setup-tpu-vm-tests.sh
+++ b/infra/helpers/setup-tpu-vm-tests.sh
@@ -98,7 +98,11 @@ if [ -d levanter ]; then
   echo "Levanter directory already exists, Assuming git repo and fetching latest changes"
   cd levanter || exit 1
   git fetch origin || exit 1
-  git reset --hard origin/$BRANCH || exit 1
+  if git rev-parse --verify "origin/$BRANCH" >/dev/null 2>&1; then
+    git reset --hard "origin/$BRANCH" || exit 1
+  else
+    git reset --hard "$BRANCH" || exit 1
+  fi
 else
   git clone $REPO levanter || exit 1
   cd levanter || exit 1


### PR DESCRIPTION
## Summary
- fix checkout command when VM already has repo

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray" -q` *(fails: ModuleNotFoundError: huggingface.co download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b45a063b08331a6a2b85bf41a1ea7