### PR TITLE
Reenable TPU ragged paged attention

### DIFF
--- a/src/levanter/layers/attention.py
+++ b/src/levanter/layers/attention.py
@@ -22,8 +22,6 @@ try:
     from jax.experimental.pallas.ops.tpu.ragged_paged_attention import (
         ragged_paged_attention as tpu_ragged_paged_attention,
     )
-
-    raise ImportError("Disabling TPU ragged paged attention until bugs are fixed.")
 except Exception:  # pragma: no cover - optional dep
     tpu_ragged_paged_attention = None
 


### PR DESCRIPTION
We can reenable RPA since shape error bug (https://github.com/marin-community/levanter/issues/1176) is already fixed by https://github.com/marin-community/levanter/pull/1192