### PR TITLE
Trackio doesn't handle jax.Arrays.

### DIFF
--- a/src/levanter/tracker/trackio.py
+++ b/src/levanter/tracker/trackio.py
@@ -44,18 +44,7 @@ class TrackioTracker(Tracker):
         del commit
         to_log = {}
         for k, v in metrics.items():
-            if isinstance(v, Histogram):
-                counts, limits = v.to_numpy_histogram()
-                to_log[f"{k}/histogram"] = {
-                    "counts": counts.tolist(),
-                    "limits": limits.tolist(),
-                    "min": v.min.item(),
-                    "max": v.max.item(),
-                    "mean": v.mean.item(),
-                    "variance": v.variance.item(),
-                }
-            else:
-                to_log[k] = _convert_value_to_loggable_rec(v)
+            to_log[k] = _convert_value_to_loggable_rec(v)
 
         import trackio
 
@@ -79,18 +68,26 @@ class TrackioTracker(Tracker):
 
 
 def _convert_value_to_loggable_rec(value: Any):
+    if isinstance(value, jax.Array):
+        if value.ndim == 0:
+            value = value.item()
+        else:
+            value = np.array(value)
+
     if isinstance(value, (list, tuple)):
         return [_convert_value_to_loggable_rec(v) for v in value]
     elif isinstance(value, typing.Mapping):
         return {k: _convert_value_to_loggable_rec(v) for k, v in value.items()}
-    elif isinstance(value, jax.Array):
-        if value.ndim == 0:
-            return value.item()
-        else:
-            return np.array(value)
     elif isinstance(value, Histogram):
         counts, limits = value.to_numpy_histogram()
-        return {"counts": counts.tolist(), "limits": limits.tolist()}
+        return {
+            "counts": counts.tolist(),
+            "limits": limits.tolist(),
+            "min": value.min.item(),
+            "max": value.max.item(),
+            "mean": value.mean.item(),
+            "variance": value.variance.item(),
+        }
     elif isinstance(value, np.ndarray):
         return value.tolist()
     elif isinstance(value, np.generic):


### PR DESCRIPTION
Fixes trackio logging for histograms and adds some safety checking for the default statistics. Trackio actually logs off the main thread, so this wasn't crashing the tests, but it was adding noise to our logs.