### PR TITLE
docs: document tpu_remote decorator

### DIFF
--- a/docs/reference/Ray-TPU.md
+++ b/docs/reference/Ray-TPU.md
@@ -1,0 +1,58 @@
+# Ray TPU Remote Functions
+
+Levanter provides a convenience decorator [levanter.infra.ray_tpu.tpu_remote][] for running Python functions on Cloud TPU slices through a Ray cluster. The decorator acquires the required TPU resources, launches the function on each host of the slice, and retries automatically if the job is preempted or encounters transient failures.
+
+## Basic Usage
+
+You can apply `tpu_remote` as a decorator:
+
+```python
+from levanter.infra.ray_tpu import tpu_remote
+
+@tpu_remote(tpu_type="v4-8")
+def add_one(x):
+    import jax.numpy as jnp
+    return jnp.add(x, 1)
+
+result = add_one(1)
+```
+
+`tpu_remote` returns a Ray remote function. Calling the decorated function submits a job to the Ray cluster and blocks until the TPU work is complete.
+
+The decorator may also be used as a function:
+
+```python
+from levanter.infra.ray_tpu import tpu_remote
+
+def add(x, y):
+    import jax.numpy as jnp
+    return jnp.add(x, y)
+
+remote_add = tpu_remote(add, tpu_type="v4-8")
+result = remote_add(1, 2)
+```
+
+## Multiple Slices
+
+If `num_slices` is greater than 1, the function is launched on each slice. The return value is a flat list containing the results from every host of all slices:
+
+```python
+@tpu_remote(tpu_type="v4-8", num_slices=2)
+def host_id():
+    import jax
+    return jax.process_index()
+
+ids = host_id()
+# ids == [0, 1, ..., 15]
+```
+
+## Retry Behaviour
+
+By default, `tpu_remote` will retry preempted jobs and transient failures. This can be controlled via the `max_retries_preemption` and `max_retries_failure` arguments.
+
+!!! note
+    `run_on_pod_ray` is deprecated. Use [tpu_remote][levanter.infra.ray_tpu.tpu_remote] for new code.
+
+## API Reference
+
+::: levanter.infra.ray_tpu.tpu_remote

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - 'reference/Configuration.md'
       - "reference/Data-Formats.md"
       - 'reference/Trackers.md'
+      - 'reference/Ray-TPU.md'
   - 'Developer Guide':
       - 'dev/Port-Models.md'
       - 'dev/GPU-Docker-Dev.md'

--- a/src/levanter/infra/ray_tpu.py
+++ b/src/levanter/infra/ray_tpu.py
@@ -477,34 +477,43 @@ class TPUHostActor:
 # TODO: Python's type system doesn't make it easy to do the abstraction over arity etc here.
 
 @typing.overload
-def tpu_remote(fn: Callable, *,
-               tpu_type: str,
-               num_slices: int = 1,
-               max_retries_preemption: int = 10000,
-               max_retries_failure: int = 10,
-               manager_resources: RayResources | None = None,
-               **kwargs) -> "TpuRemoteFunction":
+def tpu_remote(
+    fn: Callable,
+    *,
+    tpu_type: str,
+    num_slices: int = 1,
+    max_retries_preemption: int = 10000,
+    max_retries_failure: int = 10,
+    manager_resources: RayResources | None = None,
+    **kwargs,
+) -> "TpuRemoteFunction":
     ...
 
 
 @typing.overload
-def tpu_remote(*,
-               tpu_type: str,
-               num_slices: int = 1,
-               max_retries_preemption: int = 10000,
-               max_retries_failure: int = 10,
-               manager_resources: RayResources | None = None,
-               **kwargs) -> Callable[[Callable], "TpuRemoteFunction"]:
+def tpu_remote(
+    fn: None = None,
+    *,
+    tpu_type: str,
+    num_slices: int = 1,
+    max_retries_preemption: int = 10000,
+    max_retries_failure: int = 10,
+    manager_resources: RayResources | None = None,
+    **kwargs,
+) -> Callable[[Callable], "TpuRemoteFunction"]:
     ...
 
 
-def tpu_remote(fn: Callable | None = None, *,
-               tpu_type: str,
-               num_slices: int = 1,
-               max_retries_preemption: int = 10000,
-               max_retries_failure: int = 10,
-               manager_resources: RayResources | None = None,
-               **kwargs) -> Union["TpuRemoteFunction", Callable[[Callable], "TpuRemoteFunction"]]:  # type: ignore
+def tpu_remote(
+    fn: Callable | None = None,
+    *,
+    tpu_type: str,
+    num_slices: int = 1,
+    max_retries_preemption: int = 10000,
+    max_retries_failure: int = 10,
+    manager_resources: RayResources | None = None,
+    **kwargs,
+) -> Union["TpuRemoteFunction", Callable[[Callable], "TpuRemoteFunction"]]:
     """
 
     Decorator to run a function on a TPU pod. The function will be run on a slice of the TPU pod, and will be retried


### PR DESCRIPTION
## Summary
- document the `tpu_remote` decorator, including multi-slice usage and retry behavior
- add reference page to MkDocs navigation
- refine `tpu_remote` type hints to avoid mypy overload overlap

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest tests -m "not entry and not slow and not ray"` *(fails: ProxyError when reaching huggingface.co, FileNotFoundError for sample audio)*

------
https://chatgpt.com/codex/tasks/task_e_688d6d46136c83319ea9a5ae3b422545