### PR TITLE
Add token-level evaluation mode

### DIFF
--- a/config/books/eval_careless_llama3.1_70b_gatsby.yaml
+++ b/config/books/eval_careless_llama3.1_70b_gatsby.yaml
@@ -16,6 +16,9 @@ prompt_tokens: 50
 
 # Slide the character cursor by this many chars between windows.
 cursor_inc_chars: 10
+# Enable token-based sliding window mode
+token_mode: true
+cursor_inc_tokens: 5
 
 # slice length
 slice_length: 2000


### PR DESCRIPTION
## Summary
- allow token-based analysis for eval_careless_lm
- implement utilities for sliding windows over token ids
- update Gatsby example config to show token_mode usage

## Testing
- `pre-commit run --files src/levanter/books/util.py src/levanter/main/eval_careless_lm.py config/books/eval_careless_llama3.1_70b_gatsby.yaml` *(fails: command not found)*
- `pytest -k histogram -q` *(fails: ImportError: cannot import name 'PositionalSharding')*

------
https://chatgpt.com/codex/tasks/task_e_688bfac097388327a23154a5a6f999b1