### PR TITLE
Include Kimi style muon learning rate scaling

### DIFF
--- a/src/levanter/optim/muon.py
+++ b/src/levanter/optim/muon.py
@@ -137,7 +137,7 @@ def scale_with_muon(momentum=0.95, nesterov=True, steps=5, muon_eps=1e-8, use_ki
             updated_weight_array = zeropower_via_newtonschulz5(array, steps=steps, eps=muon_eps)
 
             if not use_kimi_scaling:
-                scale = jnp.sqrt(jnp.maximum(1, updated_weight_array.shape[0] / updated_weight_array.shape[1]))
+                scale = jnp.sqrt(jnp.maximum(1, updated_weight_array.shape[0] / updated_weight_array.shape[1])) # sqrt(Out/In)
             else:
                 scale = 0.2 * jnp.sqrt(jnp.maximum(updated_weight_array.shape[0], updated_weight_array.shape[1]))
             updated_weight_array *= scale

--- a/src/levanter/optim/muon.py
+++ b/src/levanter/optim/muon.py
@@ -37,7 +37,7 @@ class MuonConfig(OptimizerConfig):
     epsilon: float = 1e-8
     muon_epsilon: float = 1e-8
     max_grad_norm: float = 1.0
-    # Kimi scale the learning rate for every d_1 * d_2 module by 0.2 * jnp.sqrt{\max{d_1, d_2}}, instead of the jnp.sqrt{\max{1, d_1/d_2}} as in the original nanogpt speedrun.
+    # Kimi scales the learning rate for every d_1 * d_2 module by 0.2 * jnp.sqrt{\max{d_1, d_2}}, instead of the jnp.sqrt{\max{1, d_1/d_2}} as in the original nanogpt speedrun.
     # When this scaling is enabled, it is recommended to use learning rate and weight decay similar to adam
     use_kimi_scaling: bool = False
 


### PR DESCRIPTION
As our scaling law in the speedrun in Marin is more pessimistic than the Kimi's version, we want to sanity check whether it is because we are using different per-module learning rate scaling. 