### PR TITLE
Fix test warnings

### DIFF
--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -10,6 +10,7 @@ from levanter.models.llama import LlamaEmbedding
 
 
 class TestModel(equinox.Module):
+    __test__ = False
     Vocab: hax.Axis
     embeddings: LlamaEmbedding
     lm_head: hax.nn.Linear

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 from chex import assert_trees_all_close
 from equinox import nn as nn
-from equinox import static_field
 from jax._src.random import PRNGKey
 from transformers import AutoConfig, BatchEncoding
 
@@ -35,10 +34,10 @@ class MLP(eqx.Module):
     layers: List[nn.Linear]
     activation: Callable = eqx.field(static=True)
     final_activation: Callable = eqx.field(static=True)
-    in_size: int = static_field()
-    out_size: int = static_field()
-    width_size: int = static_field()
-    depth: int = static_field()
+    in_size: int = eqx.field(static=True)
+    out_size: int = eqx.field(static=True)
+    width_size: int = eqx.field(static=True)
+    depth: int = eqx.field(static=True)
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- fix Equinox `static_field` deprecation in `tests/test_utils.py`
- prevent pytest from trying to collect the helper `TestModel` in `tests/test_sft.py`

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: ProxyError when trying to reach huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_68850dc0f79c8331bc8fd528faab101e