### PR TITLE
Fix trainer missing info error

### DIFF
--- a/src/levanter/trainer.py
+++ b/src/levanter/trainer.py
@@ -437,8 +437,14 @@ class Trainer:
         """
         Performs training until the number of steps is reached.
         """
+        info: Optional[StepInfo[S]] = None
         for info in self.training_steps(state, train_loader):
             pass
+
+        if info is None:
+            raise RuntimeError(
+                "No training steps were executed. The dataset may be empty or there are no steps left to run."
+            )
 
         # force hooks to run at the end
         self.run_hooks(info, force=True)


### PR DESCRIPTION
## Summary
- raise a clearer error if no training steps run

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: network access to huggingface blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687febafc8b08331b07b7c29340f7561