### PR TITLE
Repro for TPU initialization error

### DIFF
--- a/src/levanter/infra/ray_tpu.py
+++ b/src/levanter/infra/ray_tpu.py
@@ -702,7 +702,7 @@ def _stop_actor(actor: ActorHandle) -> None:
         # but it doesn't really matter
         ray.get(actor.teardown.remote(), timeout=_TEARDOWN_ACTOR_TIMEOUT)
         ray.get(actor.__ray_terminate__.remote(), timeout=_TERMINATE_ACTOR_TIMEOUT)
-    except ActorDiedError:
+    except (ActorDiedError, ActorUnavailableError):
         # This is expected because the actor will terminate within  __ray_terminate__() task,
         # so the task will never succeed.
         pass

--- a/tests/test_ray_tpu.py
+++ b/tests/test_ray_tpu.py
@@ -427,7 +427,6 @@ def fail_on_slice_0_fn():
     return np.array(data)
 
 
-
 # Multislice failure: one slice fails, the whole thing should retry and eventually fail.
 @pytest.mark.ray
 def test_multislice_one_slice_fails():

--- a/tests/test_ray_tpu.py
+++ b/tests/test_ray_tpu.py
@@ -6,6 +6,7 @@ import jax.random as jrandom
 import numpy as np
 import pytest
 import ray
+from ray.actor import ActorHandle
 from jax.lax import with_sharding_constraint
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
@@ -49,7 +50,6 @@ skip_if_no_multislice = pytest.mark.skipif(
 
 
 # Base function for tests, similar to the one in ray_tpu.py
-@ray.remote(max_calls=1)
 def simple_jax_fn():
     import jax
 
@@ -104,6 +104,29 @@ def simple_jax_fn():
     return np.array(output)
 
 
+@ray.remote(max_calls=1)
+def remote_simple_jax_fn():
+    return simple_jax_fn()
+
+
+@ray.remote
+class CounterActor:
+    def __init__(self):
+        self._count = 0
+
+    def increment(self) -> None:
+        self._count += 1
+
+    def count(self) -> int:
+        return self._count
+
+
+
+# Want to try:
+# Task fails on first slice but not second
+# Some amount of sleeping
+
+
 # --- Single Slice Tests ---
 
 
@@ -114,7 +137,7 @@ def test_single_slice_simple_run():
         pytest.skip("TPU not available for single slice test")
 
     num_slices = 1
-    results = run_on_pod(simple_jax_fn, "v4-8", num_slices=num_slices)
+    results = run_on_pod(remote_simple_jax_fn, "v4-8", num_slices=num_slices)
 
     assert results is not None
     assert len(results) == num_slices
@@ -125,7 +148,7 @@ def test_single_slice_simple_run():
     assert results[0].shape == (4,)  # Based on simple_jax_fn's output dim_out
 
     # Verify a second run works
-    results_2 = run_on_pod(simple_jax_fn, "v4-8", num_slices=num_slices)
+    results_2 = run_on_pod(remote_simple_jax_fn, "v4-8", num_slices=num_slices)
     assert len(results_2) == 1
     assert isinstance(results_2[0], np.ndarray)
     assert np.array_equal(results[0], results_2[0])  # Deterministic function
@@ -139,19 +162,56 @@ def test_single_slice_run_twice():
 
     num_slices = 1
     # First run
-    results1 = run_on_pod(simple_jax_fn, "v4-8", num_slices=num_slices)
+    results1 = run_on_pod(remote_simple_jax_fn, "v4-8", num_slices=num_slices)
     assert len(results1) == 1
     assert isinstance(results1[0], np.ndarray)
     assert results1[0].shape == (4,)
 
     # Second run
-    results2 = run_on_pod(simple_jax_fn, "v4-8", num_slices=num_slices)
+    results2 = run_on_pod(remote_simple_jax_fn, "v4-8", num_slices=num_slices)
     assert len(results2) == 1
     assert isinstance(results2[0], np.ndarray)
     assert results2[0].shape == (4,)
 
     # Check if results are the same (since PRNGKey is fixed)
     assert np.array_equal(results1[0], results2[0])
+
+
+@pytest.mark.ray
+def test_single_slice_fail_once():
+    """1. Run a simple function on a single slice and verify it runs correctly."""
+    if not _TPU_AVAILABLE:
+        pytest.skip("TPU not available for single slice test")
+
+    num_slices = 1
+    results = run_on_pod(fail_once_jax_fn, "v4-8", num_slices=num_slices, max_retries_failure=1)
+
+    counter_actor = CounterActor.remote()
+
+    @ray.remote(max_calls=1)
+    def fail_once_jax_fn() -> None:
+        # do JAX work first
+        result = simple_jax_fn()
+        # fail on the first run
+        count = ray.get(counter_actor.count.remote())
+        ray.get(counter_actor.increment.remote())
+        if count == 0:
+            raise DeliberatelyRaisedException(f"Failing deliberately because count is {count}")
+        return result
+
+    assert results is not None
+    assert len(results) == num_slices
+
+    # For `num_slices=1` with "v4-8" (1 host per slice):
+    assert len(results) == 1  # One result because one host in total for one v4-8 slice.
+    assert isinstance(results[0], np.ndarray)
+    assert results[0].shape == (4,)  # Based on simple_jax_fn's output dim_out
+
+    # Verify a second run works
+    results_2 = run_on_pod(remote_simple_jax_fn, "v4-8", num_slices=num_slices)
+    assert len(results_2) == 1
+    assert isinstance(results_2[0], np.ndarray)
+    assert np.array_equal(results[0], results_2[0])  # Deterministic function
 
 
 # --- Multislice Tests ---
@@ -166,7 +226,7 @@ def test_multislice_simple_run():
     num_slices = 2
     tpu_type = "v4-8"  # Each slice is a v4-8
 
-    results = run_on_pod(simple_jax_fn, tpu_type, num_slices=num_slices)
+    results = run_on_pod(remote_simple_jax_fn, tpu_type, num_slices=num_slices)
 
     # run_on_pod_new returns a flat list of results from all hosts across all slices.
     # If each v4-8 slice has 1 host (as per TPU-v4-8-head resource meaning),
@@ -193,14 +253,14 @@ def test_multislice_run_twice():
     tpu_type = "v4-8"
 
     # First run
-    results1 = run_on_pod(simple_jax_fn, tpu_type, num_slices=num_slices)
+    results1 = run_on_pod(remote_simple_jax_fn, tpu_type, num_slices=num_slices)
     assert len(results1) == num_slices
     for i in range(num_slices):
         assert isinstance(results1[i], np.ndarray)
         assert np.array_equal(results1[i], results1[0])  # All slices should be same
 
     # Second run
-    results2 = run_on_pod(simple_jax_fn, tpu_type, num_slices=num_slices)
+    results2 = run_on_pod(remote_simple_jax_fn, tpu_type, num_slices=num_slices)
     assert len(results2) == num_slices
     for i in range(num_slices):
         assert isinstance(results2[i], np.ndarray)
@@ -209,6 +269,52 @@ def test_multislice_run_twice():
     # Compare first and second run (should be identical)
     for i in range(num_slices):
         assert np.array_equal(results1[i], results2[i])
+
+
+@pytest.mark.ray
+def test_multislice_fail_once():
+    """Run a simple function on two slices and verify it runs correctly
+    when the first slice will fail on the first run."""
+    # NOTE: This is currently causing a TPU initialization failure:
+    # https://gist.github.com/yifanmai/88c7d56f31c2558ee79cd45b97ad5de0
+
+    if not _MULTISLICE_POSSIBLE:
+        pytest.skip("Not enough TPUs for multislice test")
+
+    num_slices = 2
+    counter_actor = CounterActor.remote()
+
+    @ray.remote(max_calls=1)
+    def fail_once_on_first_slice_jax_fn() -> None:
+        import time
+        # do JAX work first
+        result = simple_jax_fn()
+        # fail on the first run one the first slice
+        slice_id_str = os.getenv("MEGASCALE_SLICE_ID")
+        if slice_id_str == "0":
+            count = ray.get(counter_actor.count.remote())
+            ray.get(counter_actor.increment.remote())
+            if count == 0:
+                raise DeliberatelyRaisedException(f"Failing deliberately because count is {count}")
+        # sleeping for a while makes the TPU initialization error repro more consistent
+        time.sleep(30)
+        return result
+
+    results = run_on_pod(fail_once_on_first_slice_jax_fn, "v4-8", num_slices=num_slices, max_retries_failure=1)
+
+    # run_on_pod_new returns a flat list of results from all hosts across all slices.
+    # If each v4-8 slice has 1 host (as per TPU-v4-8-head resource meaning),
+    # then for num_slices=2, we expect 2 results in the list.
+    assert results is not None
+    assert len(results) == num_slices  # num_slices * hosts_per_slice (assuming 1 host per v4-8 slice)
+
+    for i in range(num_slices):
+        assert isinstance(results[i], np.ndarray)
+        assert results[i].shape == (4,)
+        if i > 0:
+            # Due to MEGASCALE_SLICE_ID, the PRNG key might differ effectively if the code used it.
+            # simple_jax_fn uses a fixed PRNGKey(0) so all slices should produce identical results.
+            assert np.array_equal(results[i], results[0])
 
 
 @ray.remote(max_calls=1)
@@ -320,6 +426,7 @@ def fail_on_slice_0_fn():
     key = jrandom.PRNGKey(int(slice_id_str) if slice_id_str else 42)
     data = jrandom.normal(key, (4,))
     return np.array(data)
+
 
 
 # Multislice failure: one slice fails, the whole thing should retry and eventually fail.

--- a/tests/test_ray_tpu.py
+++ b/tests/test_ray_tpu.py
@@ -6,7 +6,6 @@ import jax.random as jrandom
 import numpy as np
 import pytest
 import ray
-from ray.actor import ActorHandle
 from jax.lax import with_sharding_constraint
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P


### PR DESCRIPTION
`test_multislice_fail_once()` is a repro for the TPU initialization error. Example command: `python ../marin/marin/run/ray_run.py --pip_deps pytest --env_vars PYTHONPATH src -- pytest tests/test_ray_tpu.py::test_multislice_fail_once -m ray -vvv -s`

Error message:

```
ray::fail_once_on_first_slice_jax_fn() (pid=48133, ip=10.130.2.221)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/jax/_src/xla_bridge.py", line 828, in _init_backend
    backend = registration.factory()
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/jax/_src/xla_bridge.py", line 161, in tpu_client_timer_callback
    client = make_tpu_client(
             ^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/jax/_src/xla_bridge.py", line 145, in make_tpu_client
    return _jax.get_c_api_client('tpu', options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jaxlib._jax.XlaRuntimeError: UNKNOWN: TPU initialization failed: open(/dev/accel3): Operation not permitted: Operation not permitted; Couldn't open device: /dev/accel3; [/dev/accel3]

During handling of the above exception, another exception occurred:

ray::fail_once_on_first_slice_jax_fn() (pid=48133, ip=10.130.2.221)
  File "/tmp/ray/session_2025-08-08_14-42-32_801915_755/runtime_resources/working_dir_files/_ray_pkg_969bc412e08f1ad3/tests/test_ray_tpu.py", line 288, in fail_once_on_first_slice_jax_fn
    result = do_simple_jax_work()
             ^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2025-08-08_14-42-32_801915_755/runtime_resources/working_dir_files/_ray_pkg_969bc412e08f1ad3/tests/test_ray_tpu.py", line 55, in do_simple_jax_work
    jax.devices()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/jax/_src/xla_bridge.py", line 942, in devices
    return get_backend(backend).devices()
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/jax/_src/xla_bridge.py", line 876, in get_backend
    return _get_backend_uncached(platform)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/jax/_src/xla_bridge.py", line 855, in _get_backend_uncached
    bs = backends()
         ^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/jax/_src/xla_bridge.py", line 758, in backends
    raise RuntimeError(err_msg)
RuntimeError: Unable to initialize backend 'tpu': UNKNOWN: TPU initialization failed: open(/dev/accel3): Operation not permitted: Operation not permitted; Couldn't open device: /dev/accel3; [/dev/accel3]  (set JAX_PLATFORMS='' to automatically choose an available backend)
```