### PR TITLE
Fix docs by re-exporting SkipStepConfig

### DIFF
--- a/src/levanter/optim/__init__.py
+++ b/src/levanter/optim/__init__.py
@@ -31,6 +31,8 @@ __all__ = [
     "ScaleBySophiaState",
     "SophiaHConfig",
     "scale_by_sophia_h",
+    # skipstep
+    "SkipStepConfig",
 ]
 
 from .adam_mini import MiniConfig, ScaleByMiniState
@@ -48,3 +50,4 @@ from .sophia import (  # SophiaGConfig,; SophiaGObjective,; scale_by_sophia_g,
     SophiaHConfig,
     scale_by_sophia_h,
 )
+from .skipstep import SkipStepConfig


### PR DESCRIPTION
## Summary
- export `SkipStepConfig` from `levanter.optim`

This allows mkdocs to find `levanter.optim.SkipStepConfig` during documentation builds.

## Testing
- `pre-commit run --files src/levanter/optim/__init__.py docs/reference/Configuration.md`
- `python -m mkdocs build --clean --site-dir ./_site` *(fails to load remote inventories due to network blocks but finishes)*
- `pytest tests -m "not entry and not slow and not ray"` *(fails: requests.exceptions.ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_688513e3b2b08331a3cce5b047e6c457