### PR TITLE
Update CI to sync without lock and add lockfile check

### DIFF
--- a/.github/workflows/check_lockfile.yaml
+++ b/.github/workflows/check_lockfile.yaml
@@ -1,15 +1,14 @@
-name: Run tests that use ray
+name: Check uv.lock
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  ray_tests:
-
+  lockfile_check:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10"]
-
     steps:
       - uses: actions/checkout@v4
       - name: Install uv and Python
@@ -20,9 +19,5 @@ jobs:
           enable-cache: true
       - name: Set up Python
         run: uv python install
-      - name: Install dependencies
-        run: uv sync --dev
-      - name: Test with pytest
-        run: |
-          PYTHONPATH=tests:src:. uv run pytest tests -m "ray"
-
+      - name: Verify lockfile
+        run: uv lock --check

--- a/.github/workflows/run_entry_tests.yaml
+++ b/.github/workflows/run_entry_tests.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install dependencies
-        run: uv sync --locked --dev
+        run: uv sync --dev
       - name: Test with pytest
         run: |
           PYTHONPATH=tests:src:. uv run pytest tests -m "entry"

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install dependencies
-        run: uv sync --locked --dev
+        run: uv sync --dev
       - name: Test with pytest
         run: |
           # check we are using the right jax version


### PR DESCRIPTION
## Summary
- remove `--locked` from unit test install steps
- add a workflow that fails when `uv.lock` is stale

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_687ec0a0e2a883318724fc7fa85d681d