### PR TITLE
Support ignoring EOS token during generation for controllable benchmarking

### DIFF
--- a/src/levanter/inference/engine.py
+++ b/src/levanter/inference/engine.py
@@ -932,6 +932,7 @@ class InferenceEngine:
         max_num_tokens = np.zeros((max_slots,), dtype=np.int32)
         temperatures = np.zeros((max_slots,), dtype=np.float32)
         prng_keys = np.zeros((max_slots, 2), dtype=np.uint32)
+        ignore_eos = np.zeros((max_slots,), dtype=bool)
         if stop_tokens_template is not None:
             stop_tokens = np.full(
                 (
@@ -985,6 +986,7 @@ class InferenceEngine:
             max_num_tokens[prefill_idx] = np.asarray(seq_params.max_num_tokens, dtype=np.int32).item()
             temperatures[prefill_idx] = np.asarray(seq_params.temperature, dtype=np.float32).item()
             prng_keys[prefill_idx] = np.asarray(seq_params.key, dtype=np.uint32)
+            ignore_eos[prefill_idx] = np.asarray(seq_params.ignore_eos, dtype=bool).item()
             if stop_tokens is not None:
                 if seq_params.stop_tokens is None:
                     stop_tokens[prefill_idx].fill(INVALID)
@@ -1024,6 +1026,7 @@ class InferenceEngine:
                     max_num_tokens[clone_idx] = np.asarray(child_params.max_num_tokens, dtype=np.int32).item()
                     temperatures[clone_idx] = np.asarray(child_params.temperature, dtype=np.float32).item()
                     prng_keys[clone_idx] = np.asarray(child_params.key, dtype=np.uint32)
+                    ignore_eos[clone_idx] = np.asarray(child_params.ignore_eos, dtype=bool).item()
                     if stop_tokens is not None:
                         stop_tokens[clone_idx] = stop_tokens[prefill_idx]
 
@@ -1058,6 +1061,7 @@ class InferenceEngine:
                 ),
                 temperature=jnp.asarray(temperatures, dtype=jnp.float32),
                 key=jnp.asarray(prng_keys, dtype=jnp.uint32),
+                ignore_eos=jnp.asarray(ignore_eos, dtype=bool),
             ),
         )
 

--- a/src/levanter/inference/jit_scheduler.py
+++ b/src/levanter/inference/jit_scheduler.py
@@ -48,6 +48,7 @@ class SeqDecodingParams(eqx.Module):
     stop_tokens: ht.i32[NamedArray, "stop_seq position"] | None
     temperature: jnp.ndarray
     key: jaxtyping.PRNGKeyArray
+    ignore_eos: jnp.ndarray = eqx.field(default_factory=lambda: jnp.array(False, dtype=bool))
 
     @staticmethod
     def default() -> "SeqDecodingParams":
@@ -60,6 +61,7 @@ class SeqDecodingParams(eqx.Module):
             stop_tokens=None,
             temperature=jnp.array(0.0, dtype=jnp.float32),
             key=jax.random.PRNGKey(0),
+            ignore_eos=jnp.array(False, dtype=bool),
         )
 
 
@@ -109,6 +111,8 @@ class DecodeState(eqx.Module):
     """temperature for sampling. 0 means greedy sampling"""
     prng_keys: jaxtyping.PRNGKeyArray
     """one per sequence, used for sampling. This is a JAX PRNG key, so it can be split to get new keys."""
+    ignore_eos: ht.bool_[NamedArray, "seq"]
+    """If True, ignore EOS/stop tokens and continue generation until max_num_tokens is reached."""
 
     # Token queue for pending decode work
     tqueue: "TokenQueue"
@@ -269,6 +273,7 @@ class DecodeState(eqx.Module):
                 max_num_tokens=new_state.max_num_tokens.at["seq", local_slot_id].set(seq_params.max_num_tokens),
                 temperature=new_state.temperature.at["seq", local_slot_id].set(seq_params.temperature),
                 prng_keys=self.prng_keys.at[local_slot_id].set(seq_params.key),  # type: ignore[name-defined]
+                ignore_eos=new_state.ignore_eos.at["seq", local_slot_id].set(seq_params.ignore_eos),
             )
             match (new_state.stop_tokens, seq_params.stop_tokens):
                 case (None, None):
@@ -330,12 +335,16 @@ class DecodeState(eqx.Module):
                 max_allowed = self.max_num_tokens["seq", sid].scalar()
                 len_done = (pos + 1) >= max_allowed
                 stop_done = False
+                # Only check for stop tokens if ignore_eos is False
                 if self.stop_tokens is not None:
                     stop_len = self.stop_tokens.axis_size("position")
                     row = tkns["seq", sid].array
                     padded = jnp.concatenate([jnp.full((stop_len,), INVALID, dtype=jnp.int32), row])
                     tail = jax.lax.dynamic_slice(padded, (pos + 1,), (stop_len,))
-                    stop_done = is_stop_signal(hax.named(tail, axis=("position",)), self.stop_tokens["seq", sid]).array
+                    stop_signal = is_stop_signal(hax.named(tail, axis=("position",)), self.stop_tokens["seq", sid]).array
+                    # Only consider stop signal if ignore_eos is False
+                    should_check_stop = ~self.ignore_eos["seq", sid].scalar()
+                    stop_done = stop_signal & should_check_stop
                 f = f.at["seq", sid].set(len_done | stop_done)
                 should_purge = should_purge.at["position", i].set(len_done | stop_done)
 
@@ -442,6 +451,7 @@ max_num_tokens: {max_num_tokens}
             ),
             temperature=hax.ones({"seq": max_seqs}, dtype=jnp.float32),
             prng_keys=jax.vmap(jax.random.PRNGKey, axis_size=max_seqs, in_axes=None)(0),
+            ignore_eos=hax.zeros({"seq": max_seqs}, dtype=bool),
             tqueue=TokenQueue.init(max_queued_tokens),
             finished=hax.zeros({"seq": max_seqs}, dtype=bool),
         )

--- a/src/levanter/inference/openai.py
+++ b/src/levanter/inference/openai.py
@@ -85,6 +85,7 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: Optional[Union[str, Dict]] = None
     parallel_tool_calls: Optional[bool] = None
     user: Optional[str] = None
+    ignore_eos: Optional[bool] = Field(default=False, description="Ignore EOS tokens and continue until max_tokens")
 
 
 class CompletionRequest(BaseModel):
@@ -108,6 +109,7 @@ class CompletionRequest(BaseModel):
     temperature: float = Field(default=1.0, description="Sampling temperature")
     top_p: Optional[float] = None
     user: Optional[str] = None
+    ignore_eos: Optional[bool] = Field(default=False, description="Ignore EOS tokens and continue until max_tokens")
 
 
 class TokensRequest(BaseModel):
@@ -162,6 +164,7 @@ class InferenceRequest:
     future: asyncio.Future
     n_generations: int = 1
     enable_logprobs: bool = False
+    ignore_eos: bool = False
 
 
 @dataclass
@@ -272,6 +275,7 @@ class InferenceContext:
         future: asyncio.Future,
         n_generations: int = 1,
         enable_logprobs: bool = False,
+        ignore_eos: bool = False,
     ) -> str:
         """Submit a request to the inference queue"""
         assert self.shutdown_event.is_set() is False, "InferenceContext is shut down"
@@ -288,6 +292,7 @@ class InferenceContext:
             future=future,
             n_generations=n_generations,
             enable_logprobs=enable_logprobs,
+            ignore_eos=ignore_eos,
         )
 
         logger.info("Enqueuing request %s", request)
@@ -390,6 +395,7 @@ class InferenceContext:
                 stop_tokens=stop_ids,
                 temperature=jnp.array(req.temperature, dtype=jnp.float32),
                 key=jrandom.PRNGKey(req.seed if req.seed is not None else i),
+                ignore_eos=jnp.array(req.ignore_eos, dtype=bool),
             )
 
             service_req = Request(
@@ -507,6 +513,7 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
                 future=future,
                 n_generations=request.n or 1,
                 enable_logprobs=bool(request.logprobs),
+                ignore_eos=request.ignore_eos or False,
             )
 
         # Wait for all results
@@ -626,6 +633,7 @@ async def _create_chat_completion(ctx: InferenceContext, request: ChatCompletion
             future=future,
             n_generations=request.n or 1,
             enable_logprobs=request.logprobs,
+            ignore_eos=request.ignore_eos or False,
         )
 
         # Wait for result

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -157,3 +157,56 @@ def test_reuse_with_clones_and_slot_reassignment():
     reqs2 = build_requests(100)
     outputs2 = svc.generate(reqs2)
     assert all(out == [3] for out in outputs2.tokens)
+
+
+def test_ignore_eos_parameter():
+    """Test that ignore_eos parameter correctly controls whether generation stops at EOS tokens."""
+    svc = _build_service()
+
+    prompt = [[1, 2]]
+    stop_tokens = [3]  # DummyModel always emits token 3 (EOS)
+
+    stop_ids = hax.named(jnp.asarray(stop_tokens, dtype=jnp.int32), axis=("position",)).broadcast_axis({"stop_seq": 1})
+
+    # Test 1: ignore_eos=False (default) - should stop after first EOS token
+    seq_params_respect_eos = SeqDecodingParams(
+        max_num_tokens=jnp.array(len(prompt[0]) + 10, dtype=jnp.int32),  # Allow up to 10 tokens
+        stop_tokens=stop_ids,
+        temperature=jnp.array(0.0, dtype=jnp.float32),
+        key=jax.random.PRNGKey(0),
+        ignore_eos=jnp.array(False, dtype=bool),  # Explicitly set to False
+    )
+    req_respect_eos = Request(
+        prompt_tokens=prompt[0], request_id=0, decode_params=seq_params_respect_eos, n_generations=1
+    )
+
+    result_respect_eos = svc.generate([req_respect_eos])
+
+    # Should stop after generating exactly 1 token (the EOS token)
+    assert len(result_respect_eos.tokens[0]) == 1, f"Expected 1 token, got {len(result_respect_eos.tokens[0])}"
+    assert result_respect_eos.tokens[0] == [3], f"Expected [3], got {result_respect_eos.tokens[0]}"
+    assert result_respect_eos.total_generated == 1
+
+    # Test 2: ignore_eos=True - should continue generating until max_num_tokens
+    max_tokens_to_generate = 5
+    seq_params_ignore_eos = SeqDecodingParams(
+        max_num_tokens=jnp.array(len(prompt[0]) + max_tokens_to_generate, dtype=jnp.int32),
+        stop_tokens=stop_ids,
+        temperature=jnp.array(0.0, dtype=jnp.float32),
+        key=jax.random.PRNGKey(1),
+        ignore_eos=jnp.array(True, dtype=bool),  # Set to True to ignore EOS
+    )
+    req_ignore_eos = Request(
+        prompt_tokens=prompt[0], request_id=1, decode_params=seq_params_ignore_eos, n_generations=1
+    )
+
+    result_ignore_eos = svc.generate([req_ignore_eos])
+
+    # Should generate exactly max_tokens_to_generate tokens, all should be EOS (token 3)
+    assert (
+        len(result_ignore_eos.tokens[0]) == max_tokens_to_generate
+    ), f"Expected {max_tokens_to_generate} tokens, got {len(result_ignore_eos.tokens[0])}"
+    assert all(
+        token == 3 for token in result_ignore_eos.tokens[0]
+    ), f"Expected all tokens to be 3, got {result_ignore_eos.tokens[0]}"
+    assert result_ignore_eos.total_generated == max_tokens_to_generate

--- a/tests/inference/test_inference_server.py
+++ b/tests/inference/test_inference_server.py
@@ -41,7 +41,7 @@ def baby_llama_config():
             max_seq_len=16,
             max_seqs=2,
             page_size=4,
-            max_queued_tokens=8,
+            max_queued_tokens=16,  # Must be >= max_seqs_in_prefill (default 16)
         ),
         temperature=0.7,
         seed=42,
@@ -503,12 +503,12 @@ def test_logprobs_match_full_forward_pass(test_client, loaded_model, trainer_con
     print(f"Server returned {len(choice.logprobs.content)} tokens:")
     for i, token_logprob in enumerate(choice.logprobs.content):
         token_str = token_logprob.token
-        # Encode the token string to get the ID
-        token_ids = tokenizer.encode(token_str, add_special_tokens=False)
-        print(f"  Token {i}: '{token_str}' -> {token_ids}, logprob={token_logprob.logprob}")
-        if len(token_ids) == 1:
-            generated_token_ids.append(token_ids[0])
-            server_logprobs.append(token_logprob.logprob)
+        token_id = tokenizer.convert_tokens_to_ids(token_str)
+        print(f"  Token {i}: '{token_str}' -> {token_id}, logprob={token_logprob.logprob}")
+        if token_id is None:
+            continue
+        generated_token_ids.append(int(token_id))
+        server_logprobs.append(token_logprob.logprob)
 
     print(f"Generated {len(generated_token_ids)} tokens: {generated_token_ids}")
     print(f"Server logprobs: {server_logprobs}")
@@ -564,3 +564,209 @@ def test_logprobs_match_full_forward_pass(test_client, loaded_model, trainer_con
         assert diff < 3e-3, f"Logprob mismatch at token {i}: server={server_lp}, model={model_lp}, diff={diff}"
 
     print("All logprobs match successfully!")
+
+
+@pytest.mark.slow
+def test_ignore_eos_generates_until_max_tokens(test_client, loaded_model):
+    """Test that ignore_eos=True generates tokens until max_tokens is reached, ignoring stop tokens."""
+    client, server = test_client
+    model, tokenizer = loaded_model
+
+    # Get EOS token ID from tokenizer
+    eos_token_id = tokenizer.eos_token_id
+    eos_token = tokenizer.decode([eos_token_id])
+
+    print(f"EOS token ID: {eos_token_id}, EOS token: '{eos_token}'")
+
+    # Test 1: Without ignore_eos (default behavior) - should stop at EOS or stop token
+    response_with_stop = client.post(
+        "/v1/completions",
+        json={
+            "model": "timinar/baby-llama-58m",
+            "prompt": "Hello",
+            "max_tokens": 10,
+            "temperature": 0.0,
+            "seed": 42,
+            "ignore_eos": False,
+        },
+    )
+
+    assert response_with_stop.status_code == 200
+    completion_with_stop = Completion.model_validate(response_with_stop.json())
+    tokens_with_stop = completion_with_stop.usage.completion_tokens
+
+    print(f"With ignore_eos=False: generated {tokens_with_stop} tokens")
+    print(f"Text: '{completion_with_stop.choices[0].text}'")
+
+    # Test 2: With ignore_eos=True - should generate exactly max_tokens
+    response_ignore_eos = client.post(
+        "/v1/completions",
+        json={
+            "model": "timinar/baby-llama-58m",
+            "prompt": "Hello",
+            "max_tokens": 2,
+            "temperature": 0.0,
+            "seed": 42,
+            "ignore_eos": True,
+        },
+    )
+
+    assert response_ignore_eos.status_code == 200
+    completion_ignore_eos = Completion.model_validate(response_ignore_eos.json())
+    tokens_ignore_eos = completion_ignore_eos.usage.completion_tokens
+
+    print(f"With ignore_eos=True: generated {tokens_ignore_eos} tokens")
+    print(f"Text: '{completion_ignore_eos.choices[0].text}'")
+
+    # With ignore_eos=True, should generate exactly max_tokens
+    assert tokens_ignore_eos == 2, f"Expected exactly 2 tokens, got {tokens_ignore_eos}"
+
+
+@pytest.mark.slow
+def test_ignore_eos_with_explicit_stop_tokens(test_client):
+    """Test that ignore_eos=True ignores explicit stop tokens."""
+    client, server = test_client
+
+    # Use a stop token is the set to the first token that's expected to be generated
+    stop_token = " butterfly"
+
+    # Test 1: Without ignore_eos - should stop at stop token
+    response_with_stop = client.post(
+        "/v1/completions",
+        json={
+            "model": "timinar/baby-llama-58m",
+            "prompt": "The quick brown",
+            "max_tokens": 10,
+            "temperature": 0.7,
+            "seed": 42,
+            "stop": stop_token,
+            "ignore_eos": False,
+        },
+    )
+
+    assert response_with_stop.status_code == 200
+    completion_with_stop = Completion.model_validate(response_with_stop.json())
+    tokens_with_stop = completion_with_stop.usage.completion_tokens
+    text_with_stop = completion_with_stop.choices[0].text
+    # With ignore_eos=True, should generate max_tokens even with stop token
+    assert tokens_with_stop == 1, f"Expected exactly 1 tokens, got {tokens_with_stop}"
+
+    print(f"With stop='{stop_token}' and ignore_eos=False:")
+    print(f"  Generated {tokens_with_stop} tokens")
+    print(f"  Text: '{text_with_stop}'")
+
+    # Test 2: With ignore_eos=True - should ignore stop token
+    response_ignore_eos = client.post(
+        "/v1/completions",
+        json={
+            "model": "timinar/baby-llama-58m",
+            "prompt": "The quick brown",
+            "max_tokens": 10,
+            "temperature": 0.7,
+            "seed": 42,
+            "stop": stop_token,
+            "ignore_eos": True,
+        },
+    )
+
+    assert response_ignore_eos.status_code == 200
+    completion_ignore_eos = Completion.model_validate(response_ignore_eos.json())
+    tokens_ignore_eos = completion_ignore_eos.usage.completion_tokens
+    text_ignore_eos = completion_ignore_eos.choices[0].text
+
+    print(f"With stop='{stop_token}' and ignore_eos=True:")
+    print(f"  Generated {tokens_ignore_eos} tokens")
+    print(f"  Text: '{text_ignore_eos}'")
+
+    # With ignore_eos=True, should generate max_tokens even with stop token
+    assert tokens_ignore_eos == 10, f"Expected exactly 10 tokens, got {tokens_ignore_eos}"
+
+    # Should generate more or equal tokens than without ignore_eos
+    assert (
+        tokens_ignore_eos >= tokens_with_stop
+    ), f"ignore_eos=True ({tokens_ignore_eos}) should generate >= tokens than with stop ({tokens_with_stop})"
+
+
+@pytest.mark.slow
+def test_ignore_eos_with_chat_completion(test_client):
+    """Test that ignore_eos works with chat completions endpoint."""
+    client, server = test_client
+
+    # Test 1: Without ignore_eos (default)
+    response_default = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "timinar/baby-llama-58m",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 2,
+            "temperature": 0.0,
+            "seed": 42,
+            "ignore_eos": False,
+        },
+    )
+
+    assert response_default.status_code == 200
+    chat_default = ChatCompletion.model_validate(response_default.json())
+    tokens_default = chat_default.usage.completion_tokens
+
+    print(f"Chat with ignore_eos=False: generated {tokens_default} tokens")
+
+    # Test 2: With ignore_eos=True
+    response_ignore_eos = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "timinar/baby-llama-58m",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 2,
+            "temperature": 0.0,
+            "seed": 42,
+            "ignore_eos": True,
+        },
+    )
+
+    assert response_ignore_eos.status_code == 200
+    chat_ignore_eos = ChatCompletion.model_validate(response_ignore_eos.json())
+    tokens_ignore_eos = chat_ignore_eos.usage.completion_tokens
+
+    print(f"Chat with ignore_eos=True: generated {tokens_ignore_eos} tokens")
+
+    # With ignore_eos=True, should generate exactly max_tokens
+    assert tokens_ignore_eos == 2, f"Expected exactly 2 tokens, got {tokens_ignore_eos}"
+
+    # Should generate at least as many tokens as default
+    assert (
+        tokens_ignore_eos >= tokens_default
+    ), f"ignore_eos=True ({tokens_ignore_eos}) should generate >= tokens than default ({tokens_default})"
+
+
+@pytest.mark.slow
+def test_ignore_eos_with_multiple_generations(test_client):
+    """Test that ignore_eos works with n > 1 (multiple generations)."""
+    client, server = test_client
+
+    response = client.post(
+        "/v1/completions",
+        json={
+            "model": "timinar/baby-llama-58m",
+            "prompt": "Once upon a time",
+            "max_tokens": 2,
+            "temperature": 0.7,
+            "seed": 42,
+            "n": 2,
+            "ignore_eos": True,
+        },
+    )
+
+    assert response.status_code == 200
+    completion = Completion.model_validate(response.json())
+
+    assert len(completion.choices) == 2
+
+    for i, choice in enumerate(completion.choices):
+        print(f"Choice {i}: generated {len(choice.text.split())} words")
+        print(f"  Text: '{choice.text}'")
+
+    # Both generations should have exactly max_tokens
+    assert completion.usage.completion_tokens == 4, f"Expected 4 tokens total (2 * 2), got {completion.usage.completion_tokens}"
+
+    print("All generations produced max_tokens with ignore_eos=True")


### PR DESCRIPTION
Standard inference benchmarks like those used by [Semi Analysis](https://github.com/InferenceMAX/InferenceMAX) requires controllable output sequence lengths to simulate traffic types with different mixtures of prefill vs decode. Thus, `ignore_eos` has become a common flag supported by both vLLM and SGLang so that the engines can ignore the EOS token and generate until a specified `max_num_tokens`.

This PR introduces `ignore_eos` support to Levanter along with 5 unit tests to ensure that this flag is respected by both the engine and the inference server. You can run the unit tests by:
```
uv run pytest tests/inference/test_engine.py tests/inference/test_inference_server.py
```