### PR TITLE
Add multi-book sliding evaluation

### DIFF
--- a/config/books/eval_sliding_total.yaml
+++ b/config/books/eval_sliding_total.yaml
@@ -1,0 +1,53 @@
+# Config for running eval_sliding_total.py over all available books
+
+base_eval:
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  model:
+    type: llama
+    seq_len: 101
+    hidden_dim: 8192
+    intermediate_dim: 28672
+    num_layers: 80
+    num_heads: 64
+    num_kv_heads: 8
+    flash_attention_block_size: 512
+    use_bias: false
+    use_layer_norm_weight: true
+    initializer_range: 0.02
+    rope:
+      type: "llama3"
+  trainer:
+    seed: 0
+    tracker:
+      type: wandb
+      project: "marin"
+      tags: ["llama3", "eval", "70b"]
+      name: "llama_3.1_70b_multi"
+    mp: p=f32,c=f32
+    per_device_eval_parallelism: -1
+    tensor_parallel_axes: ["mlp", "heads"]
+    fsdp_axis: "embed"
+    batch_axis: "batch"
+  initialize_from_hf: "/opt/gcsfuse_mount/models/meta-llama--Llama-3-1-70B"
+  use_hf_model_config: false
+  chunk_size: 100
+  slice_length: 2000
+  prompt_tokens: 50
+  cursor_inc_chars: 10
+  token_mode: true
+  cursor_inc_tokens: 5
+  eval_batch_size: 64
+  output_base_path: "gs://marin-us-central2/books_evals/llama3.1_70b/"
+
+books:
+  gatsby:
+    txt_path: src/levanter/data/books/gatsby.txt
+  harry_potter_1:
+    txt_path: src/levanter/data/books/hp1.txt
+  curious_incident:
+    txt_path: src/levanter/data/books/curious_incident_of_the_dog_in_the_nighttime.txt
+  we_were_eight_years_in_power:
+    txt_path: src/levanter/data/books/we_were_eight_years_in_power.txt
+  this_is_how_you_lose_her:
+    txt_path: src/levanter/data/books/this_is_how_you_lose_her.txt
+

--- a/src/levanter/main/eval_careless_lm.py
+++ b/src/levanter/main/eval_careless_lm.py
@@ -114,12 +114,12 @@ class EvalCarelessLmConfig:
 
     # Output -------------------------------------------------------------------
     output_base_path: str = "gs://marin-us-central2/books_evals/"  # Base path for all outputs
-    plot_path: str = "bar_plot_char_max_pz_70b.png"
+    plot_path: Optional[str] = None
     eval_batch_size: int = 32
-    histogram_path: str = "pz_distribution_histogram.png"
+    histogram_path: Optional[str] = None
     pz_threshold: float = 0.0001
     book_title: str = "Book"
-    pz_data_path: str = "pz_data.npz"
+    pz_data_path: Optional[str] = None
 
     # Performance tweaks -------------------------------------------------------
     use_dataloader: bool = True  # DataLoader keeps devices busy but uses additional host memory
@@ -261,6 +261,14 @@ def main(cfg: EvalCarelessLmConfig):
             model_name = pathlib.Path(model_path).name.lower()
     elif cfg.hf_checkpoint:
         model_name = str(cfg.hf_checkpoint).split("/")[-1].lower().replace("-", "-")
+
+    # Derive default filenames when not provided
+    if cfg.plot_path is None:
+        cfg.plot_path = f"bar_plot_max_pz_{cfg.book_title}.png"
+    if cfg.histogram_path is None:
+        cfg.histogram_path = f"pz_distribution_histogram_{cfg.book_title}.png"
+    if cfg.pz_data_path is None:
+        cfg.pz_data_path = f"pz_data_{cfg.book_title}.npz"
 
     # Construct full output paths
     full_plot_path = get_full_output_path(cfg, cfg.plot_path)

--- a/src/levanter/main/eval_sliding_total.py
+++ b/src/levanter/main/eval_sliding_total.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+import levanter
+from levanter.main.eval_careless_lm import EvalCarelessLmConfig, main as eval_book
+
+
+@dataclass
+class BookConfig:
+    """Overrides for a single book evaluation."""
+
+    txt_path: str
+    book_title: Optional[str] = None
+    plot_path: Optional[str] = None
+    histogram_path: Optional[str] = None
+    pz_data_path: Optional[str] = None
+    chunk_size: Optional[int] = None
+    slice_length: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    cursor_inc_chars: Optional[int] = None
+    token_mode: Optional[bool] = None
+    cursor_inc_tokens: Optional[int] = None
+    eval_batch_size: Optional[int] = None
+
+
+@dataclass
+class MultiBookEvalConfig:
+    """Configuration for running ``eval_careless_lm`` over many books."""
+
+    base_eval: EvalCarelessLmConfig = field(default_factory=EvalCarelessLmConfig)
+    books: Dict[str, BookConfig] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+def main(cfg: MultiBookEvalConfig):
+    """Run careless suffix evaluation for each book listed in ``cfg``."""
+
+    for name, book in cfg.books.items():
+        # Copy the base configuration and apply overrides for this book
+        book_cfg = dataclasses.replace(cfg.base_eval)
+        for field_name, value in dataclasses.asdict(book).items():
+            if value is not None:
+                setattr(book_cfg, field_name, value)
+
+        # Fill in book title if not provided
+        if not book_cfg.book_title:
+            book_cfg.book_title = name
+
+        # Set per-book output directory under base path
+        base_path = cfg.base_eval.output_base_path.rstrip("/")
+        book_cfg.output_base_path = f"{base_path}/{book_cfg.book_title}/"
+
+        eval_book(book_cfg)
+
+
+if __name__ == "__main__":
+    levanter.config.main(main)()


### PR DESCRIPTION
## Summary
- add `eval_sliding_total.py` driver to run careless suffix likelihood over many books from one config
- default output plot/data names derive from `book_title` when not specified
- include YAML covering all bundled books with automatic per-book subdirectories on GCS

## Testing
- `pytest tests/test_background_iterable.py -k test_reentrancy -q` *(fails: ImportError: cannot import name 'PositionalSharding' from 'jax.sharding')*
- `pip install --quiet "jax==0.4.26" "jaxlib==0.4.26" -f https://storage.googleapis.com/jax-releases/jax_releases.html` *(fails: Could not find a version that satisfies the requirement jax==0.4.26)*
- `pip install --quiet pre-commit && pre-commit run --files src/levanter/main/eval_careless_lm.py src/levanter/main/eval_sliding_total.py config/books/eval_sliding_total.yaml` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68916b50a600832789d90019a3188e1b