### PR TITLE
Add structured JSON logger tracker

### DIFF
--- a/docs/reference/Trackers.md
+++ b/docs/reference/Trackers.md
@@ -7,7 +7,7 @@ In the latest version, we introduce the [levanter.tracker.Tracker][] interface, 
 The interface name is taken from the [HuggingFace Accelerate](https://github.com/huggingface/accelerate/blob/0f2686c8d3e6d949c4b7efa15d7f2dee44f7ce91/src/accelerate/tracking.py#L395)
 framework.
 
-Given Levanter's historical dependency on W&B, the interface is designed to look similar to W&B's API.
+Levanter ships with trackers for W&B, TensorBoard, and a lightweight JSON logger that emits structured log lines. The interface is designed to look similar to W&B's API.
 The methods currently exposed are:
 
 * [levanter.tracker.current_tracker][]: returns the current tracker instance or sets it.
@@ -93,6 +93,8 @@ TODO: expand this section.
 
 ::: levanter.tracker.wandb.WandbTracker
 
+::: levanter.tracker.json_logger.JsonLoggerTracker
+
 ### Tracker Config
 
 ::: levanter.tracker.TrackerConfig
@@ -102,3 +104,5 @@ TODO: expand this section.
 ::: levanter.tracker.tensorboard.TensorboardConfig
 
 ::: levanter.tracker.wandb.WandbConfig
+
+::: levanter.tracker.json_logger.JsonLoggerConfig

--- a/src/levanter/tracker/json_logger.py
+++ b/src/levanter/tracker/json_logger.py
@@ -1,0 +1,120 @@
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+import jax
+
+from levanter.tracker import Tracker
+from levanter.tracker.histogram import Histogram
+from levanter.tracker.tracker import TrackerConfig
+from levanter.utils.jax_utils import jnp_to_python
+
+
+logger = logging.getLogger(__name__)
+
+
+def _to_jsonable(value: Any):
+    """Recursively convert ``value`` to something JSON serializable."""
+    if isinstance(value, dict):
+        return {k: _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(v) for v in value]
+    if isinstance(value, Histogram):
+        return {
+            "min": jnp_to_python(value.min),
+            "max": jnp_to_python(value.max),
+            "num": jnp_to_python(value.num),
+            "sum": jnp_to_python(value.sum),
+            "sum_squares": jnp_to_python(value.sum_squares),
+            "bucket_limits": jnp_to_python(value.bucket_limits),
+            "bucket_counts": jnp_to_python(value.bucket_counts),
+        }
+    if isinstance(value, jax.Array):
+        return jnp_to_python(value)
+    return value
+
+
+def _flatten(metrics: Mapping[str, Any], prefix: str = "") -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in metrics.items():
+        name = f"{prefix}/{k}" if prefix else k
+        if isinstance(v, Mapping):
+            out.update(_flatten(v, name))
+        else:
+            out[name] = v
+    return out
+
+
+class JsonLoggerTracker(Tracker):
+    """Tracker that logs metrics to a Python logger as JSON lines."""
+
+    name: str = "json_logger"
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self.logger = logger or logging.getLogger("levanter.json_logger")
+        self._last_metrics: dict[str, Any] = {}
+        self._summary_metrics: dict[str, Any] = {}
+
+    def log_hyperparameters(self, hparams: dict[str, Any]):
+        record = {
+            "tracker": self.name,
+            "event": "hparams",
+            "hparams": _to_jsonable(hparams),
+        }
+        self.logger.info(json.dumps(record))
+
+    def log(self, metrics: Mapping[str, Any], *, step: Optional[int], commit: Optional[bool] = None):
+        del commit
+        record = {
+            "tracker": self.name,
+            "event": "log",
+            "step": step,
+            "metrics": _to_jsonable(metrics),
+        }
+        self.logger.info(json.dumps(record))
+        if step is not None:
+            self._last_metrics.update(_flatten(metrics))
+
+    def log_summary(self, metrics: Mapping[str, Any]):
+        record = {
+            "tracker": self.name,
+            "event": "summary",
+            "metrics": _to_jsonable(metrics),
+        }
+        self.logger.info(json.dumps(record))
+        self._summary_metrics.update(_flatten(metrics))
+
+    def log_artifact(self, artifact_path, *, name: Optional[str] = None, type: Optional[str] = None):
+        record = {
+            "tracker": self.name,
+            "event": "artifact",
+            "path": artifact_path,
+            "name": name,
+            "artifact_type": type,
+        }
+        self.logger.info(json.dumps(record))
+
+    def finish(self):
+        summary = {**self._summary_metrics, **self._last_metrics}
+        record = {
+            "tracker": self.name,
+            "event": "finish",
+            "summary": _to_jsonable(summary),
+        }
+        self.logger.info(json.dumps(record))
+
+
+@TrackerConfig.register_subclass("json_logger")
+@dataclass
+class JsonLoggerConfig(TrackerConfig):
+    """Configuration for :class:`JsonLoggerTracker`."""
+
+    logger_name: str = "levanter.json_logger"
+    level: int = logging.INFO
+
+    def init(self, run_id: Optional[str]) -> JsonLoggerTracker:
+        del run_id
+        log = logging.getLogger(self.logger_name)
+        log.setLevel(self.level)
+        return JsonLoggerTracker(log)

--- a/tests/test_json_logger.py
+++ b/tests/test_json_logger.py
@@ -1,0 +1,27 @@
+import json
+import logging
+from io import StringIO
+
+import jax.numpy as jnp
+
+from levanter.tracker.json_logger import JsonLoggerTracker
+
+
+def test_json_logger_tracker_logs_and_finishes():
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("test_json_logger")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    tracker = JsonLoggerTracker(logger)
+    tracker.log({"a": 1, "b": jnp.array(2)}, step=1)
+    tracker.log_summary({"c": 3})
+    tracker.finish()
+
+    logs = [json.loads(l) for l in stream.getvalue().strip().splitlines()]
+    assert logs[0]["event"] == "log"
+    assert logs[0]["metrics"]["a"] == 1
+    assert logs[-1]["event"] == "finish"
+    assert logs[-1]["summary"]["a"] == 1
+    assert logs[-1]["summary"]["c"] == 3


### PR DESCRIPTION
## Summary
- add JsonLoggerTracker that emits structured JSON logs and summarizes final metrics
- document JSON logger tracker

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_json_logger.py -m "not entry and not slow and not ray"`


------
https://chatgpt.com/codex/tasks/task_e_68a74a1148b483318334b296548db320