### PR TITLE
Switch default configs to Llama

### DIFF
--- a/.github/workflows/gpt2_small_itest.yaml
+++ b/.github/workflows/gpt2_small_itest.yaml
@@ -59,7 +59,7 @@ jobs:
               --run_id ${{ github.run_id }} \
               --docker_registry ghcr --github_user ${{ github.actor }} \
               python -m levanter.main.train_lm \
-              --config_path config/gpt2_small_fast_itest.yaml \
+              --config_path config/llama_small_fast_itest.yaml \
               --trainer.checkpointer.base_path gs://levanter-checkpoints/gpt-itest/ --trainer.checkpointer.save_interval 30m $*
         env:
           USER: ci-runner-${{ github.run_id }} # Set a unique user for TPU naming in the script

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If your dataset is a [Hugging Face dataset](https://huggingface.co/docs/datasets
 python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext
 
 # optionally, you may specify a tokenizer and/or a cache directory, which may be local or on gcs
-python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext --data.tokenizer "meta-llama/Llama-2-70b-hf" --data.cache_dir "gs://path/to/cache/dir"
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext --data.tokenizer "NousResearch/Llama-2-7b-hf" --data.cache_dir "gs://path/to/cache/dir"
 ```
 
 If instead your data is a list of URLs, you can use the `data.train_urls` and `data.validation_urls` fields to specify them.

--- a/README.md
+++ b/README.md
@@ -109,16 +109,16 @@ python -m levanter.main.train_lm --config_path gpt2_nano
 
 This will train a GPT2-nano model on the [WikiText-103](https://blog.einstein.ai/the-wikitext-long-term-dependency-language-modeling-dataset/) dataset.
 
-### Training a GPT2-small on your own data
+### Training a Llama-small on your own data
 
 You can also change the dataset by changing the `dataset` field in the config file.
 If your dataset is a [Hugging Face dataset](https://huggingface.co/docs/datasets/loading_datasets.html), you can use the `data.id` field to specify it:
 
 ```bash
-python -m levanter.main.train_lm --config_path config/gpt2_small.yaml --data.id openwebtext
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext
 
 # optionally, you may specify a tokenizer and/or a cache directory, which may be local or on gcs
-python -m levanter.main.train_lm --config_path config/gpt2_small.yaml --data.id openwebtext --data.tokenizer "EleutherAI/gpt-neox-20b" --data.cache_dir "gs://path/to/cache/dir"
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext --data.tokenizer "meta-llama/Llama-2-70b-hf" --data.cache_dir "gs://path/to/cache/dir"
 ```
 
 If instead your data is a list of URLs, you can use the `data.train_urls` and `data.validation_urls` fields to specify them.
@@ -126,13 +126,13 @@ Data URLS can be local files, gcs files, or http(s) URLs, or anything that [fssp
 Levanter (really, fsspec) will automatically uncompress `.gz` and `.zstd` files, and probably other formats too.
 
 ```bash
-python -m levanter.main.train_lm --config_path config/gpt2_small.yaml --data.train_urls ["https://path/to/train/data_*.jsonl.gz"] --data.validation_urls ["https://path/to/val/data_*.jsonl.gz"]
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.train_urls ["https://path/to/train/data_*.jsonl.gz"] --data.validation_urls ["https://path/to/val/data_*.jsonl.gz"]
 ```
 
 ### Customizing a Config File
 
 You can modify the config file to change the model, the dataset, the training parameters, and more. Here's
-the `gpt2_small.yaml` file:
+the `llama_small_fast.yaml` file:
 
 ```yaml
 data:
@@ -142,18 +142,19 @@ data:
       - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://pubmed-mosaic/tokenized/openwebtext/"
 model:
-  gpt2:
-    hidden_dim: 768
-    num_heads: 12
-    num_layers: 12
-    seq_len: 1024
-    gradient_checkpointing: true
-    scale_attn_by_inverse_layer_idx: true
+  type: llama
+  hidden_dim: 768
+  intermediate_dim: 2048
+  num_heads: 12
+  num_kv_heads: 12
+  num_layers: 12
+  seq_len: 1024
+  gradient_checkpointing: true
 trainer:
   tracker:
     type: wandb
     project: "levanter"
-    tags: [ "openwebtext", "gpt2"]
+    tags: [ "openwebtext", "llama" ]
 
   mp: p=f32,c=bfloat16
   model_axis_size: 1

--- a/config/data/dolma_olmo_paloma.yaml
+++ b/config/data/dolma_olmo_paloma.yaml
@@ -1,6 +1,6 @@
 cache_dir: "gs://marin-us-central2/tokenized/OLMo-1B/dolma/v1.7"
 tokenizer: "allenai/OLMo-1B"  # requires `pip install ai2-olmo`
-# tokenizer: "meta-llama/Llama-2-7b-hf"
+# tokenizer: "NousResearch/Llama-2-7b-hf"
 stop_strategy: restart
 configs:
   dolma-algebraic-stack:

--- a/config/data/fineweb_llama_txt.yaml
+++ b/config/data/fineweb_llama_txt.yaml
@@ -1,5 +1,5 @@
 cache_dir: "gs://marin-data/tokenized/fineweb/llama2_tokenizer/txt"
-tokenizer: "meta-llama/Llama-2-7b-hf"
+tokenizer: "NousResearch/Llama-2-7b-hf"
 stop_strategy: restart
 configs:
   "fineweb":

--- a/config/data/rpv1_llama.yaml
+++ b/config/data/rpv1_llama.yaml
@@ -1,5 +1,5 @@
 cache_dir: gs://levanter-data/tokenized/redpajama_v1_llama_mixture
-tokenizer: "meta-llama/Llama-2-7b-hf"
+tokenizer: "NousResearch/Llama-2-7b-hf"
 configs:
   arxiv:
     train_urls:

--- a/config/llama2_7b.yaml
+++ b/config/llama2_7b.yaml
@@ -4,7 +4,7 @@ data:
   validation_urls:
     - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://levanter-data/tokenized/openwebtext_llama/"
-  tokenizer: "meta-llama/Llama-2-70b-hf"
+  tokenizer: "NousResearch/Llama-2-7b-hf"
 model:
   activation_function: silu
   attn_backend: null
@@ -18,7 +18,7 @@ model:
   num_heads: 32
   num_kv_heads: 8
   num_layers: 32
-  reference_checkpoint: meta-llama/Llama-2-7b-hf
+  reference_checkpoint: NousResearch/Llama-2-7b-hf
   rope:
     factor: 1.0
     theta: 10000

--- a/config/llama2_7b_continued.yaml
+++ b/config/llama2_7b_continued.yaml
@@ -1,6 +1,6 @@
 data:
   id: EleutherAI/pile
-  tokenizer: meta-llama/Llama-2-7b-hf
+  tokenizer: NousResearch/Llama-2-7b-hf
 model:
   type: llama
 initialize_from_hf: true

--- a/config/llama2_nano.yaml
+++ b/config/llama2_nano.yaml
@@ -4,7 +4,7 @@ data:
   validation_urls:
     - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://levanter-data/tokenized/openwebtext_llama/"
-  tokenizer: "meta-llama/Llama-2-70b-hf"
+  tokenizer: "NousResearch/Llama-2-7b-hf"
 model:
   type: llama
   hidden_dim: 32

--- a/config/llama2_small_fast_mix.yaml
+++ b/config/llama2_small_fast_mix.yaml
@@ -1,5 +1,5 @@
 data:
-  tokenizer: "meta-llama/Llama-2-7b-hf"
+  tokenizer: "NousResearch/Llama-2-7b-hf"
   cache_dir: "gs://levanter-data/new-tokenized/pile_mix/"
   shuffle: 10000
   configs:

--- a/config/llama_small_fast.yaml
+++ b/config/llama_small_fast.yaml
@@ -4,7 +4,7 @@ data:
   validation_urls:
     - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://levanter-data/tokenized/openwebtext_llama/"
-  tokenizer: "meta-llama/Llama-2-70b-hf"
+  tokenizer: "NousResearch/Llama-2-7b-hf"
 model:
   type: llama
   hidden_dim: 768

--- a/config/llama_small_fast_itest.yaml
+++ b/config/llama_small_fast_itest.yaml
@@ -4,7 +4,7 @@ data:
   validation_urls:
     - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://levanter-data/tokenized/openwebtext_llama/"
-  tokenizer: "meta-llama/Llama-2-70b-hf"
+  tokenizer: "NousResearch/Llama-2-7b-hf"
 model:
   type: llama
   hidden_dim: 768

--- a/config/llama_small_fast_itest.yaml
+++ b/config/llama_small_fast_itest.yaml
@@ -1,0 +1,32 @@
+data:
+  train_urls:
+    - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_train.{1..128}-of-128.jsonl.gz"
+  validation_urls:
+    - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
+  cache_dir: "gs://levanter-data/tokenized/openwebtext_llama/"
+  tokenizer: "meta-llama/Llama-2-70b-hf"
+model:
+  type: llama
+  hidden_dim: 768
+  intermediate_dim: 2048
+  num_heads: 12
+  num_kv_heads: 12
+  num_layers: 12
+  seq_len: 1024
+  gradient_checkpointing: true
+trainer:
+  tracker:
+    - type: wandb
+      project: "levanter"
+      tags: [ "openwebtext", "llama", "itest"]
+
+  mp: p=f32,c=bfloat16
+  model_axis_size: 1
+  per_device_parallelism: -1
+
+  train_batch_size: 256
+  num_train_steps: 10000
+optimizer:
+  learning_rate: 1E-3
+  weight_decay: 0.1
+  warmup: 0.01

--- a/config/llama_small_fast_remat.yaml
+++ b/config/llama_small_fast_remat.yaml
@@ -4,7 +4,7 @@ data:
   validation_urls:
     - "gs://pubmed-mosaic/openwebtext-sharded/openwebtext_val.{1..8}-of-8.jsonl.gz"
   cache_dir: "gs://levanter-data/tokenized/openwebtext_llama/"
-  tokenizer: "meta-llama/Llama-2-70b-hf"
+  tokenizer: "NousResearch/Llama-2-7b-hf"
 model:
   type: llama
   hidden_dim: 768

--- a/config/lora_llama2.yaml
+++ b/config/lora_llama2.yaml
@@ -3,8 +3,8 @@ data:
   # id: math-ai/AutoMathText
   # You may also want to set cache_dir if using more than one machine
   # cache_dir:
-  tokenizer: "meta-llama/Llama-2-70b-hf"
-initialize_from_hf: "meta-llama/Llama-2-7b-hf"
+  tokenizer: "NousResearch/Llama-2-7b-hf"
+initialize_from_hf: "NousResearch/Llama-2-7b-hf"
 peft_save_path: "lora_llama2"
 max_train_length: 2048  # train on sequences of this length to reduce memory usage
 trainer:

--- a/config/olmo/olmo_7b_repro.yaml
+++ b/config/olmo/olmo_7b_repro.yaml
@@ -2,7 +2,7 @@
 data:
   cache_dir: "gs://marin-data/tokenized/OLMo-1B/dolma-v1.7"
   tokenizer: "allenai/OLMo-1B"  # requires `pip install ai2-olmo`
-  # tokenizer: "meta-llama/Llama-2-7b-hf"
+  # tokenizer: "NousResearch/Llama-2-7b-hf"
   stop_strategy: restart
   shuffle_buffer_size: 100000
   configs:

--- a/docs/Fine-Tuning.md
+++ b/docs/Fine-Tuning.md
@@ -116,8 +116,8 @@ You'll also want to log into [WANDB](https://wandb.ai/).
 wandb login
 ```
 
-To use Llama 2, you'll need to request access to the model from [Llama 2's Hugging Face page](https://huggingface.co/meta-llama/Llama-2-7b-hf).
-Then, you'll need to log into the Hugging Face CLI:
+To use Llama 2 we recommend the open checkpoint [`NousResearch/Llama-2-7b-hf`](https://huggingface.co/NousResearch/Llama-2-7b-hf).
+Log into the Hugging Face CLI:
 
 ```bash
 huggingface-cli login
@@ -144,7 +144,7 @@ python examples/alpaca/alpaca.py --config_path levanter/examples/alpaca/alpaca-l
 Alternatively:
 
 ```bash
-python examples/alpaca/alpaca.py --config_path levanter/examples/alpaca/alpaca-llama2.yaml --model_name_or_path meta-llama/Llama-2-7b-hf
+python examples/alpaca/alpaca.py --config_path levanter/examples/alpaca/alpaca-llama2.yaml --model_name_or_path NousResearch/Llama-2-7b-hf
 ```
 
 !!! warning
@@ -266,10 +266,7 @@ to use a learning rate of 2e-5 and no weight decay. `trainer.per_device_parallel
 ### Llama 2 Config
 
 The [Llama 2 config](https://github.com/stanford-crfm/levanter/blob/main/examples/alpaca/alpaca-llama2.yaml) is identical, except for the model id.
-If you haven't already, go to [Llama 2's Hugging Face page](https://huggingface.co/meta-llama/Llama-2-7b-hf) and request access to the model.
-
-Once you have access, go to [Hugging Face's Tokens page](https://huggingface.co/settings/tokens) to get an API token. You'll need to provide this
-to the TPU VM as an environment variable. (We'll show you how to do this later.)
+`NousResearch/Llama-2-7b-hf` is freely accessible on the Hub so no additional token is required.
 
 ### Custom Datasets
 

--- a/docs/Getting-Started-GPU.md
+++ b/docs/Getting-Started-GPU.md
@@ -86,7 +86,7 @@ Then, you can run training commands from within your Docker container as follows
 
 ```bash
 python -m levanter.main.train_lm \
-    --config_path /opt/levanter/config/gpt2_small.yaml
+    --config_path /opt/levanter/config/llama_small_fast.yaml
 ```
 
 #### Running a Job in a Docker Container
@@ -98,7 +98,7 @@ sudo docker run \
     --shm-size=16g \
     -i ghcr.io/nvidia/jax:levanter \
     python -m levanter.main.train_lm \
-    --config_path /opt/levanter/config/gpt2_small.yaml
+    --config_path /opt/levanter/config/llama_small_fast.yaml
 ```
 
 For more information on how to train models in Levanter, see our [User Guide](Getting-Started-Training.md).
@@ -133,7 +133,7 @@ Now, you should be able to run training jobs in this container using the version
 
 ```bash
 python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small.yaml
+    --config_path config/llama_small_fast.yaml
 ```
 
 
@@ -151,7 +151,7 @@ Here are some examples of running a job.
 ### Running a job locally
 
 ```bash
-python -m levanter.main.train_lm --config config/gpt2_small
+python -m levanter.main.train_lm --config config/llama_small_fast
 ```
 
 ### Running a job on Slurm
@@ -162,7 +162,7 @@ Here's a simple example of running a job on a single node. This example assumes 
 and are in the root directory of the repository.
 
 ```bash
-srun --account=nlp --cpus-per-task=128 --gpus-per-node=8 --job-name=levanter-multi-1 --mem=1000G  --open-mode=append --partition=sphinx --time=14-0 infra/run-slurm.sh python src/levanter/main/train_lm.py --config_path config/gpt2_small.yaml
+srun --account=nlp --cpus-per-task=128 --gpus-per-node=8 --job-name=levanter-multi-1 --mem=1000G  --open-mode=append --partition=sphinx --time=14-0 infra/run-slurm.sh python src/levanter/main/train_lm.py --config_path config/llama_small_fast.yaml
 ```
 
 #### Single Node: One Process Per GPU
@@ -186,7 +186,7 @@ export PATH=$(echo $PATH | sed 's|:/usr/local/cuda/bin||')
 ## Activate your virtual environment
 source levanter/bin/activate
 
-srun python -m levanter.main.train_lm --config config/gpt2_small_fast --trainer.per_device_parallelism -1
+srun python -m levanter.main.train_lm --config config/llama_small_fast --trainer.per_device_parallelism -1
 ```
 
 Then, submit the job with sbatch:

--- a/docs/Getting-Started-Training.md
+++ b/docs/Getting-Started-Training.md
@@ -20,11 +20,11 @@ Please see the [Installation Guide](Installation.md) for more information on how
 
 To launch the training of a GPT2 model, run the following command:
 ```bash
-python src/levanter/main/train_lm.py --config_path config/gpt2_small.yaml
+python src/levanter/main/train_lm.py --config_path config/llama_small_fast.yaml
 ```
 
 This will execute the training pipeline pre-defined in the [train_lm.py](https://github.com/stanford-crfm/levanter/tree/main/src/levanter/main/train_lm.py) and set model and training configuration
-set in [gpt2_small.yaml](https://github.com/stanford-crfm/levanter/tree/main/config/gpt2_small.yaml). You can find more template configurations in the [config](https://github.com/stanford-crfm/levanter/tree/main/config/) directory.
+set in [llama_small_fast.yaml](https://github.com/stanford-crfm/levanter/tree/main/config/llama_small_fast.yaml). You can find more template configurations in the [config](https://github.com/stanford-crfm/levanter/tree/main/config/) directory.
 
 Configuration files are processed using [Draccus](https://github.com/dlwh/draccus). Draccus is yet-another yaml-to-dataclass library.
 It should mostly work like you would expect. Arguments may be passed in via the command line using arg-parse style
@@ -39,7 +39,7 @@ To change the dimensions of your GPT2 model and increase the number of training 
 
 ```
 python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small.yaml \
+    --config_path config/llama_small_fast.yaml \
     --model.num_heads 20 \
     --model.num_layers 36 \
     --model.hidden_dim 1280 \
@@ -61,7 +61,7 @@ To change the frequency of saving checkpoints, you can use the following command
 
 ```
 python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.checkpointer.base_path checkpoints/gpt2/ \
     --trainer.checkpointer.save_interval 20m
 ```
@@ -83,7 +83,7 @@ To change how often the model is evaluated during training, you can use the foll
 
 ```
 python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.steps_per_eval 500
 ```
 
@@ -95,7 +95,7 @@ To set explicit number of examples to process on each device during training and
 
 ```
 python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.batch_size 256 \
     --trainer.per_device_parallelism 64 \
     --trainer.eval_per_device_parallelism 64
@@ -115,7 +115,7 @@ Suppose you want to set more control on your WandB logging, you can use the foll
 
 ```
 python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.wandb.project my_project \
     --trainer.wandb.name my_run \
     --trainer.wandb.group my_new_exp_group
@@ -164,7 +164,7 @@ To do so, you can use the following command. The `trainer.wandb.resume true` is 
 
 ```
 python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.wandb.resume true \
     --trainer.id asdf1234
 ```

--- a/docs/Levanter-1.0-Release.md
+++ b/docs/Levanter-1.0-Release.md
@@ -554,10 +554,10 @@ python -m levanter.main.train_lm --config_path gpt2_nano
 If your dataset is a [Hugging Face dataset](https://huggingface.co/docs/datasets/loading_datasets.html), you can use the `data.id` field to specify it:
 
 ```bash
-python -m levanter.main.train_lm --config_path config/gpt2_small.yaml --data.id openwebtext
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext
 
 # optionally, you may specify a tokenizer and/or a cache directory, which may be local or on gcs
-python -m levanter.main.train_lm --config_path config/gpt2_small.yaml --data.id openwebtext --data.tokenizer "EleutherAI/gpt-neox-20b" --data.cache_dir "gs://path/to/cache/dir"
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext --data.tokenizer "meta-llama/Llama-2-70b-hf" --data.cache_dir "gs://path/to/cache/dir"
 ```
 
 If instead your data is a list of URLs, you can use the `data.train_urls` and `data.validation_urls` fields to specify them.
@@ -565,7 +565,7 @@ Data URLS can be local files, gcs files, or http(s) URLs, or anything that [fssp
 Levanter (really, fsspec) will automatically uncompress `.gz` and `.zstd` files, and probably other formats too.
 
 ```bash
-python -m levanter.main.train_lm --config_path config/gpt2_small.yaml --data.train_urls ["https://path/to/train/data_*.jsonl.gz"] --data.validation_urls ["https://path/to/val/data_*.jsonl.gz"]
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.train_urls ["https://path/to/train/data_*.jsonl.gz"] --data.validation_urls ["https://path/to/val/data_*.jsonl.gz"]
 ```
 
 You can also change the dataset by changing the `dataset` field in the config file.

--- a/docs/Levanter-1.0-Release.md
+++ b/docs/Levanter-1.0-Release.md
@@ -557,7 +557,7 @@ If your dataset is a [Hugging Face dataset](https://huggingface.co/docs/datasets
 python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext
 
 # optionally, you may specify a tokenizer and/or a cache directory, which may be local or on gcs
-python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext --data.tokenizer "meta-llama/Llama-2-70b-hf" --data.cache_dir "gs://path/to/cache/dir"
+python -m levanter.main.train_lm --config_path config/llama_small_fast.yaml --data.id openwebtext --data.tokenizer "NousResearch/Llama-2-7b-hf" --data.cache_dir "gs://path/to/cache/dir"
 ```
 
 If instead your data is a list of URLs, you can use the `data.train_urls` and `data.validation_urls` fields to specify them.

--- a/docs/LoRA.md
+++ b/docs/LoRA.md
@@ -197,7 +197,7 @@ Here's the complete configuration file for training the adapter. We're using the
 [Fine-Tuning tutorial](./Fine-Tuning.md), but we're using a different dataset and a different training script.
 
 ```yaml
-model_name_or_path: "meta-llama/Llama-2-7b-hf"
+model_name_or_path: "NousResearch/Llama-2-7b-hf"
 data: gsm8k
 trainer:
   mp: p=f32,c=bfloat16
@@ -372,11 +372,10 @@ helm-run --run-specs gsm:model=$MYMODEL --enable-huggingface-models $MYMODEL --s
 ```
 
 If you want to also evaluate the baseline Llama 2 model, you can do that by replacing `$MYMODEL` with
-`meta-llama/Llama-2-7b-hf`:
+`NousResearch/Llama-2-7b-hf`:
 
 ```bash
-export HUGGING_FACE_HUB_TOKEN=${YOUR TOKEN HERE}
-export MYMODEL="meta-llama/Llama-2-7b-hf"
+export MYMODEL="NousResearch/Llama-2-7b-hf"
 helm-run --run-specs gsm:model=$MYMODEL --enable-huggingface-models $MYMODEL --suite v1 --max-eval-instances 1000
 ```
 

--- a/docs/Training-On-Your-Data.md
+++ b/docs/Training-On-Your-Data.md
@@ -254,7 +254,7 @@ Levanter supports starting from an HF pretrained model. To do so, you should set
 ```yaml
 model:
   type: mpt
-initialize_from_hf: "meta-llama/Llama-2-7b-hf"
+initialize_from_hf: "NousResearch/Llama-2-7b-hf"
 use_hf_model_config: true
 ```
 
@@ -262,25 +262,12 @@ You should probably reduce the learning rate by a factor of 10 or so. TODO: figu
 
 #### Llama 2
 
-For Llama 2 specifically (or other gated models), you'll need a few extra steps:
-
-If you haven't already, go to [Llama 2's Hugging Face page](https://huggingface.co/meta-llama/Llama-2-7b-hf) and request access to the model.
-
-Once you have access, go to [Hugging Face's Tokens page](https://huggingface.co/settings/tokens) to get an API token.
-Then, pass in the token as an environment variable:
-
-```bash
-HUGGING_FACE_HUB_TOKEN=hf...
-```
-
-Pass that in anywhere you're passing in a `WANDB_API_KEY`.
-
-Then, you can use the model like so:
+For Llama 2 specifically (or other gated models), you'll need a few extra steps. Fortunately `NousResearch/Llama-2-7b-hf` is freely accessible on the Hub, so no gating is required. You can initialize like so:
 
 ```yaml
 model:
   type: llama
-initialize_from_hf: "meta-llama/Llama-2-7b-hf"
+initialize_from_hf: "NousResearch/Llama-2-7b-hf"
 use_hf_model_config: true
 ```
 

--- a/docs/Training-On-Your-Data.md
+++ b/docs/Training-On-Your-Data.md
@@ -262,7 +262,7 @@ You should probably reduce the learning rate by a factor of 10 or so. TODO: figu
 
 #### Llama 2
 
-For Llama 2 specifically (or other gated models), you'll need a few extra steps. Fortunately `NousResearch/Llama-2-7b-hf` is freely accessible on the Hub, so no gating is required. You can initialize like so:
+While some versions of Llama (and other gated models) require extra steps, `NousResearch/Llama-2-7b-hf` is freely accessible on the Hub, so no gating is required. You can initialize like so:
 
 ```yaml
 model:

--- a/docs/dev/Port-Models.md
+++ b/docs/dev/Port-Models.md
@@ -283,7 +283,7 @@ To initialize with the model configuration and checkpoint from Hugging Face, you
 ```yaml
 model:
     type: llama
-initialize_from_hf: "meta-llama/Llama-2-7b-hf"
+initialize_from_hf: "NousResearch/Llama-2-7b-hf"
 use_hf_model_config: true
 ```
 

--- a/docs/tutorials/Fine-Tuning-Semantic-Parsing.md
+++ b/docs/tutorials/Fine-Tuning-Semantic-Parsing.md
@@ -122,7 +122,7 @@ Levanter provides good support for both methods. Therefore, we can easily try bo
 
 We start with full-weight fine-tuning. Below is our configuration. Noteably:
 
-- The base model is `meta-llama/Llama-2-7b-hf`. It is set as the default value, so we don't need to specify it explicitly.
+- The base model is `NousResearch/Llama-2-7b-hf`. It is set as the default value, so we don't need to specify it explicitly.
 - Batch size: We set the batch size to 128, which is the maximum batch size that can fit into a single TPUv3-8.
 - Learning rate: We compared the results with 3 epochs vs 2 epochs, and found that 2 epochs is sufficient to achieve the best results, while 3 epochs leads to overfitting.
 

--- a/examples/alpaca-lora/alpaca-lora-llama2.yaml
+++ b/examples/alpaca-lora/alpaca-lora-llama2.yaml
@@ -1,5 +1,5 @@
 # cf https://github.com/tatsu-lab/stanford_alpaca#fine-tuning
-model_name_or_path: meta-llama/Llama-2-7b-hf
+model_name_or_path: NousResearch/Llama-2-7b-hf
 trainer:
   mp: p=f32,c=bfloat16
   wandb:

--- a/examples/alpaca/alpaca-llama2.yaml
+++ b/examples/alpaca/alpaca-llama2.yaml
@@ -1,5 +1,5 @@
 # cf https://github.com/tatsu-lab/stanford_alpaca#fine-tuning
-model_name_or_path: meta-llama/Llama-2-7b-hf
+model_name_or_path: NousResearch/Llama-2-7b-hf
 trainer:
   mp: p=f32,c=bfloat16
   wandb:

--- a/examples/alpaca/alpaca.py
+++ b/examples/alpaca/alpaca.py
@@ -89,7 +89,7 @@ class TrainArgs:
     prompts: Optional[Dict[str, str] | str] = None  # Path to the prompts file or a dict of prompts. can be gcs
     mask_inputs: bool = True  # if True, mask out the input and prompt for loss calculation
 
-    model_name_or_path: str = "meta-llama/Llama-2-7b-hf"
+    model_name_or_path: str = "NousResearch/Llama-2-7b-hf"
     trust_remote_code: bool = False  # Trust remote code when loading from HuggingFace checkpoints.
 
     model_cache_dir: Optional[str] = None  # Path to cache the model. must be local.

--- a/examples/gsm8k-lora/gsm8k_lora.py
+++ b/examples/gsm8k-lora/gsm8k_lora.py
@@ -52,7 +52,7 @@ class TrainArgs:
     output_key: str = "answer"  # key in the dataset for the output
     mask_inputs: bool = True  # if True, mask out the input and prompt for loss calculation
 
-    model_name_or_path: str = "meta-llama/Llama-2-7b-hf"
+    model_name_or_path: str = "NousResearch/Llama-2-7b-hf"
     trust_remote_code: bool = False  # Trust remote code when loading from HuggingFace checkpoints.
 
     model_cache_dir: Optional[str] = None  # Path to cache the model. must be local.

--- a/examples/sft/alpaca-llama.yaml
+++ b/examples/sft/alpaca-llama.yaml
@@ -1,4 +1,4 @@
-model_name_or_path: meta-llama/Llama-2-7b-hf
+model_name_or_path: NousResearch/Llama-2-7b-hf
 
 # Training configuration
 trainer:

--- a/examples/sft/dolly-llama.yaml
+++ b/examples/sft/dolly-llama.yaml
@@ -1,4 +1,4 @@
-model_name_or_path: meta-llama/Llama-2-7b-hf
+model_name_or_path: NousResearch/Llama-2-7b-hf
 
 # Training configuration
 trainer:

--- a/examples/sft/oasst-llama.yaml
+++ b/examples/sft/oasst-llama.yaml
@@ -1,4 +1,4 @@
-model_name_or_path: meta-llama/Llama-2-7b-hf
+model_name_or_path: NousResearch/Llama-2-7b-hf
 
 # Training configuration
 trainer:

--- a/scripts/launch_gpt2_small_fast_gpu.sh
+++ b/scripts/launch_gpt2_small_fast_gpu.sh
@@ -2,6 +2,6 @@
 # TODO: maybe move to the a100s or a6000s?
 srun --account=nlp --cpus-per-task=2 --gres=gpu:3090:4 --job-name=dlwh-job-1681253 --mem=16G --open-mode=append --partition=jag-standard --time=14-0 \
     bash infra/run-slurm.sh python src/levanter/main/train_lm.py \
-    --config_path config/gpt2_small_fast.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.checkpointer.save_interval 30m \
     --trainer.per_device_parallelism -1 $*

--- a/scripts/launch_gpt2_small_fast_supervised_tpu.sh
+++ b/scripts/launch_gpt2_small_fast_supervised_tpu.sh
@@ -2,5 +2,5 @@
 
 python infra/launch.py --foreground --tpu_name $(whoami)-levanter-itest-32 --zone us-central2-b --tpu_type v4-32 --preemptible -- \
     python -m levanter.main.train_lm \
-    --config_path config/gpt2_small_fast_supervised.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.checkpointer.base_path gs://levanter-checkpoints/gpt-itest/ --trainer.checkpointer.save_interval 30m $*

--- a/scripts/launch_gpt2_small_fast_tpu.sh
+++ b/scripts/launch_gpt2_small_fast_tpu.sh
@@ -3,5 +3,5 @@
 python infra/launch.py -e JAX_EXPLAIN_CACHE_MISSES true -e JAX_COMPILATION_CACHE_DIR gs://levanter-checkpoints/compilation-cache \
    --foreground --tpu_name $(whoami)-levanter-itest-32 --zone us-central2-b --tpu_type v4-32 --preemptible -- \
     python -m levanter.main.train_lm \
-    --config_path config/gpt2_small_fast.yaml \
+    --config_path config/llama_small_fast.yaml \
     --trainer.checkpointer.base_path gs://levanter-checkpoints/gpt-itest/ --trainer.checkpointer.save_interval 30m $*

--- a/scripts/launch_gpt2_small_itest_tpu.sh
+++ b/scripts/launch_gpt2_small_itest_tpu.sh
@@ -2,5 +2,5 @@
 
 python infra/launch.py --foreground --tpu_name $(whoami)-levanter-itest-32 --zone us-central2-b --tpu_type v4-32 --preemptible -- \
     python -m levanter.main.train_lm \
-    --config_path config/gpt2_small_itest.yaml \
+    --config_path config/llama_small_fast_itest.yaml \
     --trainer.checkpointer.base_path gs://levanter-checkpoints/gpt-itest/ --trainer.checkpointer.save_interval 30m $*

--- a/src/levanter/main/eval_lm.py
+++ b/src/levanter/main/eval_lm.py
@@ -17,7 +17,7 @@ from levanter.compat.hf_checkpoints import HFCheckpointConverter, RepoRef
 from levanter.data import DataLoader
 from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
 from levanter.eval import TaggedEvaluator, eval_model
-from levanter.models.gpt2 import Gpt2Config
+from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, compute_next_token_loss
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
@@ -34,7 +34,7 @@ class EvalLmConfig:
     hf_checkpoint: Optional[RepoRef] = None
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
     data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
-    model: LmConfig = field(default_factory=Gpt2Config)
+    model: LmConfig = field(default_factory=LlamaConfig)
 
     eval_on_train: bool = False
 

--- a/src/levanter/main/export_lm_to_hf.py
+++ b/src/levanter/main/export_lm_to_hf.py
@@ -12,7 +12,7 @@ from haliax import Axis
 import levanter
 from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import RepoRef, load_tokenizer
-from levanter.models.gpt2 import Gpt2Config
+from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.utils.jax_utils import is_inexact_arrayish, use_cpu_device
 
@@ -26,7 +26,7 @@ class ConvertLmConfig:
     output_dir: str
     upload_to_hf: Optional[RepoRef] = None  # if specified, attempt to upload this checkpoint to the hf hub
 
-    model: LmConfig = Gpt2Config()
+    model: LmConfig = LlamaConfig()
     save_tokenizer: bool = True  # if True, save the tokenizer to the output directory
     tokenizer: str = "gpt2"
     override_vocab_size: Optional[int] = None  # if specified, override the vocab size in the config

--- a/src/levanter/main/sft.py
+++ b/src/levanter/main/sft.py
@@ -67,8 +67,8 @@ class SFTConfig:
     hf_save_steps: int = 0
 
     max_seq_len: int = 2048
-    model_name_or_path: str = "meta-llama/Llama-2-7b-hf"
-    tokenizer: str = "meta-llama/Llama-2-7b-hf"
+    model_name_or_path: str = "NousResearch/Llama-2-7b-hf"
+    tokenizer: str = "NousResearch/Llama-2-7b-hf"
 
     # Add dataset type and chat-specific fields
     dataset_type: DatasetType = DatasetType.CHAT_JSONL

--- a/src/levanter/main/sft_mixture.py
+++ b/src/levanter/main/sft_mixture.py
@@ -71,8 +71,8 @@ class SFTMixtureConfig:
     hf_save_steps: int = 0
 
     max_seq_len: int = 2048
-    model_name_or_path: str = "meta-llama/Llama-2-7b-hf"
-    tokenizer: str = "meta-llama/Llama-2-7b-hf"
+    model_name_or_path: str = "NousResearch/Llama-2-7b-hf"
+    tokenizer: str = "NousResearch/Llama-2-7b-hf"
 
     # Add dataset type and chat-specific fields
     dataset_type: DatasetType = DatasetType.CHAT_JSONL

--- a/src/levanter/main/sft_mixture.py
+++ b/src/levanter/main/sft_mixture.py
@@ -71,8 +71,8 @@ class SFTMixtureConfig:
     hf_save_steps: int = 0
 
     max_seq_len: int = 2048
-    model_name_or_path: str = "NousResearch/Llama-2-7b-hf"
-    tokenizer: str = "NousResearch/Llama-2-7b-hf"
+    model_name_or_path: str = "marin-community/marin-8b-base"
+    tokenizer: str = "marin-community/marin-8b-base"
 
     # Add dataset type and chat-specific fields
     dataset_type: DatasetType = DatasetType.CHAT_JSONL

--- a/src/levanter/main/train_lm.py
+++ b/src/levanter/main/train_lm.py
@@ -22,7 +22,7 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCompatConfig, save_hf_checkpoint_callback
 from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfig, UrlSingleDatasetLMConfig
 from levanter.eval_harness import LmEvalHarnessConfig
-from levanter.models.gpt2 import Gpt2Config
+from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, compute_next_token_loss
 from levanter.optim import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class TrainLmConfig:
     data: Union[SingleDatasetLMConfig, LMMixtureDatasetConfig] = field(default_factory=UrlSingleDatasetLMConfig)
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
-    model: LmConfig = field(default_factory=Gpt2Config)
+    model: LmConfig = field(default_factory=LlamaConfig)
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
 
     # config related to continued pretraining

--- a/src/levanter/main/viz_logprobs.py
+++ b/src/levanter/main/viz_logprobs.py
@@ -16,7 +16,7 @@ from levanter.checkpoint import load_checkpoint
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data import DataLoader
 from levanter.data.text import LMMixtureDatasetConfig, SingleDatasetLMConfigBase
-from levanter.models.gpt2 import Gpt2Config
+from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
 from levanter.models.loss import next_token_loss
 from levanter.trainer import TrainerConfig
@@ -34,7 +34,7 @@ class VizLmConfig:
     path: str = "logprobs.html"
     trainer: TrainerConfig = field(default_factory=TrainerConfig)
     data: SingleDatasetLMConfigBase | LMMixtureDatasetConfig = field(default_factory=SingleDatasetLMConfigBase)
-    model: LmConfig = field(default_factory=Gpt2Config)
+    model: LmConfig = field(default_factory=LlamaConfig)
 
     num_docs: int = 32
 

--- a/src/levanter/models/llama.py
+++ b/src/levanter/models/llama.py
@@ -73,7 +73,7 @@ class LlamaConfig(HFCompatConfig):
     use_layer_norm_weight: bool = True
     rope: RotaryEmbeddingsConfig = dataclasses.field(default_factory=DefaultRotaryEmbeddingsConfig)
 
-    reference_checkpoint: str = "meta-llama/Llama-2-7b-hf"
+    reference_checkpoint: str = "NousResearch/Llama-2-7b-hf"
     tokenizer: Optional[str] = None
 
     # Axis

--- a/tests/test_eval_lm.py
+++ b/tests/test_eval_lm.py
@@ -23,9 +23,9 @@ def test_eval_lm():
     model_config = LlamaConfig(
         num_layers=2,
         num_heads=2,
+        num_kv_heads=2,
         seq_len=64,
         hidden_dim=32,
-        use_flash_attention=True,
     )
 
     with tempfile.TemporaryDirectory() as f:
@@ -67,9 +67,9 @@ def test_eval_lm_from_hf():
     model_config = LlamaConfig(
         num_layers=2,
         num_heads=2,
+        num_kv_heads=2,
         seq_len=1024,
         hidden_dim=32,
-        use_flash_attention=True,
     )
 
     with tempfile.TemporaryDirectory() as f:

--- a/tests/test_eval_lm.py
+++ b/tests/test_eval_lm.py
@@ -10,7 +10,7 @@ import levanter.main.eval_lm as eval_lm
 import tiny_test_corpus
 from levanter.checkpoint import save_checkpoint
 from levanter.distributed import RayConfig
-from levanter.models.gpt2 import Gpt2LMHeadModel
+from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
 from levanter.tracker import NoopConfig
 from levanter.trainer_state import TrainerState
 from test_utils import skip_if_no_torch
@@ -20,7 +20,7 @@ from test_utils import skip_if_no_torch
 def test_eval_lm():
     # just testing if eval_lm has a pulse
     # save a checkpoint
-    model_config = eval_lm.Gpt2Config(
+    model_config = LlamaConfig(
         num_layers=2,
         num_heads=2,
         seq_len=64,
@@ -33,7 +33,7 @@ def test_eval_lm():
             data_config, _ = tiny_test_corpus.construct_small_data_cache(f)
             tok = data_config.the_tokenizer
             Vocab = haliax.Axis("vocab", len(tok))
-            model = Gpt2LMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
+            model = LlamaLMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
 
             state = TrainerState(0, model, model, jax.random.PRNGKey(0), None, True, None, None)
 
@@ -64,7 +64,7 @@ def test_eval_lm():
 def test_eval_lm_from_hf():
     # just testing if eval_lm has a pulse
     # save a checkpoint
-    model_config = eval_lm.Gpt2Config(
+    model_config = LlamaConfig(
         num_layers=2,
         num_heads=2,
         seq_len=1024,
@@ -77,7 +77,7 @@ def test_eval_lm_from_hf():
             data_config, _ = tiny_test_corpus.construct_small_data_cache(f)
             tok = data_config.the_tokenizer
             Vocab = haliax.Axis("vocab", len(tok))
-            model = Gpt2LMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
+            model = LlamaLMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
 
             state = TrainerState(0, model, model, jax.random.PRNGKey(0), None, True, None, None)
 

--- a/tests/test_hf_utils.py
+++ b/tests/test_hf_utils.py
@@ -27,9 +27,9 @@ def test_load_tokenizer_in_memory_fs():
     assert len(tokenizer) == 5027
 
 
-@skip_if_hf_model_not_accessible("meta-llama/Llama-2-7b-hf")
+@skip_if_hf_model_not_accessible("NousResearch/Llama-2-7b-hf")
 def test_byte_length_of_token():
-    tok = load_tokenizer("meta-llama/Llama-2-7b-hf")
+    tok = load_tokenizer("NousResearch/Llama-2-7b-hf")
     ids = tok("this is hello a test", add_special_tokens=False)["input_ids"]
     assert byte_length_of_token(tok, ids[2]) == len(" hello".encode("utf-8"))
     assert byte_length_of_token(tok, 25) == 1
@@ -66,9 +66,9 @@ def test_byte_length_of_token():
         assert byte_length == expected_length, f"Token {i} has length {byte_length} but expected {expected_length}"
 
 
-@skip_if_hf_model_not_accessible("meta-llama/Llama-2-7b-hf")
+@skip_if_hf_model_not_accessible("NousResearch/Llama-2-7b-hf")
 def test_byte_length_of_token_multi():
-    tok = load_tokenizer("meta-llama/Llama-2-7b-hf")
+    tok = load_tokenizer("NousResearch/Llama-2-7b-hf")
     multi_checks = [
         "👍你好",
     ]

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -24,10 +24,10 @@ from test_utils import (
 
 
 @skip_if_no_torch
-@skip_if_hf_model_not_accessible("meta-llama/Llama-2-7b-hf")
+@skip_if_hf_model_not_accessible("NousResearch/Llama-2-7b-hf")
 def test_llama_config():
     # load HF config and convert to levanter config
-    hf_config = transformers.LlamaConfig.from_pretrained("meta-llama/Llama-2-7b-hf")
+    hf_config = transformers.LlamaConfig.from_pretrained("NousResearch/Llama-2-7b-hf")
     llama_config = LlamaConfig.from_hf_config(hf_config)
 
     # convert back to HF config

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -26,7 +26,7 @@ from levanter.lora import (
     save_merged_hf_model,
     save_peft_pretrained,
 )
-from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
+from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
 from levanter.trainer_state import TrainerState
 from levanter.utils.tree_utils import inference_mode
 from test_utils import skip_if_module_missing, skip_if_no_torch
@@ -113,7 +113,7 @@ def test_lora_peft_integration():
 
     hf_dict = get_peft_model_state_dict(model)
 
-    converter = Gpt2Config().hf_checkpoint_converter()
+    converter = LlamaConfig().hf_checkpoint_converter()
 
     lev_model = converter.load_pretrained(converter.default_config.model_type, "stanford-crfm/expanse-gpt2-small-x777")
 
@@ -182,11 +182,11 @@ def test_merge_lora():
 def test_lora_load_in_peft():
     import torch
 
-    converter: HFCheckpointConverter = Gpt2Config().hf_checkpoint_converter()
-    config = Gpt2Config(seq_len=128, num_layers=2, num_heads=2)
+    converter: HFCheckpointConverter = LlamaConfig().hf_checkpoint_converter()
+    config = LlamaConfig(seq_len=128, intermediate_dim=512, num_layers=2, num_heads=2, num_kv_heads=2)
     Vocab = converter.Vocab
 
-    model = Gpt2LMHeadModel.init(Vocab, config=config, key=jax.random.PRNGKey(0))
+    model = LlamaLMHeadModel.init(Vocab, config=config, key=jax.random.PRNGKey(0))
     model = inference_mode(model, True)
 
     input = hax.random.randint(jax.random.PRNGKey(0), config.Pos, 0, Vocab.size)
@@ -232,11 +232,11 @@ def test_lora_load_in_peft():
 def test_lora_merged_load_in_hf():
     import torch
 
-    converter: HFCheckpointConverter = Gpt2Config().hf_checkpoint_converter()
-    config = Gpt2Config(seq_len=128, num_layers=2, num_heads=2)
+    converter: HFCheckpointConverter = LlamaConfig().hf_checkpoint_converter()
+    config = LlamaConfig(seq_len=128, intermediate_dim=512, num_layers=2, num_heads=2, num_kv_heads=2)
     Vocab = converter.Vocab
 
-    model = Gpt2LMHeadModel.init(Vocab, config=config, key=jax.random.PRNGKey(0))
+    model = LlamaLMHeadModel.init(Vocab, config=config, key=jax.random.PRNGKey(0))
     model = inference_mode(model, True)
 
     input = hax.random.randint(jax.random.PRNGKey(0), config.Pos, 0, Vocab.size)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -87,9 +87,9 @@ def test_merge_split_encodings(local_gpt2_tokenizer):
     assert short_out == reg_out
 
 
-@skip_if_hf_model_not_accessible("meta-llama/Llama-2-7b-hf")
+@skip_if_hf_model_not_accessible("NousResearch/Llama-2-7b-hf")
 def test_llama_tokenizer_needs_long_sequence_workaround():
-    tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+    tokenizer = AutoTokenizer.from_pretrained("NousResearch/Llama-2-7b-hf")
     batch_tokenizer = BatchTokenizer(tokenizer)
     assert batch_tokenizer._needs_long_sequence_workaround
 

--- a/tests/test_train_lm.py
+++ b/tests/test_train_lm.py
@@ -23,6 +23,7 @@ def test_train_lm():
                 model=train_lm.LlamaConfig(
                     num_layers=2,
                     num_heads=2,
+                    num_kv_heads=2,
                     seq_len=64,
                     hidden_dim=32,
                     attn_backend=None,  # use default for platform
@@ -55,6 +56,7 @@ def test_train_lm_fp8():
                 model=train_lm.LlamaConfig(
                     num_layers=2,
                     num_heads=2,
+                    num_kv_heads=2,
                     seq_len=64,
                     hidden_dim=32,
                     attn_backend=None,  # use default for platform

--- a/tests/test_train_lm.py
+++ b/tests/test_train_lm.py
@@ -20,7 +20,7 @@ def test_train_lm():
         try:
             config = train_lm.TrainLmConfig(
                 data=data_config,
-                model=train_lm.Gpt2Config(
+                model=train_lm.LlamaConfig(
                     num_layers=2,
                     num_heads=2,
                     seq_len=64,
@@ -52,7 +52,7 @@ def test_train_lm_fp8():
         try:
             config = train_lm.TrainLmConfig(
                 data=data_config,
-                model=train_lm.Gpt2Config(
+                model=train_lm.LlamaConfig(
                     num_layers=2,
                     num_heads=2,
                     seq_len=64,

--- a/tests/test_viz_lm.py
+++ b/tests/test_viz_lm.py
@@ -21,9 +21,9 @@ def test_viz_lm():
     model_config = LlamaConfig(
         num_layers=2,
         num_heads=2,
+        num_kv_heads=2,
         hidden_dim=32,
         seq_len=64,
-        use_flash_attention=True,
     )
 
     with tempfile.TemporaryDirectory() as f:

--- a/tests/test_viz_lm.py
+++ b/tests/test_viz_lm.py
@@ -10,7 +10,7 @@ import levanter.main.viz_logprobs as viz_logprobs
 import tiny_test_corpus
 from levanter.checkpoint import save_checkpoint
 from levanter.distributed import RayConfig
-from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
+from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
 from levanter.tracker import NoopConfig
 
 
@@ -18,7 +18,7 @@ from levanter.tracker import NoopConfig
 def test_viz_lm():
     # just testing if eval_lm has a pulse
     # save a checkpoint
-    model_config = Gpt2Config(
+    model_config = LlamaConfig(
         num_layers=2,
         num_heads=2,
         hidden_dim=32,
@@ -31,7 +31,7 @@ def test_viz_lm():
             data_config, _ = tiny_test_corpus.construct_small_data_cache(f)
             tok = data_config.the_tokenizer
             Vocab = haliax.Axis("vocab", len(tok))
-            model = Gpt2LMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
+            model = LlamaLMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
 
             save_checkpoint({"model": model}, 0, f"{f}/ckpt")
 


### PR DESCRIPTION
## Summary
- make Llama the default training architecture in `train_lm.py`, `eval_lm.py`, `viz_logprobs.py` and export script
- update scripts and CI workflows to use `llama_small_fast.yaml`
- update docs and README to reference Llama configs
- add `llama_small_fast_itest.yaml` for integration tests
- switch unit tests to Llama models

## Testing
- `pre-commit run --files $(git status --porcelain | cut -c4- | tr '\n' ' ')`
- `pytest tests -m "not entry and not slow and not ray" -q` *(failed: cannot import name 'BuiltInKeyEntry' from 'jax._src.tree_util')*

------
https://chatgpt.com/codex/tasks/task_e_68802a6c9cb08331befd5b53f84b086f