### PR TITLE
Fix output token length off-by-one in multiple generation

### DIFF
--- a/src/levanter/inference/engine.py
+++ b/src/levanter/inference/engine.py
@@ -555,9 +555,8 @@ def _handle_clones(
         decode_state, cache = state
         src_slot_id = src_ids["position", i].scalar()
         dst_slot_id = tgt_ids["position", i].scalar()
-        decode_state = decode_state.clone_pages_from(src_slot_id, dst_slot_id)
 
-        src_len = decode_state.seq_lens["seq", src_slot_id].scalar()
+        src_len = decode_state.seq_lens["seq", dst_slot_id].scalar()
         used_pages = (src_len + size - 1) // size
         last_idx = jnp.maximum(used_pages - 1, 0)
 


### PR DESCRIPTION
# Fixes https://github.com/marin-community/levanter/issues/1266

When multiple generations were requested (n > 1), the clone generations consistently generated one fewer token than requested. The root cause was in the copy_pages_for_updated_seq function inside _handle_clones.

# What Was Happening

Clone sequences were created with seq_len = N (prompt length)

Parent sequence sampled a token, updating its seq_len to N+1

_handle_clones was called to sample tokens for clones

copy_pages_for_updated_seq called clone_pages_from, which overwrote the clone's seq_len with the parent's UPDATED seq_len (N+1)

Then update_tokens was called, incrementing the clone's seq_len to N+2

This caused the clone to think it was one token ahead, making it stop generation one token early

# The Fix

Removed the unnecessary call to clone_pages_from in copy_pages_for_updated_seq. Since clones are already properly set up in _clone_sequence, the function only needs to copy the partial last KV cache page. Now it uses the clone's existing seq_len instead of calling clone_pages_from which was corrupting the state.

# Tests
All inference tests pass after this fix:

```
================================== test session starts ==================================
platform darwin -- Python 3.11.9, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/kevin/marin/levanter
configfile: pyproject.toml
plugins: asyncio-1.2.0, jaxtyping-0.3.3, anyio-4.11.0, profiling-1.8.1, forked-1.6.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 105 items                                                                     

tests/inference/test_clone_pages.py ...                                           [  2%]
tests/inference/test_engine.py ..                                                 [  4%]
tests/inference/test_inference_server.py ...........                              [ 15%]
tests/inference/test_inference_utils.py .......                                   [ 21%]
tests/inference/test_jit_scheduler.py .....                                       [ 26%]
tests/inference/test_page_table.py ....                                           [ 30%]
tests/inference/test_paged_attention.py ......................................... [ 69%]
................................                                                  [100%]

============================ 105 passed in 81.58s (0:01:21) =============================
```

# Deep dive

BEFORE commit 34ed673a:

PageTable had its own seq_lens field that was SEPARATE from DecodeState.seq_lens

When the parent sampled a token, update_tokens updated DecodeState.seq_lens but NOT PageTable.seq_lens

In copy_pages_for_updated_seq, when it read page_table.seq_lens["seq", src_slot_id], it got the STALE/ORIGINAL value (N), not the updated value (N+1)

This meant clone_pages_from copied the correct seq_len = N from the stale page_table

AFTER commit 34ed673a:

The refactoring moved seq_lens from PageTable to SequenceTable

DecodeState.seq_lens became a property returning self.sequences.seq_lens (unified storage)

Now when parent calls update_tokens, it updates the SAME sequences.seq_lens that clone_pages_from reads

So decode_state.seq_lens["seq", src_slot_id] returns the updated value (N+1), not N

This caused clone_pages_from to overwrite the clone's seq_len with the parent's UPDATED seq_len, introducing the off-by-one error

The old code was accidentally relying on the fact that page_table.seq_lens was stale/outdated. The refactoring unified the storage, which exposed this latent bug. My fix removes the problematic clone_pages_from call entirely since the clone is already properly set up.

# Credits

Attempted to fix with Codex and Claude Code but couldn't. Devin fixed it after I localized the bug to a commit.
