### PR TITLE
Use DecodeState for generation tracking

### DIFF
--- a/docs/design/inference.md
+++ b/docs/design/inference.md
@@ -86,7 +86,7 @@ torch, not much interesting here given jetstream. focused on batch inference I t
 ## Sample LM Integration
 - [ ] expose a free list of pages in `PageTable`
 - [ ] allocate pages from the free list inside the generation loop
-- [ ] store partial sequences in `DecodeState` instead of `JitScheduler`
-- [ ] check `DecodeState.is_finished` during generation
+- [x] store partial sequences in `DecodeState` instead of `JitScheduler`
+- [x] check `DecodeState.is_finished` during generation
 - [ ] remove `PageTable` from the core decoding loop
 - [ ] integrate any remaining pieces needed for `sample_lm`

--- a/tests/inference/test_decode_state.py
+++ b/tests/inference/test_decode_state.py
@@ -45,7 +45,7 @@ def test_update_tokens_and_finish_max():
     kv = hax.named(jnp.array([0, 1], dtype=jnp.int32), axis=("page",))
     toks = hax.named(jnp.array([1, 2], dtype=jnp.int32), axis=("position",))
     params = SeqDecodingParams(max_num_tokens=jnp.array(4, dtype=jnp.int32), stop_tokens=None, temperature=jnp.array(1.0, dtype=jnp.float32))
-    ds = eqx.filter_jit(ds.assign_seq)(0, 0, kv, toks, 0, params)
+    ds = eqx.filter_jit(ds.assign_seq)(0, 0, kv, toks, 2, params)
 
     logprobs = hax.full({"seq": 1, "position": 4}, 0.0, dtype=jnp.float32)
     ds = dataclasses.replace(ds, logprobs=logprobs)
@@ -70,7 +70,7 @@ def test_stop_sequence_triggers_finished():
     toks = hax.named(jnp.array([10, 11], dtype=jnp.int32), axis=("position",))
     stop = hax.named(jnp.array([[INVALID, 4]], dtype=jnp.int32), axis=("stop_seq", "position"))
     params = SeqDecodingParams(max_num_tokens=jnp.array(6, dtype=jnp.int32), stop_tokens=stop, temperature=jnp.array(1.0, dtype=jnp.float32))
-    ds = eqx.filter_jit(ds.assign_seq)(0, 0, kv, toks, 0, params)
+    ds = eqx.filter_jit(ds.assign_seq)(0, 0, kv, toks, 2, params)
 
     new_toks = hax.named(jnp.array([3, 4], dtype=jnp.int32), axis=("position",))
     seqs = hax.named(jnp.array([0, 0], dtype=jnp.int32), axis=("position",))
@@ -78,3 +78,22 @@ def test_stop_sequence_triggers_finished():
     ds = eqx.filter_jit(ds.update_tokens)(seqs, new_toks, new_lps, jnp.array(2, dtype=jnp.int32))
 
     assert eqx.filter_jit(ds.is_finished)(jnp.array(0, dtype=jnp.int32))
+
+
+def test_extract_new_tokens():
+    ds = _make_state(max_tokens=6)
+    kv = hax.named(jnp.array([0, 1], dtype=jnp.int32), axis=("page",))
+    toks = hax.named(jnp.array([1, 2], dtype=jnp.int32), axis=("position",))
+    params = SeqDecodingParams(max_num_tokens=jnp.array(6, dtype=jnp.int32), stop_tokens=None, temperature=jnp.array(1.0, dtype=jnp.float32))
+    ds = eqx.filter_jit(ds.assign_seq)(0, 0, kv, toks, 2, params)
+
+    new_toks = hax.named(jnp.array([3, 4, 5], dtype=jnp.int32), axis=("position",))
+    seqs = hax.named(jnp.array([0, 0, 0], dtype=jnp.int32), axis=("position",))
+    new_lps = hax.named(jnp.zeros(3, dtype=jnp.float32), axis=("position",))
+    ds = eqx.filter_jit(ds.update_tokens)(seqs, new_toks, new_lps, jnp.array(3, dtype=jnp.int32))
+
+    ds2, toks_out, counts = eqx.filter_jit(ds.extract_new_tokens)()
+
+    assert counts["seq", 0] == 3
+    assert jnp.array_equal(toks_out["seq", 0, "position", hax.ds(0, 3)].array, jnp.array([3, 4, 5], dtype=jnp.int32))
+    assert ds2.prefix_len["seq", 0] == ds2.num_tokens["seq", 0]

--- a/tests/test_jit_scheduler.py
+++ b/tests/test_jit_scheduler.py
@@ -7,7 +7,7 @@ from levanter.inference.utils import INVALID
 
 
 def test_enqueue_and_pack():
-    sched = JitScheduler.init(max_seqs=4, max_queued_tokens=8, max_buffered_tokens=8)
+    sched = JitScheduler.init(8)
     toks = hax.named(jnp.array([1, 2], dtype=jnp.int32), "position")
     seqs = hax.named(jnp.array([0, 1], dtype=jnp.int32), "position")
     sched = eqx.filter_jit(sched.enqueue_tokens)(toks, seqs, 2)
@@ -22,7 +22,7 @@ def test_enqueue_and_pack():
 
 
 def test_enqueue_and_pack_over_length():
-    sched = JitScheduler.init(max_seqs=4, max_queued_tokens=8, max_buffered_tokens=8)
+    sched = JitScheduler.init(8)
     toks = hax.named(jnp.array([1, 2], dtype=jnp.int32), "position")
     seqs = hax.named(jnp.array([0, 1], dtype=jnp.int32), "position")
     sched = eqx.filter_jit(sched.enqueue_tokens)(toks, seqs, 2)
@@ -37,19 +37,10 @@ def test_enqueue_and_pack_over_length():
 
 
 
-def test_update_after_sampling():
-    sched = JitScheduler.init(max_seqs=4, max_queued_tokens=8, max_buffered_tokens=16)
-    toks = hax.named(jnp.array([5], dtype=jnp.int32), "position")
-    seqs = hax.named(jnp.array([0], dtype=jnp.int32), "position")
-
-    sched = eqx.filter_jit(sched.update_after_sampling)(toks, seqs, 1)
-    assert jnp.array_equal(sched.generated_tokens["seq", 0, "position", hax.ds(0, 1)].array, jnp.array([5], dtype=jnp.int32))
-    assert jnp.array_equal(sched.num_generated_tokens.array, jnp.array([1,0,0,0], dtype=jnp.int32))
-    assert sched.num_queued_tokens == 1
 
 
 def test_partial_dequeue():
-    sched = JitScheduler.init(max_seqs=4, max_queued_tokens=8, max_buffered_tokens=16)
+    sched = JitScheduler.init(8)
     toks = hax.named(jnp.array([1, 2, 3], dtype=jnp.int32), "position")
     seqs = hax.named(jnp.array([0, 0, 0], dtype=jnp.int32), "position")
     sched = eqx.filter_jit(sched.enqueue_tokens)(toks, seqs, 3)
@@ -66,82 +57,19 @@ def test_partial_dequeue():
     assert sched.num_queued_tokens == 1
 
 
-def _make_scheduler_with_tokens(max_tokens=8, max_buffered_tokens=16):
+def _make_scheduler_with_tokens(max_tokens=8):
     # Build a scheduler and push four tokens: [10,20,30,40]
-    # with seq‐ids [0,1,0,1].
-    sched = JitScheduler.init(max_seqs=4, max_queued_tokens=max_tokens, max_buffered_tokens=max_buffered_tokens)
+    # with seq-ids [0,1,0,1].
+    sched = JitScheduler.init(max_tokens)
     toks = hax.named(jnp.array([10, 20, 30, 40], dtype=jnp.int32), axis=("position",))
-    seqs = hax.named(jnp.array([ 0,  1,  0,  1], dtype=jnp.int32), axis=("position",))
-    return eqx.filter_jit(sched.update_after_sampling)(toks, seqs, 4)
+    seqs = hax.named(jnp.array([0, 1, 0, 1], dtype=jnp.int32), axis=("position",))
+    return eqx.filter_jit(sched.enqueue_tokens)(toks, seqs, 4)
 
 
-def test_extract_single_sequence():
-    sched = _make_scheduler_with_tokens(max_buffered_tokens=16)
-    # extract up to 3 tokens for seq=0
-    seq_ids = hax.named(jnp.array([0], dtype=jnp.int32), axis=("seq",))
-    sched2, out = eqx.filter_jit(sched.extract_generated_tokens)(seq_ids, 3)
-
-    # seq 0 produced [10,30] then pad INVALID
-    expected = jnp.array([[10, 30, INVALID]], dtype=jnp.int32)
-    assert jnp.array_equal(out.array, expected)
-
-    # buffer should now only have the tokens for seq=1 in order [20,40]
-    remaining = sched2.generated_tokens["seq", 1, "position", hax.ds(0,2)].array
-    assert jnp.array_equal(remaining, jnp.array([20, 40], dtype=jnp.int32))
-    # count updated
-    assert jnp.array_equal(sched2.num_generated_tokens.array, jnp.array([0,2,0,0], dtype=jnp.int32))
-
-
-def test_extract_multiple_sequences():
-    sched = _make_scheduler_with_tokens(max_buffered_tokens=16)
-    # extract up to 2 tokens for seq=0 and seq=1
-    seq_ids = hax.named(jnp.array([0,1], dtype=jnp.int32), axis=("seq",))
-    sched2, out = eqx.filter_jit(sched.extract_generated_tokens)(seq_ids, 2)
-
-    # row 0 → seq 0: [10,30], row 1 → seq 1: [20,40]
-    expected = jnp.array([[10, 30], [20, 40]], dtype=jnp.int32)
-    assert jnp.array_equal(out.array, expected)
-
-    # buffer now empty
-    assert jnp.all(sched2.num_generated_tokens.array == 0)
-    assert jnp.all(sched2.generated_tokens.array == INVALID)
-
-
-def test_extract_partial_sequence():
-    sched = _make_scheduler_with_tokens(max_buffered_tokens=16)
-    # request seq-id 0, but only 1 token available
-    seq_ids = hax.named(jnp.array([0], dtype=jnp.int32), axis=("seq",))
-    sched2, out = eqx.filter_jit(sched.extract_generated_tokens)(seq_ids, 1)
-
-    expected = jnp.array([[10]], dtype=jnp.int32)
-    assert jnp.array_equal(out.array, expected)
-
-    # buffer should now have 1 token for seq 0 and 2 for seq 1
-    remaining0 = sched2.generated_tokens["seq", 0, "position", hax.ds(0,1)].array
-    remaining1 = sched2.generated_tokens["seq", 1, "position", hax.ds(0,2)].array
-    assert jnp.array_equal(remaining0, jnp.array([30], dtype=jnp.int32))
-    assert jnp.array_equal(remaining1, jnp.array([20, 40], dtype=jnp.int32))
-
-
-def test_extract_nonexistent_sequence_leaves_buffer():
-    sched = _make_scheduler_with_tokens(max_buffered_tokens=16)
-    # request seq-id 2 (never inserted)
-    seq_ids = hax.named(jnp.array([2], dtype=jnp.int32), axis=("seq",))
-    sched2, out = eqx.filter_jit(sched.extract_generated_tokens)(seq_ids, 3)
-
-    # output should be all INVALID
-    assert jnp.array_equal(out.array, jnp.full((1,3), INVALID, dtype=jnp.int32))
-
-    # buffer remains exactly as before
-    assert jnp.array_equal(sched2.num_generated_tokens.array, sched.num_generated_tokens.array)
-    assert jnp.array_equal(
-        sched2.generated_tokens.array,
-        sched.generated_tokens.array
-    )
 
 
 def test_purge_queue_of_seq():
-    sched = JitScheduler.init(max_seqs=4, max_queued_tokens=8, max_buffered_tokens=8)
+    sched = JitScheduler.init(8)
     # Enqueue tokens with seq_ids: [0, 1, 0, 2, 1, 2]
     toks = hax.named(jnp.array([10, 20, 30, 40, 50, 60], dtype=jnp.int32), "position")
     seqs = hax.named(jnp.array([0, 1, 0, 2, 1, 2], dtype=jnp.int32), "position")


### PR DESCRIPTION
## Summary
- remove unused generated token buffer from `JitScheduler`
- update sampling loop to rely only on `DecodeState`
- tick off completed TODOs in `docs/design/inference.md`
- simplify scheduler tests

## Testing
- `uv run pre-commit run --files docs/design/inference.md src/levanter/inference/jit_scheduler.py src/levanter/main/sample_lm.py tests/test_jit_scheduler.py`
- `uv run pytest tests/test_jit_scheduler.py::test_enqueue_and_pack -q`
- `uv run pytest tests/inference/test_decode_state.py::test_extract_new_tokens -q`
- `uv run pytest tests -m "not entry and not slow and not ray"` *(fails: huggingface.co blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68886f3d1ee88331836cdeda4cb446fc