### PR TITLE
Freeze LayerNormConfigBase classes

### DIFF
--- a/src/levanter/layers/normalization.py
+++ b/src/levanter/layers/normalization.py
@@ -9,7 +9,7 @@ from haliax.nn import LayerNorm, RmsNorm
 from haliax.nn.normalization import LayerNormBase
 
 
-@dataclass
+@dataclass(frozen=True)
 class LayerNormConfigBase(draccus.ChoiceRegistry, abc.ABC):
     """Base class for layer normalization configurations."""
 
@@ -28,7 +28,7 @@ class LayerNormConfigBase(draccus.ChoiceRegistry, abc.ABC):
 
 
 @LayerNormConfigBase.register_subclass("rms")
-@dataclass
+@dataclass(frozen=True)
 class RmsNormConfig(LayerNormConfigBase):
     """Configuration for RMS normalization."""
 
@@ -37,7 +37,7 @@ class RmsNormConfig(LayerNormConfigBase):
 
 
 @LayerNormConfigBase.register_subclass("layer")
-@dataclass
+@dataclass(frozen=True)
 class LayerNormConfig(LayerNormConfigBase):
     """Configuration for standard layer normalization."""
 

--- a/src/levanter/models/gemma.py
+++ b/src/levanter/models/gemma.py
@@ -45,7 +45,7 @@ from transformers import PretrainedConfig as HfConfig  # noqa: E402
 
 
 @LayerNormConfigBase.register_subclass("gemma")
-@dataclass
+@dataclass(frozen=True)
 class GemmaNormConfig(LayerNormConfigBase):
     """Configuration for Gemma's custom RMS normalization."""
 


### PR DESCRIPTION
## Summary
- freeze `LayerNormConfigBase` and its subclasses
- include Gemma's norm config in the frozen dataclasses

## Testing
- `pre-commit run --files src/levanter/layers/normalization.py src/levanter/models/gemma.py`
- `pytest tests -m "not entry and not slow and not ray" -q` *(fails: ImportError: cannot import name 'BuiltInKeyEntry' from 'jax._src.tree_util')*

------
https://chatgpt.com/codex/tasks/task_e_687ddaf432e88331ad3b09c699df84c1