### PR TITLE
Fix: Correct implementation in scion.py

### DIFF
--- a/src/levanter/optim/scion.py
+++ b/src/levanter/optim/scion.py
@@ -1,3 +1,20 @@
+# Revised by Wanyun Xie (wanyun.xie@epfl.ch)
+# 1. Changed the scaling factor calculation in the `transform_linear_layer` function to use sqrt(d_out/d_in), removing the conditional maximum with 1. 
+# 2. Added the scaling factor 1/d_in in `scale_by_sign`.
+# 3. Added scaling factors `spectral_radius` and `sign_radius` to allow for additional scaling after orthogonalization.
+# 4. Removed weight decay, since Scion does a convex combination with learning rate directly.
+# 5. Removed scion_to_signum_lr as its role is replaced by the scaling factors `spectral_radius` and `sign_radius`.
+# 6. Added BiasRMS_transform that applies RMS normalization to bias parameters.
+
+# Other tips:
+# - Note that we usually set `sign_radius` larger than `spectral_radius`. This is opposite to the original setting `signum_lr = learning_rate * 0.25`.
+# - Tuning lr and spectral_radius/sign_radius is important and can be transferred from a small proxy model. `spectral_radius=50` and `sign_radius=3000` is what we set for modded-nanogpt, not for this one.
+# - Could choose constrained or unconstrained version of Scion by setting `unconstrained` flag.
+# - Not sure how necessary to set different momentum for Spectral and Sign.
+# - Not sure how necessary to set `max_grad_norm` for Sign.
+# - It's okay to still keep Sign for bias parameters, but without 1/d scaling as we suggested in Table 6 of Scion paper https://arxiv.org/abs/2502.07529.
+
+
 import dataclasses
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -26,13 +43,15 @@ class ScionConfig(OptimizerConfig):
     """
 
     lr: float = 0.02
-    scion_to_signum_lr: float = 0.25  # Scaling factor between AdamW and Scion learning rates
+    # scion_to_signum_lr: float = 0.25  
     momentum: float = 0.95
     backend_steps: int = 10  # Number of steps for Newton-Schulz orthogonalization
-    weight_decay: float = 0.0
     beta1: float = 0.9
-    scion_epsilon: float = 1e-8
+    epsilon: float = 1e-8
     max_grad_norm: float = 1.0
+    unconstrained: bool = False
+    spectral_radius: float = 50
+    sign_radius : float = 3000
 
     def build(self, num_train_steps):
         """
@@ -41,31 +60,40 @@ class ScionConfig(OptimizerConfig):
         learning_rate_schedule = self.lr_scheduler(num_train_steps)
 
         def optimizer(learning_rate):
-            signum_lr = learning_rate * self.scion_to_signum_lr
-
-            def scion_transform():
+            # signum_lr = learning_rate * self.scion_to_signum_lr
+            def Spectral_transform():
                 components = []
-                components.append(scale_with_scion(self.momentum, self.backend_steps, self.scion_epsilon))
-                if self.weight_decay > 0:
-                    components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
+                components.append(scale_with_spectral(self.momentum, self.backend_steps, self.epsilon, self.spectral_radius))
+                if not self.unconstrained:
+                    components.append(optax.add_decayed_weights(1, self.build_weight_decay_mask()))
                 components.append(optax.scale(-learning_rate))
                 optimizer = optax.chain(*components)
                 return optimizer
 
-            def signum_transform():
+            def Sign_transform():
                 components = []
                 if self.max_grad_norm:
                     components.append(optax.clip_by_global_norm(self.max_grad_norm))
-                components.append(scale_by_signum(self.beta1))
-                if self.weight_decay > 0:
-                    components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
-                components.append(optax.scale(-signum_lr))
+                components.append(scale_by_sign(self.beta1, self.sign_radius))
+                if not self.unconstrained:
+                    components.append(optax.add_decayed_weights(1, self.build_weight_decay_mask()))
+                components.append(optax.scale(-learning_rate))
+                optimizer = optax.chain(*components)
+                return optimizer
+
+            def BiasRMS_transform():
+                components = []
+                components.append(scale_by_biasrms(momentum=self.momentum, eps=self.epsilon))
+                if not self.unconstrained:
+                    components.append(optax.add_decayed_weights(1, self.build_weight_decay_mask()))
+                components.append(optax.scale(-learning_rate))
                 optimizer = optax.chain(*components)
                 return optimizer
 
             transformations = {
-                "scion": scion_transform(),
-                "signum": signum_transform(),
+                "Spectral": Spectral_transform(),
+                "Sign": Sign_transform(),
+                "BiasRMS": BiasRMS_transform(),
             }
 
             return optax.multi_transform(transformations, self.create_mask)
@@ -74,7 +102,7 @@ class ScionConfig(OptimizerConfig):
 
     def create_mask(self, params):
         """
-        Creates a mask that labels parameters as 'scion' or 'signum' based on their
+        Creates a mask that labels parameters as 'Spectral' or 'Sign' based on their
         dimensionality and module path, using AdamW for Embedding and lm_head parameters.
         """
         paths = leaf_key_paths(params)
@@ -82,12 +110,12 @@ class ScionConfig(OptimizerConfig):
         def mask_fn(param, path):
             path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
             if "Embedding" in path_str or "lm_head" in path_str:
-                return "signum"
+                return "Sign"
             elif isinstance(param, Linear):
                 # scion for linear layers
-                return dataclasses.replace(param, weight="scion", bias="signum" if param.bias is not None else None)
+                return dataclasses.replace(param, weight="Spectral", bias="BiasRMS" if param.bias is not None else None)
             else:
-                return "signum"
+                return "Sign"
 
         return jax.tree_util.tree_map(mask_fn, params, paths, is_leaf=lambda x: isinstance(x, Linear))
 
@@ -98,7 +126,7 @@ class ScaleByScionState(NamedTuple):
     momentum_buffer: optax.Updates
 
 
-def scale_by_signum(momentum=0.95):
+def scale_by_sign(momentum=0.95, sign_radius=3000):
     def init_fn(params):
         momentum_buffer = otu.tree_zeros_like(params)  # First moment
         return ScaleByScionState(momentum_buffer=momentum_buffer)
@@ -112,14 +140,14 @@ def scale_by_signum(momentum=0.95):
             is_leaf=lambda x: x is None,
         )
 
-        updates = jax.tree_map(lambda u: None if u is None else jnp.sign(u), buf, is_leaf=lambda x: x is None)
+        updates = jax.tree_map(lambda u: None if u is None else sign_radius/u.shape[1] * jnp.sign(u), buf, is_leaf=lambda x: x is None)
 
         return updates, ScaleByScionState(momentum_buffer=buf)
 
     return optax.GradientTransformation(init_fn, update_fn)
 
 
-def scale_with_scion(momentum=0.95, steps=5, scion_eps=1e-8):
+def scale_with_spectral(momentum=0.95, steps=5, eps=1e-8, spectral_radius=50):
     def init_fn(params):
         momentum_buffer = otu.tree_zeros_like(params)  # First moment
         return ScaleByScionState(momentum_buffer=momentum_buffer)
@@ -137,16 +165,45 @@ def scale_with_scion(momentum=0.95, steps=5, scion_eps=1e-8):
         def transform_linear_layer(layer: haliax.nn.Linear):
             assert layer.weight.ndim == 2
 
-            updated_weight_array = zeropower_via_newtonschulz5(layer.weight.array, steps=steps, eps=scion_eps)
+            updated_weight_array = zeropower_via_newtonschulz5(layer.weight.array, steps=steps, eps=eps)
 
-            scale = jnp.sqrt(jnp.maximum(1, updated_weight_array.shape[0] / updated_weight_array.shape[1]))
-            updated_weight_array *= scale
+            # scale = jnp.sqrt(jnp.maximum(1, updated_weight_array.shape[0] / updated_weight_array.shape[1]))
+            scale = jnp.sqrt(updated_weight_array.shape[0] / updated_weight_array.shape[1])
+            updated_weight_array *= scale * spectral_radius
 
             updated_weight = dataclasses.replace(layer.weight, array=updated_weight_array)
 
             return dataclasses.replace(layer, weight=updated_weight)  # type: ignore
 
         updates = map_flattened_linear_layers(transform_linear_layer, updates)
+
+        return updates, ScaleByScionState(momentum_buffer=buf)
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+def scale_by_biasrms(momentum=0.95, eps=1e-8):
+    def init_fn(params):
+        momentum_buffer = otu.tree_zeros_like(params)  # First moment
+        return ScaleByScionState(momentum_buffer=momentum_buffer)
+
+    def update_fn(updates, state, params=None):
+        buf = state.momentum_buffer
+        buf = jax.tree.map(
+            lambda m, g: None if g is None else momentum * m + (1 - momentum) * g,
+            buf,
+            updates,
+            is_leaf=lambda x: x is None,
+        )
+
+        def rms_normalize_and_sign(u):
+            if u is None:
+                return None
+            rms_values = jnp.sqrt(jnp.mean(u ** 2, axis=0, keepdims=True))
+            u_normalized = u / (rms_values + eps)
+            return u_normalized
+        
+        updates = jax.tree_map(rms_normalize_and_sign, buf, is_leaf=lambda x: x is None)
 
         return updates, ScaleByScionState(momentum_buffer=buf)
 


### PR DESCRIPTION
Hello! Thank you for the great work and for implementing the optimizer from our paper, "Training Deep Learning Models with Norm-Constrained LMOs".

I noticed a few minor discrepancies between the current implementation and the details described in our paper. I've submitted this pull request to align the code more closely with the original algorithm. Detailed comments and explanations have also been added to the top of the optim/scion.py file.

1. Changed the scaling factor calculation in the `transform_linear_layer` function to use sqrt(d_out/d_in), removing the conditional maximum with 1. 
2. Added the scaling factor 1/d_in in `scale_by_sign`.
3. Added scaling factors `spectral_radius` and `sign_radius` to allow for additional scaling after orthogonalization.
4. Removed weight decay, since Scion does a convex combination with learning rate directly.
5. Removed scion_to_signum_lr as its role is replaced by the scaling factors `spectral_radius` and `sign_radius`.
6. Added BiasRMS_transform that applies RMS normalization to bias parameters.