### PR TITLE
Add dataset token count callback

### DIFF
--- a/src/levanter/callbacks/__init__.py
+++ b/src/levanter/callbacks/__init__.py
@@ -13,6 +13,7 @@ from levanter.callbacks._metrics import (
     log_epoch_progress,
     log_performance_stats,
     log_step_info,
+    log_dataset_token_counts,
     logger,
     pbar_logger,
 )
@@ -161,5 +162,6 @@ __all__ = [
     "log_epoch_progress",
     "log_performance_stats",
     "log_step_info",
+    "log_dataset_token_counts",
     "pbar_logger",
 ]


### PR DESCRIPTION
## Summary
- add `log_dataset_token_counts` callback to log dataset sizes
- register the new callback in `train_lm`
- improve logging by waiting for dataset lengths on a thread and then logging in callback

## Testing
- `pre-commit run --files src/levanter/callbacks/_metrics.py src/levanter/main/train_lm.py src/levanter/callbacks/__init__.py`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: ModuleNotFoundError: No module named 'haliax')*



------
https://chatgpt.com/codex/tasks/task_e_687b53b0e3a48331848dcffcd1e66273