### PR TITLE
Sliding Window Attention Mask and Attention Sinks

### DIFF
--- a/src/levanter/layers/__init__.py
+++ b/src/levanter/layers/__init__.py
@@ -1,15 +1,25 @@
 __all__ = [
     # attention
     "Attention",
+    "AttentionWithSink",
     "AttentionBackend",
     "AttentionConfig",
     "AttentionMask",
     "dot_product_attention",
+    "dot_product_attention_with_sink",
     # normalization
     "LayerNormConfig",
     "LayerNormConfigBase",
     "RmsNormConfig",
 ]
 
-from .attention import Attention, AttentionBackend, AttentionConfig, AttentionMask, dot_product_attention
+from .attention import (
+    Attention,
+    AttentionBackend,
+    AttentionConfig,
+    AttentionMask,
+    AttentionWithSink,
+    dot_product_attention,
+    dot_product_attention_with_sink,
+)
 from .normalization import LayerNormConfig, LayerNormConfigBase, RmsNormConfig

--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -1225,6 +1225,13 @@ def _tpu_splash_attention(
                 base_mask = splash_attention_mask.CausalMask(shape=(Sq, Sk))
             else:
                 base_mask = splash_attention_mask.FullMask(_shape=(Sq, Sk))
+            if mask.sliding_window is not None:
+                local_mask = splash_attention_mask.LocalMask(
+                    shape=(Sq, Sk),
+                    window_size=(mask.sliding_window - 1, None),
+                    offset=0,
+                )
+                base_mask = splash_attention_mask.LogicalAnd(base_mask, local_mask)
             # This is going to be a pain to support
             if mask.explicit_mask is not None:
                 raise NotImplementedError("Explicit masks are not yet supported for splash attention")

--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -47,7 +47,7 @@ def default_attention_type() -> AttentionBackend:
 
 
 @named_call
-def _dot_product_attention(
+def dot_product_attention(
     QPos: AxisSelector,
     KPos: AxisSelection,
     Key: AxisSelector,
@@ -220,51 +220,6 @@ def _dot_product_attention(
         )
 
 
-def dot_product_attention(
-    QPos: AxisSelector,
-    KPos: AxisSelection,
-    Key: AxisSelector,
-    query: NamedArray,
-    key: NamedArray,
-    value: NamedArray,
-    mask: Optional[Union["AttentionMask", NamedArray]] = None,
-    bias: Optional[NamedArray] = None,
-    attention_dtype: Optional[jnp.dtype] = None,
-    precision: PrecisionLike = None,
-    use_flash: Optional[bool] = None,
-    attn_backend: Optional[AttentionBackend] = None,
-    flash_block_size: Optional[int] = None,
-    dropout: float = 0.0,
-    *,
-    logits_soft_cap: float | None = None,
-    scaling_factor: float | None = None,
-    inference: bool = True,
-    prng: PRNGKeyArray | None = None,
-):
-    """Standard dot-product attention."""
-
-    return _dot_product_attention(
-        QPos,
-        KPos,
-        Key,
-        query,
-        key,
-        value,
-        mask,
-        bias,
-        attention_dtype,
-        precision,
-        use_flash,
-        attn_backend,
-        flash_block_size,
-        dropout,
-        logits_soft_cap=logits_soft_cap,
-        scaling_factor=scaling_factor,
-        inference=inference,
-        prng=prng,
-    )
-
-
 def dot_product_attention_with_sink(
     QPos: AxisSelector,
     KPos: AxisSelection,
@@ -400,45 +355,6 @@ def _simple_attention_with_dropout(
     out = haliax.nn.dropout(weights, dropout, key=prng, inference=inference)
 
     return haliax.dot(out, value, axis=KPos)
-
-
-def simple_attention_with_dropout(
-    QPos: Axis,
-    KPos: Axis,
-    Key: Axis,
-    query: NamedArray,
-    key: NamedArray,
-    value: NamedArray,
-    mask: Optional[Union[NamedArray, "AttentionMask"]] = None,
-    bias: Optional[NamedArray] = None,
-    inference: bool = False,
-    dropout: float = 0.0,
-    attention_dtype: Optional[jnp.dtype] = None,
-    precision: PrecisionLike = None,
-    *,
-    prng: Optional[PRNGKeyArray] = None,
-    scaling_factor: float | None = None,
-    logits_soft_cap: Optional[float] = None,
-):
-    """Dot-product attention with optional dropout and masking."""
-
-    return _simple_attention_with_dropout(
-        QPos,
-        KPos,
-        Key,
-        query,
-        key,
-        value,
-        mask,
-        bias,
-        inference,
-        dropout,
-        attention_dtype,
-        precision,
-        prng=prng,
-        scaling_factor=scaling_factor,
-        logits_soft_cap=logits_soft_cap,
-    )
 
 
 def _try_te_attention(

--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -47,7 +47,7 @@ def default_attention_type() -> AttentionBackend:
 
 
 @named_call
-def dot_product_attention(
+def _dot_product_attention(
     QPos: AxisSelector,
     KPos: AxisSelection,
     Key: AxisSelector,
@@ -174,7 +174,7 @@ def dot_product_attention(
                 logits_soft_cap=logits_soft_cap,
             )
         case AttentionBackend.VANILLA:
-            attention_out = simple_attention_with_dropout(
+            attention_out = _simple_attention_with_dropout(
                 QPos,
                 KPos,
                 Key,
@@ -220,7 +220,137 @@ def dot_product_attention(
         )
 
 
-def simple_attention_with_dropout(
+def dot_product_attention(
+    QPos: AxisSelector,
+    KPos: AxisSelection,
+    Key: AxisSelector,
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    mask: Optional[Union["AttentionMask", NamedArray]] = None,
+    bias: Optional[NamedArray] = None,
+    attention_dtype: Optional[jnp.dtype] = None,
+    precision: PrecisionLike = None,
+    use_flash: Optional[bool] = None,
+    attn_backend: Optional[AttentionBackend] = None,
+    flash_block_size: Optional[int] = None,
+    dropout: float = 0.0,
+    *,
+    logits_soft_cap: float | None = None,
+    scaling_factor: float | None = None,
+    inference: bool = True,
+    prng: PRNGKeyArray | None = None,
+):
+    """Standard dot-product attention."""
+
+    return _dot_product_attention(
+        QPos,
+        KPos,
+        Key,
+        query,
+        key,
+        value,
+        mask,
+        bias,
+        attention_dtype,
+        precision,
+        use_flash,
+        attn_backend,
+        flash_block_size,
+        dropout,
+        logits_soft_cap=logits_soft_cap,
+        scaling_factor=scaling_factor,
+        inference=inference,
+        prng=prng,
+    )
+
+
+def dot_product_attention_with_sink(
+    QPos: AxisSelector,
+    KPos: AxisSelection,
+    Key: AxisSelector,
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    attn_sink: NamedArray,
+    mask: Optional[Union["AttentionMask", NamedArray]] = None,
+    bias: Optional[NamedArray] = None,
+    attention_dtype: Optional[jnp.dtype] = None,
+    precision: PrecisionLike = None,
+    use_flash: Optional[bool] = None,
+    attn_backend: Optional[AttentionBackend] = None,
+    flash_block_size: Optional[int] = None,
+    dropout: float = 0.0,
+    *,
+    logits_soft_cap: float | None = None,
+    scaling_factor: float | None = None,
+    inference: bool = True,
+    prng: PRNGKeyArray | None = None,
+):
+    """Dot-product attention variant with a learned sink term per head.
+
+    The sink is implemented by appending a dummy key/value of zeros and
+    inserting the sink logit via the bias term at the final key position.
+    """
+
+    QPos = query.resolve_axis(QPos)
+    KPos = key.resolve_axis(KPos)
+    Key = query.resolve_axis(Key)
+
+    KPos1 = KPos.resize(1)
+    KPosPlus = KPos.resize(KPos.size + 1)
+
+    zero_key_axes = tuple(KPos1 if ax == KPos else ax for ax in key.axes)
+    zero_key = hax.zeros(zero_key_axes, dtype=key.dtype)
+    key = hax.concatenate(KPosPlus, [key, zero_key])
+
+    zero_val_axes = tuple(KPos1 if ax == KPos else ax for ax in value.axes)
+    zero_val = hax.zeros(zero_val_axes, dtype=value.dtype)
+    value = hax.concatenate(KPosPlus, [value, zero_val])
+
+    m = materialize_mask(mask, QPos, KPos)
+    if m is not None:
+        sink_mask_axes = tuple(KPos1 if ax == KPos else ax for ax in m.axes)
+        sink_mask = hax.ones(sink_mask_axes, dtype=m.dtype)
+        m = hax.concatenate(KPosPlus, [m, sink_mask])
+
+    bias_axes_prefix = tuple(ax for ax in query.axes if ax != Key)
+    sink_bias = attn_sink
+    for ax in bias_axes_prefix:
+        if ax not in sink_bias.axes:
+            sink_bias = sink_bias.broadcast_axis(ax)
+    sink_bias = sink_bias.broadcast_axis(KPos1)
+
+    if bias is not None:
+        bias = hax.concatenate(KPosPlus, [bias, sink_bias])
+    else:
+        zero_bias_axes = bias_axes_prefix + (KPos,)
+        zero_bias = hax.zeros(zero_bias_axes, dtype=sink_bias.dtype)
+        bias = hax.concatenate(KPosPlus, [zero_bias, sink_bias])
+
+    return dot_product_attention(
+        QPos,
+        KPosPlus,
+        Key,
+        query,
+        key,
+        value,
+        m,
+        bias,
+        attention_dtype,
+        precision,
+        use_flash,
+        attn_backend,
+        flash_block_size,
+        dropout,
+        logits_soft_cap=logits_soft_cap,
+        scaling_factor=scaling_factor,
+        inference=inference,
+        prng=prng,
+    )
+
+
+def _simple_attention_with_dropout(
     QPos: Axis,
     KPos: Axis,
     Key: Axis,
@@ -270,6 +400,45 @@ def simple_attention_with_dropout(
     out = haliax.nn.dropout(weights, dropout, key=prng, inference=inference)
 
     return haliax.dot(out, value, axis=KPos)
+
+
+def simple_attention_with_dropout(
+    QPos: Axis,
+    KPos: Axis,
+    Key: Axis,
+    query: NamedArray,
+    key: NamedArray,
+    value: NamedArray,
+    mask: Optional[Union[NamedArray, "AttentionMask"]] = None,
+    bias: Optional[NamedArray] = None,
+    inference: bool = False,
+    dropout: float = 0.0,
+    attention_dtype: Optional[jnp.dtype] = None,
+    precision: PrecisionLike = None,
+    *,
+    prng: Optional[PRNGKeyArray] = None,
+    scaling_factor: float | None = None,
+    logits_soft_cap: Optional[float] = None,
+):
+    """Dot-product attention with optional dropout and masking."""
+
+    return _simple_attention_with_dropout(
+        QPos,
+        KPos,
+        Key,
+        query,
+        key,
+        value,
+        mask,
+        bias,
+        inference,
+        dropout,
+        attention_dtype,
+        precision,
+        prng=prng,
+        scaling_factor=scaling_factor,
+        logits_soft_cap=logits_soft_cap,
+    )
 
 
 def _try_te_attention(
@@ -617,6 +786,18 @@ def _materialize_segment_mask(segment_ids, QPos, KPos, q_slice, k_slice) -> Name
     return q_segment_ids.broadcast_axis(sub_KPos) == kv_segment_ids
 
 
+def _materialize_sliding_window_mask(
+    window: int, QPos: Axis, KPos: Axis, q_slice: haliax.dslice, k_slice: haliax.dslice
+) -> NamedArray:
+    """Materialize a causal sliding window mask."""
+    sub_q = QPos.resize(q_slice.size)
+    sub_k = KPos.resize(k_slice.size)
+    q_pos = hax.arange(sub_q) + q_slice.start
+    k_pos = hax.arange(sub_k) + k_slice.start
+    diff = q_pos.broadcast_axis(sub_k) - k_pos.broadcast_axis(sub_q)
+    return (diff >= 0) & (diff < window)
+
+
 class AttentionMask(eqx.Module):
     """
 
@@ -646,6 +827,7 @@ class AttentionMask(eqx.Module):
     is_causal: bool = eqx.field(static=True)
     explicit_mask: Optional[NamedArray] = None
     segment_ids: Optional[NamedArray] = None
+    sliding_window: Optional[int] = eqx.field(default=None, static=True)
     # CF https://github.com/jax-ml/jax/blob/47858c4ac2fd4757a3b6fc5bb2981b71a71f00c2/jax/experimental/pallas/ops/tpu/flash_attention.py#L34
     # TODO: add prefixlm
     # cf https://github.com/google-research/t5x/blob/51a99bff8696c373cc03918707ada1e98cbca407/t5x/examples/decoder_only/layers.py#L978
@@ -674,6 +856,12 @@ class AttentionMask(eqx.Module):
 
         mask = combine_masks_and(causal, explicit)
 
+        if self.sliding_window is not None:
+            sw_mask = _materialize_sliding_window_mask(
+                self.sliding_window, QPos, KPos, q_slice=q_slice, k_slice=k_slice
+            )
+            mask = combine_masks_and(mask, sw_mask)
+
         if self.segment_ids is not None:
             segment_mask = _materialize_segment_mask(self.segment_ids, QPos, KPos, q_slice, k_slice)
             mask = combine_masks_and(mask, segment_mask)
@@ -681,28 +869,68 @@ class AttentionMask(eqx.Module):
         return mask
 
     @staticmethod
-    def causal() -> "AttentionMask":
-        return AttentionMask(is_causal=True)
+    def causal(sliding_window: Optional[int] = None) -> "AttentionMask":
+        """Create a causal AttentionMask.
+
+        Args:
+            sliding_window: If provided, restrict each query position to attend only to keys within
+                ``sliding_window`` previous positions.
+        """
+        return AttentionMask(is_causal=True, sliding_window=sliding_window)
 
     @staticmethod
     def explicit(mask: NamedArray) -> "AttentionMask":
         return AttentionMask(is_causal=False, explicit_mask=mask)
 
     def with_segment_ids(self, segment_ids: NamedArray) -> "AttentionMask":
-        return AttentionMask(is_causal=self.is_causal, explicit_mask=self.explicit_mask, segment_ids=segment_ids)
+        return AttentionMask(
+            is_causal=self.is_causal,
+            explicit_mask=self.explicit_mask,
+            segment_ids=segment_ids,
+            sliding_window=self.sliding_window,
+        )
+
+    def with_sliding_window(self, sliding_window: int | None) -> "AttentionMask":
+        """Return a copy of this mask with ``sliding_window`` applied."""
+        return AttentionMask(
+            is_causal=self.is_causal,
+            explicit_mask=self.explicit_mask,
+            segment_ids=self.segment_ids,
+            sliding_window=sliding_window,
+        )
 
     def __and__(self, other) -> "AttentionMask":
         is_causal = self.is_causal or other.is_causal
         explicit_mask = combine_masks_and(self.explicit_mask, other.explicit_mask)
         segment_ids = self._check_for_same_segment_ids(other)
+        if self.sliding_window is None:
+            sliding_window = other.sliding_window
+        elif other.sliding_window is None:
+            sliding_window = self.sliding_window
+        else:
+            sliding_window = min(self.sliding_window, other.sliding_window)
 
-        return AttentionMask(is_causal=is_causal, explicit_mask=explicit_mask, segment_ids=segment_ids)
+        return AttentionMask(
+            is_causal=is_causal,
+            explicit_mask=explicit_mask,
+            segment_ids=segment_ids,
+            sliding_window=sliding_window,
+        )
 
     def __or__(self, other) -> "AttentionMask":
         is_causal = self.is_causal and other.is_causal
         explicit_mask = combine_masks_or(self.explicit_mask, other.explicit_mask)
         segment_ids = self._check_for_same_segment_ids(other)
-        return AttentionMask(is_causal=is_causal, explicit_mask=explicit_mask, segment_ids=segment_ids)
+        if self.sliding_window is None or other.sliding_window is None:
+            sliding_window = None
+        else:
+            sliding_window = max(self.sliding_window, other.sliding_window)
+        return AttentionMask(
+            is_causal=is_causal,
+            explicit_mask=explicit_mask,
+            segment_ids=segment_ids,
+            sliding_window=sliding_window,
+        )
 
     def _check_for_same_segment_ids(self, other):
         if self.segment_ids is not None and other.segment_ids is not None:
@@ -1229,6 +1457,88 @@ class Attention(eqx.Module):
         )
 
         # Flatten heads and apply output projection
+        attn_output = attn_output.flatten_axes(("kv_heads", "q_heads_per_group"), "heads")
+        attn_output = attn_output.astype(x.dtype)
+        attn_output = self.o_proj(attn_output, key=key_o)
+
+        return attn_output
+
+
+class AttentionWithSink(Attention):
+    """Attention module that includes a learned sink term per head.
+
+    The sink is added to the softmax denominator, reducing the attention mass
+    assigned to tokens and allowing some probability to fall into a separate
+    bucket. This can improve stability during generation.
+    """
+
+    sinks: NamedArray | None = None
+
+    @staticmethod
+    def init(config: AttentionConfig, *, key) -> "AttentionWithSink":
+        base = Attention.init(config, key=key)
+        sinks = hax.zeros((config.KVHeads, config.QHeadsPerGroup), dtype=jnp.float32)
+        return AttentionWithSink(
+            base.config,
+            base.q_proj,
+            base.k_proj,
+            base.v_proj,
+            base.o_proj,
+            base.q_norm,
+            base.k_norm,
+            base.rot_embs,
+            sinks,
+        )
+
+    @named_call
+    def __call__(
+        self, x: NamedArray, mask: Optional[NamedArray | AttentionMask], *, key=None, pos_ids: NamedArray | None = None
+    ) -> NamedArray:
+        key_q, key_k, key_v, key_o = maybe_rng_split(key, 4)
+
+        q_proj = self.q_proj(x, key=key_q)
+        k_proj = self.k_proj(x, key=key_k)
+        v = self.v_proj(x, key=key_v)
+
+        if self.config.qk_norm is not None:
+            q = self.q_norm(q_proj)  # type: ignore[misc]
+            k = self.k_norm(k_proj)  # type: ignore[misc]
+        else:
+            q = q_proj
+            k = k_proj
+
+        q = q.rearrange((..., "kv_heads", "q_heads_per_group", "position", "head_size"))
+        k = k.rearrange((..., "kv_heads", "position", "head_size"))
+        v = v.rearrange((..., "kv_heads", "position", "head_size"))
+
+        if self.rot_embs is not None:
+            if pos_ids is None:
+                pos_ids = hax.arange(x.resolve_axis("position"), dtype=jnp.int32)
+            q = self.rot_embs(q, pos_ids)
+            k = self.rot_embs(k, pos_ids)
+
+        k = k.rename({"position": "key_position"})
+        v = v.rename({"position": "key_position"})
+
+        attn_output = dot_product_attention_with_sink(
+            "position",
+            "key_position",
+            "head_size",
+            q,
+            k,
+            v,
+            self.sinks,
+            mask,
+            attention_dtype=jnp.float32 if self.config.upcast_attn else x.dtype,
+            attn_backend=self.config.attn_backend,
+            flash_block_size=self.config.flash_attention_block_size,
+            scaling_factor=self.config.scaling_factor,
+            logits_soft_cap=self.config.logits_soft_cap,
+            dropout=0.0,
+            inference=True,
+            prng=key,
+        )
+
         attn_output = attn_output.flatten_axes(("kv_heads", "q_heads_per_group"), "heads")
         attn_output = attn_output.astype(x.dtype)
         attn_output = self.o_proj(attn_output, key=key_o)

--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -174,7 +174,7 @@ def dot_product_attention(
                 logits_soft_cap=logits_soft_cap,
             )
         case AttentionBackend.VANILLA:
-            attention_out = _simple_attention_with_dropout(
+            attention_out = simple_attention_with_dropout(
                 QPos,
                 KPos,
                 Key,
@@ -305,7 +305,7 @@ def dot_product_attention_with_sink(
     )
 
 
-def _simple_attention_with_dropout(
+def simple_attention_with_dropout(
     QPos: Axis,
     KPos: Axis,
     Key: Axis,
@@ -561,9 +561,9 @@ def _te_materialize_mask(KPos, QPos, batch_size, mask):
 
             fused_attn_mask = mask.materialize(QPos, KPos)
 
-            assert (
-                fused_attn_mask is not None
-            ), "If AttentionMask is causal, the materialized array should never be None. Something is wrong."
+            assert fused_attn_mask is not None, (
+                "If AttentionMask is causal, the materialized array should never be None. Something is wrong."
+            )
 
             fused_attn_mask = fused_attn_mask.array
             fused_attn_mask = jnp.dstack([fused_attn_mask] * batch_size)
@@ -873,8 +873,7 @@ def materialize_mask(
     KPos: Axis,
     q_slice: Optional[haliax.dslice] = None,
     k_slice: Optional[haliax.dslice] = None,
-) -> NamedArray:
-    ...
+) -> NamedArray: ...
 
 
 @overload
@@ -884,8 +883,7 @@ def materialize_mask(
     KPos: Axis,
     q_slice: Optional[haliax.dslice] = None,
     k_slice: Optional[haliax.dslice] = None,
-) -> Optional[NamedArray]:
-    ...
+) -> Optional[NamedArray]: ...
 
 
 def materialize_mask(
@@ -1238,9 +1236,9 @@ class AttentionConfig:
     """Configuration for QK normalization. If None, no normalization is applied."""
 
     def __post_init__(self):
-        assert (
-            self.num_heads % self.num_kv_heads == 0
-        ), f"num_heads={self.num_heads} not divisible by num_kv_heads={self.num_kv_heads}."
+        assert self.num_heads % self.num_kv_heads == 0, (
+            f"num_heads={self.num_heads} not divisible by num_kv_heads={self.num_kv_heads}."
+        )
 
     @property
     def head_size(self) -> int:

--- a/src/levanter/models/lm_model.py
+++ b/src/levanter/models/lm_model.py
@@ -31,6 +31,7 @@ class LmExample(eqx.Module):
         ignore_id: Optional[int] = None,
         eos_id: Optional[int] = None,
         segment_ids: Optional[hax.NamedArray] = None,
+        sliding_window: int | None = None,
     ) -> "LmExample":
         if tokens.ndim != 1:
             raise ValueError("tokens must be a 1D array")
@@ -54,7 +55,7 @@ class LmExample(eqx.Module):
 
         loss_mask = loss_mask.astype(jnp.int32)
 
-        attn_mask = AttentionMask.causal()
+        attn_mask = AttentionMask.causal(sliding_window=sliding_window)
 
         if eos_id is not None and segment_ids is None:
             # the next token after an eos token is in a new segment
@@ -76,9 +77,10 @@ class LmExample(eqx.Module):
         *,
         ignore_id: Optional[int] = None,
         all_causal: bool = True,
+        sliding_window: int | None = None,
     ) -> "LmExample":
         if all_causal:
-            attn_mask = AttentionMask.causal()
+            attn_mask = AttentionMask.causal(sliding_window=sliding_window)
         else:
             # causal just for the completion part. We don't have a special structured mask for this, so we just
             raise NotImplementedError("Not implemented yet")

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -381,7 +381,8 @@ def test_segment_ids_are_respected(impl):
     assert_trees_all_close(result.array[3:, 1], 0.0, atol=1e-3, rtol=1e-3)
 
 
-def attention_ref(
+# Reference implementation of Attention Sink with Sliding Window from https://github.com/openai/gpt-oss/blob/main/gpt_oss/triton/attention.py
+def sink_attention_ref_gpt_oss(
     query,
     key,
     value,
@@ -426,7 +427,7 @@ def attention_ref(
     return output
 
 
-def attention(
+def sink_attention(
     query,
     key,
     value,


### PR DESCRIPTION
## Summary
- support sliding window attention via `AttentionMask` and materialization helpers
- allow `LmExample` builders to specify sliding window masks
- test causal sliding window masking
- introduce attention sink support through `AttentionWithSink` and `dot_product_attention_with_sink`
- implement sink by appending zero key/value and biasing the final logit so all backends can handle sinks without custom softmax

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_attention.py tests/test_sharded_dataset.py::test_resolve_audio_pointer` *(fails: FileNotFoundError: https://ccrma.stanford.edu/~jos/mp3/trumpet.mp3)*

------
https://chatgpt.com/codex/tasks/task_e_689357f863f08322b2d7589f16a2ed1b