### PR TITLE
Fix GPT-2 integration workflow install

### DIFF
--- a/.github/workflows/gpt2_small_itest.yaml
+++ b/.github/workflows/gpt2_small_itest.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install dependencies
-        run: uv pip install --system -e .
+        run: uv pip install -e .
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
## Summary
- fix the install step in `gpt2_small_itest.yaml` to avoid using `--system`

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: Unknown pytest mark and network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688533130578833198d832570ae03250