### PR TITLE
Add multi-book sliding evaluation

### DIFF
--- a/config/books/eval_sliding_total.yaml
+++ b/config/books/eval_sliding_total.yaml
@@ -1,0 +1,60 @@
+# Example config for running eval_sliding_total.py over the bundled books
+
+base_eval:
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  model:
+    type: llama
+    seq_len: 101
+    hidden_dim: 8192
+    intermediate_dim: 28672
+    num_layers: 80
+    num_heads: 64
+    num_kv_heads: 8
+    flash_attention_block_size: 512
+    use_bias: false
+    use_layer_norm_weight: true
+    initializer_range: 0.02
+    rope:
+      type: "llama3"
+  trainer:
+    seed: 0
+    tracker:
+      type: wandb
+      project: "marin"
+      tags: ["llama3", "eval", "70b"]
+      name: "llama_3.1_70b_multi"
+    mp: p=f32,c=f32
+    per_device_eval_parallelism: -1
+    tensor_parallel_axes: ["mlp", "heads"]
+    fsdp_axis: "embed"
+    batch_axis: "batch"
+  initialize_from_hf: "/opt/gcsfuse_mount/models/meta-llama--Llama-3-1-70B"
+  use_hf_model_config: false
+  chunk_size: 100
+  slice_length: 2000
+  prompt_tokens: 50
+  cursor_inc_chars: 10
+  token_mode: true
+  cursor_inc_tokens: 5
+  # Large batches (e.g. 128) fit during evaluation because FSDP shards
+  # parameters and we avoid gradients or optimizer state.
+  eval_batch_size: 64
+  output_base_path: "gs://marin-us-central2/books_evals/llama3.1_70b/"
+
+books:
+  gatsby:
+    txt_path: src/levanter/data/books/gatsby.txt
+    book_title: gatsby
+  hp1:
+    txt_path: src/levanter/data/books/hp1.txt
+    book_title: harry_potter_1
+  curious_incident:
+    txt_path: src/levanter/data/books/curious_incident_of_the_dog_in_the_nighttime.txt
+    book_title: curious_incident
+  this_is_how_you_lose_her:
+    txt_path: src/levanter/data/books/this_is_how_you_lose_her.txt
+    book_title: this_is_how_you_lose_her
+  we_were_eight_years_in_power:
+    txt_path: src/levanter/data/books/we_were_eight_years_in_power.txt
+    book_title: we_were_eight_years_in_power
+

--- a/src/levanter/main/eval_sliding_total.py
+++ b/src/levanter/main/eval_sliding_total.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+import fsspec
+import levanter
+from levanter.main.eval_careless_lm import EvalCarelessLmConfig, main as eval_book
+
+
+@dataclass
+class BookConfig:
+    """Overrides for a single book evaluation."""
+
+    txt_path: str
+    plot_path: Optional[str] = None
+    histogram_path: Optional[str] = None
+    pz_data_path: Optional[str] = None
+    book_title: str = "Book"
+    chunk_size: Optional[int] = None
+    slice_length: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    cursor_inc_chars: Optional[int] = None
+    token_mode: Optional[bool] = None
+    cursor_inc_tokens: Optional[int] = None
+    eval_batch_size: Optional[int] = None
+
+
+@dataclass
+class MultiBookEvalConfig:
+    """Configuration for running ``eval_careless_lm`` over many books."""
+
+    base_eval: EvalCarelessLmConfig = field(default_factory=EvalCarelessLmConfig)
+    books: Dict[str, BookConfig] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+def main(cfg: MultiBookEvalConfig):
+    """Run careless suffix evaluation for each book listed in ``cfg``."""
+
+    for name, book in cfg.books.items():
+        # Copy the base configuration and apply overrides for this book
+        book_cfg = dataclasses.replace(cfg.base_eval)
+        for field_name, value in dataclasses.asdict(book).items():
+            if value is not None:
+                setattr(book_cfg, field_name, value)
+
+        # Ensure a distinct plot title if none provided explicitly
+        if book_cfg.book_title == "Book":
+            book_cfg.book_title = name
+
+        # Derive default output filenames when not provided
+        if book.plot_path is None:
+            book_cfg.plot_path = f"bar_plot_max_pz_{book_cfg.book_title}.png"
+        if book.histogram_path is None:
+            book_cfg.histogram_path = f"pz_distribution_histogram_{book_cfg.book_title}.png"
+        if book.pz_data_path is None:
+            book_cfg.pz_data_path = f"pz_data_{book_cfg.book_title}.npz"
+
+        # Construct per-book output directory using base path and timestamp
+        ts = datetime.datetime.now().strftime("%Y%m%d%H%M")
+        base = cfg.base_eval.output_base_path.rstrip("/")
+        book_cfg.output_base_path = f"{base}/{book_cfg.book_title}/{ts}/"
+
+        # Ensure the directory exists (works for local or cloud paths)
+        fs, path = fsspec.core.url_to_fs(book_cfg.output_base_path)
+        fs.makedirs(path, exist_ok=True)
+
+        eval_book(book_cfg)
+
+
+if __name__ == "__main__":
+    levanter.config.main(main)()


### PR DESCRIPTION
## Summary
- add `eval_sliding_total.py` driver to run careless suffix likelihood over many books from one config
- provide example `eval_sliding_total.yaml` showing multi-book config structure
- auto-generate per-book output directories and filenames using fsspec
- document why evaluation can use large (e.g., 128) batch sizes when parameters are FSDP-sharded and no gradients/optimizer state are stored

## Testing
- `pytest tests/test_background_iterable.py::test_background_iterable_smoke -q` *(fails: ImportError: cannot import name 'PositionalSharding' from 'jax.sharding')*

------
https://chatgpt.com/codex/tasks/task_e_68916b50a600832789d90019a3188e1b