### PR TITLE
Refactor JitScheduler buffer shape

### DIFF
--- a/src/levanter/main/sample_lm.py
+++ b/src/levanter/main/sample_lm.py
@@ -220,7 +220,7 @@ def main(config: SampleLmConfig):
         MAX_NEW_TOKENS = 32
         table = PageTable.init(64, len(prompt_ids), 8, 32)
         cache = haliax.named_jit(model.initial_cache)(table, dtype=config.trainer.mp.compute_dtype)
-        sched = JitScheduler.init(256, 128)
+        sched = JitScheduler.init(table.max_seqs, 256, 128)
         gen_state = GenState(
             sched=sched,
             cache=cache,


### PR DESCRIPTION
## Summary
- refactor `JitScheduler` to maintain generated tokens per sequence
- adjust API to require `max_seqs` at init
- update sample_lm and tests for new behaviour

## Testing
- `pre-commit run --files src/levanter/inference/jit_scheduler.py tests/test_jit_scheduler.py src/levanter/main/sample_lm.py`
- `uv run pytest tests/test_jit_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b183e2dc8331856b293d9c19528e