### PR TITLE
chore: show slow tests in CI

### DIFF
--- a/.github/workflows/run_entry_tests.yaml
+++ b/.github/workflows/run_entry_tests.yaml
@@ -25,5 +25,5 @@ jobs:
         run: uv sync --dev
       - name: Test with pytest
         run: |
-          PYTHONPATH=tests:src:. uv run pytest tests -m "entry"
+          PYTHONPATH=tests:src:. uv run pytest tests -m "entry" --durations=20
 

--- a/.github/workflows/run_ray_tests.yaml
+++ b/.github/workflows/run_ray_tests.yaml
@@ -24,5 +24,5 @@ jobs:
         run: uv sync --dev
       - name: Test with pytest
         run: |
-          PYTHONPATH=tests:src:. uv run pytest tests -m "ray"
+          PYTHONPATH=tests:src:. uv run pytest tests -m "ray" --durations=20
 

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -27,4 +27,4 @@ jobs:
       - name: Test with pytest
         run: |
           # check we are using the right jax version
-          PYTHONPATH=tests:src:. uv run --with "jax[cpu]==${{ matrix.jax-version }}" pytest tests -m "not entry and not slow and not ray"
+          PYTHONPATH=tests:src:. uv run --with "jax[cpu]==${{ matrix.jax-version }}" pytest tests -m "not entry and not slow and not ray" --durations=20

--- a/.github/workflows/tpu_unit_tests.yaml
+++ b/.github/workflows/tpu_unit_tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Run most tests
         run: |
           export TPU_NAME=ci-run-${{ github.run_id }}
-          gcloud compute tpus tpu-vm ssh $TPU_NAME --zone ${TPU_ZONE} --command "JAX_TRACEBACK_FILTERING=off PYTHONPATH=$PYTHONPATH:levanter/tests CI=1 bash levanter/infra/run.sh pytest levanter/tests -m 'not entry and not ray'"
+          gcloud compute tpus tpu-vm ssh $TPU_NAME --zone ${TPU_ZONE} --command "JAX_TRACEBACK_FILTERING=off PYTHONPATH=$PYTHONPATH:levanter/tests CI=1 bash levanter/infra/run.sh pytest levanter/tests -m 'not entry and not ray' --durations=20"
 # Something's wrong with these
 #
 #      - name: Run forked tests


### PR DESCRIPTION
## Summary
- report slowest tests in standard workflow
- surface slow tests for entry, ray, and TPU test runs

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest tests -m "not entry and not slow and not ray"` *(fails: ProxyError and missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c312f0d6088331a3706d8be694ff53