### PR TITLE
Pin `trackio>=0.5.0` for consistency with existing `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test = [
   "chex>=0.1.86",
   "httpx>=0.28.1",
   "pytest-profiling>=1.8.1",
-  "trackio",
+  "trackio>=0.5.0",
 ]
 
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -2289,7 +2289,7 @@ test = [
     { name = "pytest-profiling", specifier = ">=1.8.1" },
     { name = "soundfile" },
     { name = "tensorboardx", specifier = ">=2.6" },
-    { name = "trackio" },
+    { name = "trackio", specifier = ">=0.5.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pyproject.toml` has an unpinned "trackio" dependency, and existing `uv.lock` has trackio 0.5.0, but on a fresh resolve `uv lock` downgrades trackio to [0.0.6]:

1. `uv` picks pydantic 2.12.3 (latest)
2. That forces `gradio<=5.23.1` (later versions added a `pydantic<2.12` UB)
3. That makes `trackio==0.5.0` unsatisfiable (it requires `gradio>=5.48.0` ⇒ `pydantic<2.12`)

`trackio>=0.5.0` pin ensures consistent resolution:
- `trackio>=0.5.0` ⇒ `gradio>=5.48.0` ⇒ `pydantic<2.12`
- pydantic stays at 2.11.x, everyone's happy

This prevents test failures ([e.g.][tpu#31]) seen in https://github.com/marin-community/marin/pull/1723 due to a missing `step` parameter.

[0.0.6]: https://pypi.org/project/trackio/0.0.6/
[tpu#31]: https://github.com/marin-community/marin/actions/runs/18979090914?pr=1723