### PR TITLE
Handle oversized microbatch sizes gracefully

### DIFF
--- a/src/levanter/grad_accum.py
+++ b/src/levanter/grad_accum.py
@@ -79,14 +79,23 @@ def microbatched(
     if microbatch_size <= 0:
         raise ValueError(f"Bad value for {microbatch_size=}")
 
+    if microbatch_size >= batch_size:
+        return fn
+
     num_micro_steps = batch_size // microbatch_size
 
-    if num_micro_steps == 1:
-        return fn
+    if num_micro_steps <= 0:
+        raise ValueError(
+            f"microbatch_size ({microbatch_size}) must be less than batch size ({batch_size}) or divisible into it"
+        )
 
     Microbatch = Batch.resize(microbatch_size)
     AccumStep = Axis("accum_step", num_micro_steps)
-    assert num_micro_steps * microbatch_size == batch_size
+    if num_micro_steps * microbatch_size != batch_size:
+        raise ValueError(
+            "Batch size must be an integer multiple of microbatch_size. "
+            f"Got batch size {batch_size} and microbatch_size {microbatch_size}."
+        )
 
     if reduce not in ReductionType:
         raise ValueError(f"accum_type must be one of {ReductionType}")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -20,7 +20,8 @@ from levanter.metrics import (
 from levanter.tracker import NoopConfig
 from levanter.trainer import Trainer, TrainerConfig, WrappedLossFunction
 
-Batch = hax.Axis("batch", size=4)
+# Use a batch size that remains divisible by the data-parallel axis on multi-device setups.
+Batch = hax.Axis("batch", size=4 * max(1, jax.device_count()))
 Embed = hax.Axis("embed", size=8)
 
 


### PR DESCRIPTION
## Summary
- avoid microbatching when the configured microbatch size is greater than or equal to the total batch size
- raise a clear error when the batch size is not divisible by the microbatch size instead of asserting
- scale the trainer metrics test batch axis with the number of devices so it passes on multi-device setups

## Testing
- uv run pytest tests/test_metrics.py::test_trainer_train_step -k microbatching

------
https://chatgpt.com/codex/tasks/task_e_68efe05898d08331b5272edf63182758